### PR TITLE
Add a `skip_serializing_null` attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
 script:
   - set -e
   - |
-    for FEATURES_COMMAND in "--no-default-features" "" "--features=chrono" "--features=json" "--all-features"
+    for FEATURES_COMMAND in "--no-default-features" "" "--features=chrono" "--features=json" "--features=macros" "--all-features"
     do
       cargo build --verbose --all ${FEATURES_COMMAND}
       # skip this step if clippy is not available, e.g., bad nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add `skip_serializing_null` attribute, which adds `#[serde(skip_serializing_if = "Option::is_none")]` for each Option in a struct.
+    This is helpfull for APIs which have many optional fields.
+
 ## [1.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* Add `skip_serializing_null` attribute, which adds `#[serde(skip_serializing_if = "Option::is_none")]` for each Option in a struct.
+* Add `skip_serializing_none` attribute, which adds `#[serde(skip_serializing_if = "Option::is_none")]` for each Option in a struct.
     This is helpfull for APIs which have many optional fields.
     The effect of can be negated by adding `serialize_always` on those fields, which should always be serialized.
     Existing `skip_serializing_if` will never be modified and those fields keep their behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add `skip_serializing_null` attribute, which adds `#[serde(skip_serializing_if = "Option::is_none")]` for each Option in a struct.
     This is helpfull for APIs which have many optional fields.
+    The effect of can be negated by adding `serialize_always` on those fields, which should always be serialized.
+    Existing `skip_serializing_if` will never be modified and those fields keep their behavior.
 
 ## [1.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace]
+members = [
+    "serde_with_macros",
+]
+
 [package]
 name = "serde_with"
 version = "1.2.0"
