### PR TITLE
Add trybuild tests to check the error messages created by the macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ after_success:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]] || [[ "$TRAVIS_RUST_VERSION" == nightly ]]
     then
+      export TARPAULIN=1
       cargo tarpaulin --out Xml --all --all-features
       bash <(curl -s https://codecov.io/bash)
       echo "CodeCov Uploading of data was successful!"

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -31,8 +31,10 @@ features = [
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"
+rustc_version = "0.2.3"
 serde = { version = "1.0.75", features = [ "derive" ] }
 serde_json = "1.0.25"
+trybuild = "1.0.4"
 version-sync = "0.7.0"
 
 [package.metadata.docs.rs]

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -31,7 +31,7 @@ features = [
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"
-rustc_version = "0.2.3"
+rustversion = "0.1.4"
 serde = { version = "1.0.75", features = [ "derive" ] }
 serde_json = "1.0.25"
 trybuild = "1.0.4"

--- a/serde_with_macros/tests/compile-fail/skip-none-always.rs
+++ b/serde_with_macros/tests/compile-fail/skip-none-always.rs
@@ -1,0 +1,28 @@
+extern crate serde;
+extern crate serde_with_macros;
+
+use serde::Serialize;
+use serde_with_macros::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Serialize)]
+struct Data {
+    #[serialize_always]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: Option<char>,
+}
+
+#[skip_serializing_none]
+#[derive(Serialize)]
+struct Data2 (
+    #[serialize_always]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    Option<char>
+);
+
+#[skip_serializing_none]
+#[derive(Serialize)]
+struct Data3 {
+    #[serialize_always]
+    a: char,
+}

--- a/serde_with_macros/tests/compile-fail/skip-none-always.stderr
+++ b/serde_with_macros/tests/compile-fail/skip-none-always.stderr
@@ -1,0 +1,23 @@
+error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field: `a`.
+ --> $DIR/skip-none-always.rs:7:1
+  |
+7 | #[skip_serializing_none]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field.
+  --> $DIR/skip-none-always.rs:15:1
+   |
+15 | #[skip_serializing_none]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `serialize_always` may only be used on fields of type `Option`.
+  --> $DIR/skip-none-always.rs:23:1
+   |
+23 | #[skip_serializing_none]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  |
+  = note: consider adding a `main` function to `$DIR/tests/compile-fail/skip-none-always.rs`
+
+For more information about this error, try `rustc --explain E0601`.

--- a/serde_with_macros/tests/compile-fail/skip-none-not-struct.rs
+++ b/serde_with_macros/tests/compile-fail/skip-none-not-struct.rs
@@ -1,0 +1,6 @@
+extern crate serde_with_macros;
+
+use serde_with_macros::skip_serializing_none;
+
+#[skip_serializing_none]
+fn test() {}

--- a/serde_with_macros/tests/compile-fail/skip-none-not-struct.stderr
+++ b/serde_with_macros/tests/compile-fail/skip-none-not-struct.stderr
@@ -1,0 +1,11 @@
+error: The attribute can only be applied to struct or enum definitions.
+ --> $DIR/skip-none-not-struct.rs:5:1
+  |
+5 | #[skip_serializing_none]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  |
+  = note: consider adding a `main` function to `$DIR/tests/compile-fail/skip-none-not-struct.rs`
+
+For more information about this error, try `rustc --explain E0601`.

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,0 +1,13 @@
+extern crate rustc_version;
+extern crate trybuild;
+
+use rustc_version::{version, Version};
+
+#[test]
+fn compile_test() {
+    // This test fails for older compiler versions since the error messages are different.
+    if version().unwrap() >= Version::parse("1.35.0").unwrap() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/compile-fail/*.rs");
+    }
+}

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,13 +1,15 @@
-extern crate rustc_version;
+extern crate rustversion;
 extern crate trybuild;
 
-use rustc_version::{version, Version};
-
+// This test fails for older compiler versions since the error messages are different.
+#[rustversion::attr(before(1.35), ignore)]
 #[test]
 fn compile_test() {
-    // This test fails for older compiler versions since the error messages are different.
-    if version().unwrap() >= Version::parse("1.35.0").unwrap() {
-        let t = trybuild::TestCases::new();
-        t.compile_fail("tests/compile-fail/*.rs");
+    // This test does not work under tarpaulin, so skip it if detected
+    if std::env::var("TARPAULIN") == Ok("1".to_string()) {
+        return;
     }
+
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
 }


### PR DESCRIPTION

Use trybuild as an improvement over compiletest as the test framework
for the UI tests.
Older Rust versions (<1.35.0) have different error messages, so the new
UI tests fail on them, therefore gate them on the Rust version.

Closes #50