### PR TITLE
Adds option deserialization only inner value if Some(T)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `unwrap_or_skip` allows to transparently serialize the inner part of a `Some(T)`
+
 ## [0.2.1]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { version = "1.0.17", optional = true }
 [dev-dependencies]
 serde_derive = "1.0.65"
 serde_json = "1.0.17"
+ron = "0.3.0"
 pretty_assertions = "0.5.1"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Some serialization formats might add the Some() while serializing
values, for example RON. This can be undesired if you want to provide an
optional value which is skipped if not set.

Resolves #7

Co-authored-by: Tim Ryan <id@timryan.org>