### PR TITLE
Bump serde_with_macros version

### DIFF
--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Features for the `syn` dependency were missing.
+    This was hidden due to the dev-dependencies whose features leaked into the normal build.
+
 ## [1.0.0]
 
 Initial Release

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.1]
+
 ### Fixed
 
 * Features for the `syn` dependency were missing.

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -24,13 +24,9 @@ quote = "0.6.11"
 
 [dependencies.syn]
 version = "0.15.29"
-default-features = false
 features = [
-    "extra-traits", # Only for debugging
+    # "extra-traits", # Only for debugging
     "full",
-    "parsing",
-    "printing",
-    "proc-macro",
 ]
 
 [dev-dependencies]

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_with_macros"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["jonasbb"]
 
 description = "proc-macro library for serde_with"

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -9,7 +9,7 @@
     variant_size_differences
 )]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.0.1")]
 
 //! proc-macro extensions for [`serde_with`]
 //!


### PR DESCRIPTION
`syn` was missing some feature dependencies, which where hidden due to the dev-dependency features leaking into the normal build.
This caused problems on doc.rs though.