### PR TITLE
Improve CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ branches:
 
 matrix:
   include:
-    - name: "Bors (1.30.0)"
-      if: branch = staging OR branch = trying OR type = cron
-      rust: 1.30.0
+    - name: "Bors (1.31.1)"
+      if: type = pull_request OR branch = staging OR branch = trying OR type = cron OR type = api
+      rust: 1.31.1
     - name: "Bors (stable)"
-      if: branch = staging OR branch = trying OR type = cron
+      if: branch = staging OR branch = trying OR type = cron OR type = api
       rust: stable
     - name: "Bors (beta)"
-      if: branch = staging OR branch = trying OR type = cron
+      if: branch = staging OR branch = trying OR type = cron OR type = api
       rust: beta
     - name: "Bors (nightly)"
-      if: branch = staging OR branch = trying OR type = cron
+      if: branch = staging OR branch = trying OR type = cron OR type = api
       rust: nightly
     - name: "PR Open"
-      if: type = pull_request AND branch = master
+      if: type = pull_request AND branch = master OR type = api
       rust: nightly
 
 # https://levans.fr/rust_travis_cache.html
@@ -59,16 +59,24 @@ before_script:
   - which cargo-install-update || cargo install cargo-update
   # Update cargo metadata to make cargo install-update work
   - cargo fetch
-  # Install or update cargo tarpaulin
+  # Install or update all tools
   - |
-    if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-      env RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install-update --allow-no-update cargo-tarpaulin
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]] || [[ "$TRAVIS_RUST_VERSION" == nightly ]]
+    then
+      cargo install-update --allow-no-update \
+        cargo-audit \
+        cargo-tarpaulin
     fi
   # Update all tools
   - cargo install-update -a
 
 script:
   - set -e
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]]
+    then
+      cargo audit
+    fi
   - |
     for FEATURES_COMMAND in "--no-default-features" "" "--features=chrono" "--features=json" "--features=macros" "--all-features"
     do
@@ -81,8 +89,8 @@ script:
 
 after_success:
   - |
-    if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-      # Uncomment the following two lines create and upload a report for codecov.io
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]] || [[ "$TRAVIS_RUST_VERSION" == nightly ]]
+    then
       cargo tarpaulin --out Xml --all --all-features
       bash <(curl -s https://codecov.io/bash)
       echo "CodeCov Uploading of data was successful!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Bump minimal Rust version to 1.31.1 to support Rust Edition 2018
+* Improved CI pipeline by running `cargo audit` and `tarpaulin` in all configurations now.
+
 ## [1.3.1]
 
 ### Fixed

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Bump minimal Rust version to 1.31.1 to support Rust Edition 2018
+* Improved CI pipeline by running `cargo audit` and `tarpaulin` in all configurations now.
+
 ## [1.0.1]
 
 ### Fixed


### PR DESCRIPTION
* Run cargo audit
* Use tarpaulin also on stable Rust versions
* Bump minimal version to 1.31.1 to use Edition 2018