### PR TITLE
Cleanup some oversights left in the last release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0]
+
 ### Added
 
 * Add a helper to deserialize a `Vec<u8>` from `String` (#35)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT OR Apache-2.0"
 
 exclude = [
     ".codecov.yml",
+    ".github",
     ".gitignore",
     ".pre-commit-config.yaml",
     ".travis.yml",
@@ -26,7 +27,7 @@ exclude = [
 ]
 
 [badges]
-travis-ci = { repository = "jonasbb/serde_with", branch = "master" }
+# github-actions = { repository = "jonasbb/serde_with", workflow = "Rust CI" }
 codecov = { repository = "jonasbb/serde_with", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)
 [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
-[![Build Status](https://travis-ci.org/jonasbb/serde_with.svg?branch=master)](https://travis-ci.org/jonasbb/serde_with)
+[![Build Status](https://github.com/jonasbb/serde_with/workflows/Rust%20CI/badge.svg)](https://github.com/jonasbb/serde_with)
 [![codecov](https://codecov.io/gh/jonasbb/serde_with/branch/master/graph/badge.svg)](https://codecov.io/gh/jonasbb/serde_with)
 
 ---
@@ -56,12 +56,7 @@ However, this will prohibit you from applying deserialize on the value returned 
 The crate comes with custom attributes, which futher extend how serde serialization can be customized.
 They are enabled by default, but can be disabled, by removing the default features from this crate.
 
-The `serde_with` crate re-exports all items from `serde_with_macros`.
-This means, if you want to use any proc_macros, import them like `use serde_with::skip_serializing_none`.
-
-[The documentation for the custom attributes can be found here.](serde_with_macros)
-
-[with-annotation]: https://serde.rs/field-attrs.html#serdewith--module
+[with-annotation]: https://serde.rs/field-attrs.html#with
 [serde#553]: https://github.com/serde-rs/serde/issues/553
 
 ## License

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [badges]
-travis-ci = { repository = "jonasbb/serde_with", branch = "master" }
+# github-actions = { repository = "jonasbb/serde_with", workflow = "Rust CI" }
 codecov = { repository = "jonasbb/serde_with", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! [![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)
 //! [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
-//! [![Build Status](https://travis-ci.org/jonasbb/serde_with.svg?branch=master)](https://travis-ci.org/jonasbb/serde_with)
+//! [![Build Status](https://github.com/jonasbb/serde_with/workflows/Rust%20CI/badge.svg)](https://github.com/jonasbb/serde_with)
 //! [![codecov](https://codecov.io/gh/jonasbb/serde_with/branch/master/graph/badge.svg)](https://codecov.io/gh/jonasbb/serde_with)
 //!
 //! ---
@@ -79,12 +79,7 @@
 //! The crate comes with custom attributes, which futher extend how serde serialization can be customized.
 //! They are enabled by default, but can be disabled, by removing the default features from this crate.
 //!
-//! The `serde_with` crate re-exports all items from `serde_with_macros`.
-//! This means, if you want to use any proc_macros, import them like `use serde_with::skip_serializing_none`.
-//!
-//! [The documentation for the custom attributes can be found here.](serde_with_macros)
-//!
-//! [with-annotation]: https://serde.rs/field-attrs.html#serdewith--module
+//! [with-annotation]: https://serde.rs/field-attrs.html#with
 //! [serde#553]: https://github.com/serde-rs/serde/issues/553
 
 #[cfg(feature = "chrono")]


### PR DESCRIPTION

* Switch the badges to Github Actions instead of Travis.
* Remove link for proc-macro documentation, since doc reexport works now.
* Add version number to changelog title.
* Ignore the .github folder for crates archive.