@@ -26,12 +31,15 @@ codecov = { repository = "jonasbb/serde_with", branch = "master", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
+default = [ "macros" ]
 json = [ "serde_json" ]
+macros = [ "serde_with_macros" ]
 
 [dependencies]
 chrono = { version = "0.4.1", features = [ "serde" ], optional = true }
 serde = "1.0.75"
 serde_json = { version = "1.0.1", optional = true }
+serde_with_macros = { path = "./serde_with_macros", version = "0.1.0", optional = true}
 
 [dev-dependencies]
 fnv = "1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ macros = [ "serde_with_macros" ]
 chrono = { version = "0.4.1", features = [ "serde" ], optional = true }
 serde = "1.0.75"
 serde_json = { version = "1.0.1", optional = true }
-serde_with_macros = { path = "./serde_with_macros", version = "0.1.0", optional = true}
+serde_with_macros = { path = "./serde_with_macros", version = "1.0.0", optional = true}
 
 [dev-dependencies]
 fnv = "1.0.6"

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_with_macros"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["jonasbb"]
 
 description = "proc-macro library for serde_with"
@@ -19,3 +19,25 @@ codecov = { repository = "jonasbb/serde_with", branch = "master", service = "git
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+proc-macro2 = { version = "0.4.27" }
+quote = "0.6.11"
+
+[dependencies.syn]
+version = "0.15.29"
+default-features = false
+features = [
+    "extra-traits", # Only for debugging
+    "full",
+    "parsing",
+    "printing",
+    "proc-macro",
+]
+
+[dev-dependencies]
+pretty_assertions = "0.5.1"
+serde = { version = "1.0.75", features = [ "derive" ] }
+serde_json = "1.0.25"
+version-sync = "0.7.0"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "serde_with_macros"
+version = "0.1.0"
+authors = ["jonasbb"]
+
+description = "proc-macro library for serde_with"
+documentation = "https://docs.rs/serde_with_macros/"
+repository = "https://github.com/jonasbb/serde_with/serde_with_macros"
+readme = "README.md"
+keywords = ["serde", "utilities", "serialization", "deserialization"]
+license = "MIT/Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[badges]
+travis-ci = { repository = "jonasbb/serde_with", branch = "master" }
+codecov = { repository = "jonasbb/serde_with", branch = "master", service = "github" }
+maintenance = { status = "actively-developed" }
+
+[dependencies]

--- a/serde_with_macros/LICENSE-APACHE
+++ b/serde_with_macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/serde_with_macros/LICENSE-MIT
+++ b/serde_with_macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/serde_with_macros/README.md
+++ b/serde_with_macros/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1,0 +1,71 @@
+#![deny(
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    variant_size_differences
+)]
+#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.0.0")]
+
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse::Parser, parse_macro_input, Attribute, Fields, ItemStruct, Path, Type};
+
+/// Return `true`, if the type path refers to `std::option::Option`
+///
+/// Accepts
+///
+/// * `Option`
+/// * `std::option::Option`, with or without leading `::`
+/// * `core::option::Option`, with or without leading `::`
+fn is_std_option(path: &Path) -> bool {
+    (path.leading_colon.is_none() && path.segments.len() == 1 && path.segments[0].ident == "Option")
+        || (path.segments.len() == 3
+            && (path.segments[0].ident == "std" || path.segments[0].ident == "core")
+            && path.segments[1].ident == "option"
+            && path.segments[2].ident == "Option")
+}
+
+#[proc_macro_attribute]
+pub fn skip_serializing_null(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(input as ItemStruct);
+
+    // For each field in the struct given by `input`, add the `skip_serializing_if` attribute,
+    // if and only if, it is of type `Option`
+    match &mut input.fields {
+        // simple, no fields, do nothing
+        Fields::Unit => {}
+
+        Fields::Named(ref mut fields) => {
+            fields.named.iter_mut().for_each(|field| {
+                if let Type::Path(path) = &field.ty {
+                    if is_std_option(&path.path) {
+                        // FIXME if skip_serializing_if already exists, do not add it again
+                        // Add the `skip_serializing_if` attribute
+                        let attr_tokens = quote!(
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                        );
+                        let parser = Attribute::parse_outer;
+                        let attrs = parser
+                            .parse2(attr_tokens)
+                            .expect("Static attr tokens should not panic");
+                        field.attrs.extend(attrs);
+                    }
+                }
+            })
+        }
+
+        Fields::Unnamed(ref mut _fields) => unimplemented!("Unnamed"),
+    };
+
+    // Hand the modified input back to the compiler
+    TokenStream::from(quote!(#input))
+}

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -24,6 +24,36 @@ use syn::{
     Type,
 };
 
+#[proc_macro_attribute]
+pub fn skip_serializing_null(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let res = match skip_serializing_null_do(input) {
+        Ok(res) => res,
+        Err(msg) => {
+            let span = Span::call_site();
+            Error::new(span, msg).to_compile_error()
+        }
+    };
+    TokenStream::from(res)
+}
+
+fn skip_serializing_null_do(input: TokenStream) -> Result<proc_macro2::TokenStream, String> {
+    // For each field in the struct given by `input`, add the `skip_serializing_if` attribute,
+    // if and only if, it is of type `Option`
+    if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
+        skip_serializing_null_handle_fields(&mut input.fields)?;
+        Ok(quote!(#input))
+    } else if let Ok(mut input) = syn::parse::<ItemEnum>(input.clone()) {
+        input
+            .variants
+            .iter_mut()
+            .map(|variant| skip_serializing_null_handle_fields(&mut variant.fields))
+            .collect::<Result<(), _>>()?;
+        Ok(quote!(#input))
+    } else {
+        Err("The attribute can only be applied to struct or enum definitions.".into())
+    }
+}
+
 /// Return `true`, if the type path refers to `std::option::Option`
 ///
 /// Accepts
@@ -78,16 +108,40 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 }
 
 /// Add the skip_serializing_if annotation to each field of the struct
-fn skip_serializing_null_add_attr_to_field<'a>(fields: impl IntoIterator<Item = &'a mut Field>) {
-    fields.into_iter().for_each(|field| {
-        if let Type::Path(path) = &field.ty {
+fn skip_serializing_null_add_attr_to_field<'a>(
+    fields: impl IntoIterator<Item = &'a mut Field>,
+) -> Result<(), String> {
+    fields.into_iter().map(|field| ->Result<(), String> {
+        if let Type::Path(path) = &field.ty.clone() {
             if is_std_option(&path.path) {
-                // Do nothing, if the value already exists
-                if field_has_attribute(&field, "serde", "skip_serializing_if") {
-                    return;
+                let has_skip_serializing_if =
+                    field_has_attribute(&field, "serde", "skip_serializing_if");
+
+                // Remove the `serialize_always` attribute
+                let mut has_always_attr = false;
+                field.attrs.retain(|attr| {
+                    let has_attr = attr.path.is_ident("serialize_always");
+                    has_always_attr |= has_attr;
+                    !has_attr
+                });
+
+                // Error on conflicting attributes
+                if has_always_attr && has_skip_serializing_if {
+                    let mut msg = r#"The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field"#.to_string();
+                    if let Some(ident) = &field.ident {
+                       msg += ": `";
+                       msg += &ident.to_string();
+                       msg += "`";
+                    }
+                        msg +=".";
+                    return Err(msg);
                 }
 
-                // FIXME if skip_serializing_if already exists, do not add it again
+                // Do nothing if `skip_serializing_if` or `serialize_always` is already present
+                if has_skip_serializing_if || has_always_attr {
+                    return Ok(());
+                }
+
                 // Add the `skip_serializing_if` attribute
                 let attr_tokens = quote!(
                     #[serde(skip_serializing_if = "Option::is_none")]
@@ -97,45 +151,30 @@ fn skip_serializing_null_add_attr_to_field<'a>(fields: impl IntoIterator<Item = 
                     .parse2(attr_tokens)
                     .expect("Static attr tokens should not panic");
                 field.attrs.extend(attrs);
+            } else {
+                // Warn on use of `serialize_always` on non-Option fields
+                let has_attr= field.attrs.iter().any(|attr| {
+                    attr.path.is_ident("serialize_always")
+                });
+                if has_attr  {
+                    return Err("`serialize_always` may only be used on fields of type `Option`.".into());
+                }
             }
         }
-    })
+        Ok(())
+    }).collect()
 }
 
 /// Handle a single struct or a single enum variant
-fn skip_serializing_null_handle_fields(fields: &mut Fields) {
+fn skip_serializing_null_handle_fields(fields: &mut Fields) -> Result<(), String> {
     match fields {
         // simple, no fields, do nothing
-        Fields::Unit => {}
+        Fields::Unit => Ok(()),
         Fields::Named(ref mut fields) => {
             skip_serializing_null_add_attr_to_field(fields.named.iter_mut())
         }
         Fields::Unnamed(ref mut fields) => {
             skip_serializing_null_add_attr_to_field(fields.unnamed.iter_mut())
         }
-    };
-}
-
-#[proc_macro_attribute]
-pub fn skip_serializing_null(_args: TokenStream, input: TokenStream) -> TokenStream {
-    // For each field in the struct given by `input`, add the `skip_serializing_if` attribute,
-    // if and only if, it is of type `Option`
-    let res = if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
-        skip_serializing_null_handle_fields(&mut input.fields);
-        quote!(#input)
-    } else if let Ok(mut input) = syn::parse::<ItemEnum>(input.clone()) {
-        input.variants.iter_mut().for_each(|variant| {
-            skip_serializing_null_handle_fields(&mut variant.fields);
-        });
-        quote!(#input)
-    } else {
-        let span = Span::call_site();
-        Error::new(
-            span,
-            "The attribute can only be applied to struct or enum definitions.",
-        )
-        .to_compile_error()
-    };
-    // Hand the modified input back to the compiler
-    TokenStream::from(res)
+    }
 }

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -12,12 +12,14 @@
 #![doc(html_root_url = "https://docs.rs/serde_with_macros/1.0.0")]
 
 extern crate proc_macro;
+extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
-use syn::{parse::Parser, parse_macro_input, Attribute, Fields, ItemStruct, Path, Type};
+use syn::{parse::Parser, Attribute, Error, Field, Fields, ItemEnum, ItemStruct, Path, Type};
 
 /// Return `true`, if the type path refers to `std::option::Option`
 ///
@@ -34,38 +36,60 @@ fn is_std_option(path: &Path) -> bool {
             && path.segments[2].ident == "Option")
 }
 
-#[proc_macro_attribute]
-pub fn skip_serializing_null(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let mut input = parse_macro_input!(input as ItemStruct);
+/// Add the skip_serializing_if annotation to each field of the struct
+fn skip_serializing_null_add_attr_to_field<'a>(fields: impl IntoIterator<Item = &'a mut Field>) {
+    fields.into_iter().for_each(|field| {
+        if let Type::Path(path) = &field.ty {
+            if is_std_option(&path.path) {
+                // FIXME if skip_serializing_if already exists, do not add it again
+                // Add the `skip_serializing_if` attribute
+                let attr_tokens = quote!(
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                );
+                let parser = Attribute::parse_outer;
+                let attrs = parser
+                    .parse2(attr_tokens)
+                    .expect("Static attr tokens should not panic");
+                field.attrs.extend(attrs);
+            }
+        }
+    })
+}
 
-    // For each field in the struct given by `input`, add the `skip_serializing_if` attribute,
-    // if and only if, it is of type `Option`
-    match &mut input.fields {
+/// Handle a single struct or a single enum variant
+fn skip_serializing_null_handle_fields(fields: &mut Fields) {
+    match fields {
         // simple, no fields, do nothing
         Fields::Unit => {}
-
         Fields::Named(ref mut fields) => {
-            fields.named.iter_mut().for_each(|field| {
-                if let Type::Path(path) = &field.ty {
-                    if is_std_option(&path.path) {
-                        // FIXME if skip_serializing_if already exists, do not add it again
-                        // Add the `skip_serializing_if` attribute
-                        let attr_tokens = quote!(
-                            #[serde(skip_serializing_if = "Option::is_none")]
-                        );
-                        let parser = Attribute::parse_outer;
-                        let attrs = parser
-                            .parse2(attr_tokens)
-                            .expect("Static attr tokens should not panic");
-                        field.attrs.extend(attrs);
-                    }
-                }
-            })
+            skip_serializing_null_add_attr_to_field(fields.named.iter_mut())
         }
-
-        Fields::Unnamed(ref mut _fields) => unimplemented!("Unnamed"),
+        Fields::Unnamed(ref mut fields) => {
+            skip_serializing_null_add_attr_to_field(fields.unnamed.iter_mut())
+        }
     };
+}
 
+#[proc_macro_attribute]
+pub fn skip_serializing_null(_args: TokenStream, input: TokenStream) -> TokenStream {
+    // For each field in the struct given by `input`, add the `skip_serializing_if` attribute,
+    // if and only if, it is of type `Option`
+    let res = if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
+        skip_serializing_null_handle_fields(&mut input.fields);
+        quote!(#input)
+    } else if let Ok(mut input) = syn::parse::<ItemEnum>(input.clone()) {
+        input.variants.iter_mut().for_each(|variant| {
+            skip_serializing_null_handle_fields(&mut variant.fields);
+        });
+        quote!(#input)
+    } else {
+        let span = Span::call_site();
+        Error::new(
+            span,
+            "The attribute can only be applied to struct or enum definitions.",
+        )
+        .to_compile_error()
+    };
     // Hand the modified input back to the compiler
-    TokenStream::from(quote!(#input))
+    TokenStream::from(res)
 }

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -85,9 +85,9 @@ use syn::{
 /// The `serialize_always` cannot be used together with a manual `skip_serializing_if` annotations, as these conflict in their meaning.
 /// A compile error will be generated if this occurs.
 ///
-/// The `skip_serializing_none` only works if the type is called `Option`, `std::option::Option`, or `core::option::Option`.
-/// Type aliasing on `Option` and giving it another name, will cause this field to be ignored.
-/// This cannot be supported, as proc-macros run before type checking, thus it is not possible to determine if a type alias refers to an `Option`.
+/// The `skip_serializing_none` only works if the type is called [`Option`], [`std::option::Option`], or [`core::option::Option`].
+/// Type aliasing an [`Option`] and giving it another name, will cause this field to be ignored.
+/// This cannot be supported, as proc-macros run before type checking, thus it is not possible to determine if a type alias refers to an [`Option`].
 ///
 /// ```rust,ignore
 /// # extern crate serde;

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -78,13 +78,42 @@ struct DataExistingAnnotation {
 
 #[test]
 fn test_existing_annotation() {
-    let expected = json!({
-        "name": null
-    });
+    let expected = json!({ "name": null });
     let data = DataExistingAnnotation {
         a: None,
         b: None,
         c: None,
+        d: None,
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+    assert_eq!(data, serde_json::from_value(res).unwrap());
+}
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataSerializeAlways {
+    #[serialize_always]
+    a: Option<String>,
+    #[serialize_always]
+    b: Option<String>,
+    c: i64,
+    #[serialize_always]
+    d: Option<String>,
+}
+
+#[test]
+fn test_serialize_always() {
+    let expected = json!({
+        "a": null,
+        "b": null,
+        "c": 0,
+        "d": null
+    });
+    let data = DataSerializeAlways {
+        a: None,
+        b: None,
+        c: 0,
         d: None,
     };
     let res = serde_json::to_value(&data).unwrap();

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -6,7 +6,7 @@ extern crate serde_with_macros;
 use pretty_assertions::assert_eq;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use serde_with_macros::skip_serializing_null;
+use serde_with_macros::skip_serializing_none;
 
 macro_rules! test {
     ($fn:ident, $struct:ident) => {
@@ -38,7 +38,7 @@ macro_rules! test_tuple {
     };
 }
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DataBasic {
     a: Option<String>,
@@ -48,7 +48,7 @@ struct DataBasic {
 }
 test!(test_basic, DataBasic);
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DataFullyQualified {
     a: ::std::option::Option<String>,
@@ -62,7 +62,7 @@ fn never<T>(_t: &T) -> bool {
     false
 }
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DataExistingAnnotation {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +90,7 @@ fn test_existing_annotation() {
     assert_eq!(data, serde_json::from_value(res).unwrap());
 }
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DataSerializeAlways {
     #[serialize_always]
@@ -121,12 +121,12 @@ fn test_serialize_always() {
     assert_eq!(data, serde_json::from_value(res).unwrap());
 }
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize)]
 struct DataTuple(Option<String>, std::option::Option<String>);
 test_tuple!(test_tuple, DataTuple);
 
-#[skip_serializing_null]
+#[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize)]
 enum DataEnum {
     Tuple(Option<i64>, std::option::Option<bool>),

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -1,0 +1,65 @@
+extern crate pretty_assertions;
+extern crate serde;
+extern crate serde_json;
+extern crate serde_with_macros;
+
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_with_macros::skip_serializing_null;
+
+macro_rules! test {
+    ($fn:ident, $struct:ident) => {
+        #[test]
+        fn $fn() {
+            let expected = json!({});
+            let data = $struct {
+                a: None,
+                b: None,
+                c: None,
+                d: None,
+            };
+            let res = serde_json::to_value(&data).unwrap();
+            assert_eq!(expected, res);
+            assert_eq!(data, serde_json::from_value(res).unwrap());
+        }
+    };
+}
+
+macro_rules! test_tuple {
+    ($fn:ident, $struct:ident) => {
+        #[test]
+        fn $fn() {
+            let expected = json!({});
+            let data = $struct(None, None);
+            let res = serde_json::to_value(&data).unwrap();
+            assert_eq!(expected, res);
+            assert_eq!(data, serde_json::from_value(res).unwrap());
+        }
+    };
+}
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataBasic {
+    a: Option<String>,
+    b: Option<String>,
+    c: Option<String>,
+    d: Option<String>,
+}
+test!(test_basic, DataBasic);
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataFullyQualified {
+    a: ::std::option::Option<String>,
+    b: std::option::Option<String>,
+    c: ::std::option::Option<i64>,
+    d: core::option::Option<String>,
+}
+test!(test_fully_qualified, DataFullyQualified);
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataTuple(Option<String>, std::option::Option<String>);
+test_tuple!(test_tuple, DataTuple);

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -58,6 +58,40 @@ struct DataFullyQualified {
 }
 test!(test_fully_qualified, DataFullyQualified);
 
+fn never<T>(_t: &T) -> bool {
+    false
+}
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataExistingAnnotation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "abc")]
+    b: Option<String>,
+    #[serde(default)]
+    c: Option<String>,
+    #[serde(skip_serializing_if = "never")]
+    #[serde(rename = "name")]
+    d: Option<String>,
+}
+
+#[test]
+fn test_existing_annotation() {
+    let expected = json!({
+        "name": null
+    });
+    let data = DataExistingAnnotation {
+        a: None,
+        b: None,
+        c: None,
+        d: None,
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+    assert_eq!(data, serde_json::from_value(res).unwrap());
+}
+
 #[skip_serializing_null]
 #[derive(Debug, Eq, PartialEq, Serialize)]
 struct DataTuple(Option<String>, std::option::Option<String>);

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -30,11 +30,10 @@ macro_rules! test_tuple {
     ($fn:ident, $struct:ident) => {
         #[test]
         fn $fn() {
-            let expected = json!({});
+            let expected = json!([]);
             let data = $struct(None, None);
             let res = serde_json::to_value(&data).unwrap();
             assert_eq!(expected, res);
-            assert_eq!(data, serde_json::from_value(res).unwrap());
         }
     };
 }
@@ -60,6 +59,33 @@ struct DataFullyQualified {
 test!(test_fully_qualified, DataFullyQualified);
 
 #[skip_serializing_null]
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize)]
 struct DataTuple(Option<String>, std::option::Option<String>);
 test_tuple!(test_tuple, DataTuple);
+
+#[skip_serializing_null]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+enum DataEnum {
+    Tuple(Option<i64>, std::option::Option<bool>),
+    Struct {
+        a: Option<String>,
+        b: Option<String>,
+    },
+}
+
+#[test]
+fn test_enum() {
+    let expected = json!({
+        "Tuple": []
+    });
+    let data = DataEnum::Tuple(None, None);
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+
+    let expected = json!({
+        "Struct": {}
+    });
+    let data = DataEnum::Struct { a: None, b: None };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}

--- a/serde_with_macros/tests/version_numbers.rs
+++ b/serde_with_macros/tests/version_numbers.rs
@@ -1,0 +1,6 @@
+extern crate version_sync;
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ extern crate chrono as chrono_crate;
 pub extern crate serde;
 #[cfg(feature = "json")]
 extern crate serde_json;
+#[cfg(feature = "macros")]
+extern crate serde_with_macros;
 
 #[cfg(feature = "chrono")]
 pub mod chrono;
@@ -93,6 +95,11 @@ mod flatten_maybe;
 pub mod rust;
 #[doc(hidden)]
 pub mod with_prefix;
+
+// Re-Export all proc_macros, as these should be seen as part of the serde_with crate
+#[cfg(feature = "macros")]
+#[doc(inline)]
+pub use serde_with_macros::*;
 
 /// Separator for string-based collection de/serialization
 pub trait Separator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,13 @@
 //!
 //! However, this will prohibit you from applying deserialize on the value returned by serializing a struct.
 //!
+//! # Attributes
+//!
+//! The crate comes with custom attributes, which futher extend how serde serialization can be customized.
+//! They are enabled by default, but can be disabled, by removing the default features from this crate.
+//!
+//! [The documentation for the custom attributes can be found here.](serde_with_macros)
+//!
 //! [with-annotation]: https://serde.rs/field-attrs.html#serdewith--module
 //! [serde#553]: https://github.com/serde-rs/serde/issues/553
 


### PR DESCRIPTION
The `skip_serializing_null` attribute can be added to any struct and adds `#[serde(skip_serializing_if = "Option::is_none")]` to every `Option` field.
The intended use is for parsing data, e.g., from APIs, which has many optional values.

It turns

```rust
#[skip_serializing_null]
#[derive(Serialize)]
struct Data {
    a: Option<String>,
    b: Option<String>,
    c: Option<String>,
    d: Option<String>,
}
```

into

```rust
#[derive(Serialize)]
struct Data {
    #[serde(skip_serializing_if = "Option::is_none")]
    a: Option<String>,
    #[serde(skip_serializing_if = "Option::is_none")]
    b: Option<String>,
    #[serde(skip_serializing_if = "Option::is_none")]
    c: Option<String>,
    #[serde(skip_serializing_if = "Option::is_none")]
    d: Option<String>,
}
```

The issue was originally suggested at https://github.com/dtolnay/request-for-implementation/issues/18.

# Missing

* [x] Is `skip_serializing_null` the best name? That is how serde or JSON name the empty value, in Rust it is none.
* [x] Support tuple structs
* [x] Support enums
* [x] Handle existing `skip_serializing_if` annotations, by skipping those fields
* [x] Support an additional attribute, which ensures the field is always serialized
* [x] Write compile tests, which ensure the correct error message
* [x] Write documentation for the feature