### PR TITLE
Add the double option helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Double Option pattern to differentiate between missing, unset, or existing value
+
 ## [0.2.0]
 
 ### Added


### PR DESCRIPTION
It allows to differentiate between missing values, null values, and
existing values, for example in JSON.