### PR TITLE
Improve performance of applying prefix

### DIFF
--- a/src/with_prefix.rs
+++ b/src/with_prefix.rs
@@ -390,8 +390,10 @@ where
     where
         T: ?Sized + Serialize,
     {
-        self.delegate
-            .serialize_entry(&format!("{}{}", self.prefix, key), value)
+        let mut prefixed_key = String::with_capacity(self.prefix.len() + key.len());
+        prefixed_key.push_str(self.prefix);
+        prefixed_key.push_str(key);
+        self.delegate.serialize_entry(&prefixed_key, value)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {


### PR DESCRIPTION
`format!("{}{}", a, b)` is a very slow method of concatenating strings. See benchmark: https://gist.github.com/peterjoel/97431103893703e81926ae9bd8f768c5#file-results-txt-L2
