### PR TITLE
Added `rust::seq_display_fromstr` to help de/serialize collections

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -97,6 +97,127 @@ pub mod display_fromstr {
     }
 }
 
+/// De/Serialize sequences using [FromIterator] and [IntoIterator] implementation for it and [Display][] and [FromStr][] implementation for each element
+///
+/// This allows to serialize and deserialize collections with elements which can be represented as strings.
+///
+/// [FromIterator]: https://doc.rust-lang.org/std/iter/trait.FromIterator.html
+/// [IntoIterator]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
+/// [Display]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
+/// [FromStr]: https://doc.rust-lang.org/stable/std/str/trait.FromStr.html
+///
+/// # Examples
+///
+/// ```
+/// # extern crate serde;
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// # extern crate serde_json;
+/// # extern crate serde_with;
+/// # use std::net::Ipv4Addr;
+/// # use std::collections::BTreeSet;
+/// #[derive(Deserialize, Serialize)]
+/// struct A {
+///     #[serde(with = "serde_with::rust::seq_display_fromstr")]
+///     addresses: BTreeSet<Ipv4Addr>,
+///     #[serde(with = "serde_with::rust::seq_display_fromstr")]
+///     bs: Vec<bool>,
+/// }
+///
+/// # fn main() {
+/// let v: A = serde_json::from_str(r#"{
+///     "addresses": ["192.168.2.1", "192.168.2.2", "192.168.1.1", "192.168.2.2"],
+///     "bs": ["true", "false"]
+/// }"#).unwrap();
+/// assert_eq!(v.addresses.len(), 3);
+/// assert!(v.addresses.contains(&Ipv4Addr::new(192, 168, 2, 1)));
+/// assert!(v.addresses.contains(&Ipv4Addr::new(192, 168, 2, 2)));
+/// assert!(!v.addresses.contains(&Ipv4Addr::new(192, 168, 1, 2)));
+/// assert_eq!(v.bs.len(), 2);
+/// assert!(v.bs[0]);
+/// assert!(!v.bs[1]);
+///
+/// let x = A {
+///     addresses: vec![
+///         Ipv4Addr::new(127, 53, 0, 1),
+///         Ipv4Addr::new(127, 53, 1, 1),
+///         Ipv4Addr::new(127, 53, 0, 2)
+///     ].into_iter().collect(),
+///     bs: vec![false, true],
+/// };
+/// assert_eq!(r#"{"addresses":["127.53.0.1","127.53.0.2","127.53.1.1"],"bs":["false","true"]}"#, serde_json::to_string(&x).unwrap());
+/// # }
+/// ```
+pub mod seq_display_fromstr {
+    use serde::{
+        de::{Deserializer, Error, SeqAccess, Visitor},
+        ser::{SerializeSeq, Serializer},
+    };
+    use std::fmt::{self, Display};
+    use std::iter::{FromIterator, IntoIterator};
+    use std::marker::PhantomData;
+    use std::str::FromStr;
+
+    /// Deserialize collection T using [FromIterator] and [FromStr] for each element
+    pub fn deserialize<'de, D, T, I>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromIterator<I> + Sized,
+        I: FromStr,
+        I::Err: Display,
+    {
+        struct Helper<S>(PhantomData<S>);
+
+        impl<'de, S> Visitor<'de> for Helper<S>
+        where
+            S: FromStr,
+            <S as FromStr>::Err: Display,
+        {
+            type Value = Vec<S>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a sequence")
+            }
+
+            fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut values = access
+                    .size_hint()
+                    .map(Self::Value::with_capacity)
+                    .unwrap_or_else(Self::Value::new);
+
+                while let Some(value) = access.next_element::<&str>()? {
+                    values.push(value.parse::<S>().map_err(Error::custom)?);
+                }
+
+                Ok(values)
+            }
+        }
+
+        deserializer
+            .deserialize_seq(Helper(PhantomData))
+            .map(T::from_iter)
+    }
+
+    /// Serialize collection T using [IntoIterator] and [Display] for each element
+    pub fn serialize<S, T, I>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        for<'a> &'a T: IntoIterator<Item = &'a I>,
+        I: Display,
+    {
+        let iter = value.into_iter();
+        let (_, to) = iter.size_hint();
+        let mut seq = serializer.serialize_seq(to)?;
+        for item in iter {
+            seq.serialize_element(&item.to_string())?;
+        }
+        seq.end()
+    }
+}
+
 /// De/Serialize a delimited collection using [Display][] and [FromStr][] implementation
 ///
 /// You can define an arbitrary separator, by specifying a type which implements [Separator][].


### PR DESCRIPTION
This helper uses `FromIterator`/`IntoIterator` traits for collection
itself and `Display`/`FromStr` for each element.