### PR TITLE
Bump min Rust to 1.36 because of Travis test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ branches:
 
 matrix:
   include:
-    - name: "Bors (1.31.1)"
+    - name: "Bors (1.36.0)"
       if: type = pull_request OR branch = staging OR branch = trying OR type = cron OR type = api
-      rust: 1.31.1
+      rust: 1.36.0
     - name: "Bors (stable)"
       if: branch = staging OR branch = trying OR type = cron OR type = api
       rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* Bump minimal Rust version to 1.31.1 to support Rust Edition 2018
+* Bump minimal Rust version to 1.36.0
+    * Support Rust Edition 2018
+    * version-sync depends on smallvec which requires 1.36
 * Improved CI pipeline by running `cargo audit` and `tarpaulin` in all configurations now.
 
 ## [1.3.1]


### PR DESCRIPTION

* smallvec is required for version-sync test