### PR TITLE
Add a deserialization adapter, which creates a Vec<u8> from string or bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add a helper to deserialize a `Vec<u8>` from `String` (#35)
+
 ### Changed
 
 * Bump minimal Rust version to 1.31.1 to support Rust Edition 2018

--- a/src/flatten_maybe.rs
+++ b/src/flatten_maybe.rs
@@ -76,7 +76,9 @@ macro_rules! flattened_maybe {
                 (Some(t), None) | (None, Some(t)) => Ok(t),
                 (None, None) => Err(serde::de::Error::missing_field($field)),
                 (Some(_), Some(_)) => Err(serde::de::Error::custom(concat!(
-                    "`", $field, "` is both flattened and not"
+                    "`",
+                    $field,
+                    "` is both flattened and not"
                 ))),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,9 @@ extern crate serde_with_macros;
 #[cfg(feature = "chrono")]
 pub mod chrono;
 mod duplicate_key_impls;
+mod flatten_maybe;
 #[cfg(feature = "json")]
 pub mod json;
-mod flatten_maybe;
 pub mod rust;
 #[doc(hidden)]
 pub mod with_prefix;

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1272,7 +1272,7 @@ pub mod tuple_list_as_map {
     /// Serialize any iteration of tuples into a map.
     pub fn serialize<'a, I, K, V, S>(iter: I, serializer: S) -> Result<S::Ok, S::Error>
     where
-        I: IntoIterator<Item =  &'a (K, V)>,
+        I: IntoIterator<Item = &'a (K, V)>,
         I::IntoIter: ExactSizeIterator,
         K: Serialize + 'a,
         V: Serialize + 'a,

--- a/tests/chrono.rs
+++ b/tests/chrono.rs
@@ -1,11 +1,11 @@
 #![cfg(feature = "chrono")]
 
 extern crate chrono;
+extern crate pretty_assertions;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_with;
-extern crate pretty_assertions;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use pretty_assertions::assert_eq;


### PR DESCRIPTION

This was wished in #35.
It apparently can be helpful for interacting with languages which have
other definitions of strings.

Closes #35