### PR TITLE
Adds option deserialization for inner value if Some(T)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod chrono;
 #[cfg(feature = "json")]
 pub mod json;
 pub mod rust;
+pub mod option;
 
 /// Seperator for string-based collection de/serialization
 pub trait Separator {

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,23 +1,23 @@
 //! De/Serialization of Option Types
 
-/// Serialize value if Some(..), skip if None
+/// Serialize inner value if Some(..). If none, serialize the unit struct ().
+/// When used with: (skip_serializing_if = "Option::is_none") and 
+/// serde(default), you can skip a value if it's None, or serialize its inner
+/// value if Some(T).
 pub mod unwrap_or_skip {
-    use serde::de::{DeserializeOwned, Deserializer, Error, Visitor};
-    use serde::ser::{self, Serialize, Serializer};
-    use serde_json;
-    use std::fmt;
-    use std::marker::PhantomData;
+    use serde::de::{DeserializeOwned, Deserializer};
+    use serde::ser::{Serialize, Serializer};
 
     /// Deserialize value wrapped in Some(T)
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
     where
         D: Deserializer<'de>,
         T: DeserializeOwned,
     {
-        deserializer.deserialize(Some(T))
+        T::deserialize(deserializer).map(|x| Some(x))
     }
 
-    /// Serialize value if Some(T), skip if None
+    /// Serialize value if Some(T), unit struct if None
     pub fn serialize<T, S>(option: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
         T: Serialize,

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,0 +1,32 @@
+//! De/Serialization of Option Types
+
+/// Serialize value if Some(..), skip if None
+pub mod unwrap_or_skip {
+    use serde::de::{DeserializeOwned, Deserializer, Error, Visitor};
+    use serde::ser::{self, Serialize, Serializer};
+    use serde_json;
+    use std::fmt;
+    use std::marker::PhantomData;
+
+    /// Deserialize value wrapped in Some(T)
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: DeserializeOwned,
+    {
+        deserializer.deserialize(Some(T))
+    }
+
+    /// Serialize value if Some(T), skip if None
+    pub fn serialize<T, S>(option: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        if let &Some(ref value) = option {
+            value.serialize(serializer)
+        } else {
+            ().serialize(serializer)
+        }
+    }
+}


### PR DESCRIPTION
I kinda just banged this out, but this implements:

1. Serialize an inner value if Some(T), skip writing anything if None
2. Deserialize values into Some(T)

This should allow, e.g.:

```
struct Doc {
  #[serde(with = "serde_with::option::unwrap_or_skip")]
  value: Option<String>,
}
```

And have the value skipped if None, or written if Some.