### PR TITLE
Fix the minimal syn version for serde_with_macros

### DIFF
--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0.1"
 quote = "1.0.0"
 
 [dependencies.syn]
-version = "1.0.0"
+version = "1.0.3"
 features = [
     # "extra-traits", # Only for debugging
     "full",


### PR DESCRIPTION

get_ident was only added in 1.0.3