### PR TITLE
Convert between Sequence-ish types and maps

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-mod impls;
+pub(crate) mod impls;
 
 pub trait DeserializeAs<'de, T>: Sized {
     fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,7 @@
+use crate::de::{impls::DeserializeAsWrap, DeserializeAs};
+use serde::de::MapAccess;
+use std::marker::PhantomData;
+
 /// Re-Implementation of `serde::private::de::size_hint::cautious`
 #[inline]
 pub(crate) fn size_hint_cautious(hint: Option<usize>) -> usize {
@@ -9,3 +13,41 @@ pub(crate) const NANOS_PER_SEC: u32 = 1_000_000_000;
 // pub(crate) const NANOS_PER_MICRO: u32 = 1_000;
 // pub(crate) const MILLIS_PER_SEC: u64 = 1_000;
 // pub(crate) const MICROS_PER_SEC: u64 = 1_000_000;
+
+pub(crate) struct MapIter<'de, A, K, KAs, V, VAs> {
+    pub(crate) access: A,
+    marker: PhantomData<(&'de (), K, KAs, V, VAs)>,
+}
+
+impl<'de, A, K, KAs, V, VAs> MapIter<'de, A, K, KAs, V, VAs> {
+    pub(crate) fn new(access: A) -> Self
+    where
+        A: MapAccess<'de>,
+    {
+        Self {
+            access,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, A, K, KAs, V, VAs> Iterator for MapIter<'de, A, K, KAs, V, VAs>
+where
+    A: MapAccess<'de>,
+    KAs: DeserializeAs<'de, K>,
+    VAs: DeserializeAs<'de, V>,
+{
+    #[allow(clippy::type_complexity)]
+    type Item = Result<(DeserializeAsWrap<K, KAs>, DeserializeAsWrap<V, VAs>), A::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.access.next_entry().transpose()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.access.size_hint() {
+            Some(size) => (size, Some(size)),
+            None => (0, None),
+        }
+    }
+}

--- a/tests/serde_as.rs
+++ b/tests/serde_as.rs
@@ -8,7 +8,11 @@ use serde_with::{
     As, BytesOrString, DefaultOnError, DisplayFromStr, DurationSeconds, Flexible, Integer,
     NoneAsEmptyString, Same, SameAs,
 };
-use std::{collections::BTreeMap, fmt::Debug, rc::Rc, sync::Arc};
+use std::{
+    collections::{BTreeMap, LinkedList, VecDeque},
+    rc::Rc,
+    sync::Arc,
+};
 
 #[test]
 fn test_display_fromstr() {
@@ -190,18 +194,45 @@ fn test_tuple_list_as_map() {
         r#"{"values":{"1":"1.2.3.4","10":"1.2.3.4","200":"255.255.255.255"}}"#,
     );
 
-    // #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    // struct StructDeque {
-    //     #[serde(with = "As::<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
-    //     values: VecDeque<(u32, IpAddr)>,
-    // };
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructDeque {
+        #[serde(with = "As::<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
+        values: VecDeque<(u32, IpAddr)>,
+    };
 
-    // is_equal(
-    //     StructDeque {
-    //         values: vec![(1, ip), (10, ip), (200, ip2)].into(),
-    //     },
-    //     r#"{"values":{"1":"1.2.3.4","10":"1.2.3.4","200":"255.255.255.255"}}"#,
-    // );
+    is_equal(
+        StructDeque {
+            values: vec![(1, ip), (10, ip), (200, ip2)].into(),
+        },
+        r#"{"values":{"1":"1.2.3.4","10":"1.2.3.4","200":"255.255.255.255"}}"#,
+    );
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructLinkedList {
+        #[serde(with = "As::<HashMap<DisplayFromStr, DisplayFromStr>>")]
+        values: LinkedList<(u32, IpAddr)>,
+    };
+
+    is_equal(
+        StructDeque {
+            values: vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect(),
+        },
+        r#"{"values":{"1":"1.2.3.4","10":"1.2.3.4","200":"255.255.255.255"}}"#,
+    );
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructOption {
+        #[serde(with = "As::<HashMap<DisplayFromStr, DisplayFromStr>>")]
+        values: Option<(u32, IpAddr)>,
+    };
+
+    is_equal(
+        StructOption {
+            values: Some((1, ip)),
+        },
+        r#"{"values":{"1":"1.2.3.4"}}"#,
+    );
+    is_equal(StructOption { values: None }, r#"{"values":{}}"#);
 }
 
 #[test]


### PR DESCRIPTION

Sequence-ish types are types implementing IntoIterator and FromIterator. This includes BinaryHeap or HashSet.