### PR TITLE
Exclude various config files from crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 keywords = ["serde", "utilities"]
 license = "MIT/Apache-2.0"
 
+exclude = [".gitignore", ".travis.yml", "bors.toml", "README.tpl", "rustfmt.toml"]
+
 [features]
 json = [ "serde_json" ]
 


### PR DESCRIPTION
This reduces the size of the crate file on crates.io