### PR TITLE
Update dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ serde_with_macros = { path = "./serde_with_macros", version = "1.0.1", optional 
 
 [dev-dependencies]
 fnv = "1.0.6"
-pretty_assertions = "0.5.1"
-ron = ">=0.3.0,<0.5"
+pretty_assertions = "0.6.1"
+ron = ">=0.3.0, <0.6"
 serde_derive = "1.0.75"
 serde_json = "1.0.25"
-version-sync = "0.7.0"
+version-sync = "0.8.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -30,12 +30,12 @@ features = [
 ]
 
 [dev-dependencies]
-pretty_assertions = "0.5.1"
+pretty_assertions = "0.6.1"
 rustversion = "0.1.4"
 serde = { version = "1.0.75", features = [ "derive" ] }
 serde_json = "1.0.25"
-trybuild = "1.0.4"
-version-sync = "0.7.0"
+trybuild = "1.0.14"
+version-sync = "0.8.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION

Require a newer version of trybuild, such that the changes in the
nightly output are normalized away.