### PR TITLE
Impove proc-macro error handling

### DIFF
--- a/serde_with_macros/src/utils.rs
+++ b/serde_with_macros/src/utils.rs
@@ -1,0 +1,20 @@
+use std::iter::Iterator;
+use syn::Error;
+
+pub(crate) trait IteratorExt {
+    fn collect_error(self) -> Result<(), Error>
+    where
+        Self: Iterator<Item = Result<(), Error>> + Sized,
+    {
+        let accu = Ok(());
+        self.fold(accu, |accu, error| match (accu, error) {
+            (Ok(()), error) => error,
+            (accu, Ok(())) => accu,
+            (Err(mut err), Err(error)) => {
+                err.combine(error);
+                Err(err)
+            }
+        })
+    }
+}
+impl<I> IteratorExt for I where I: Iterator<Item = Result<(), Error>> + Sized {}

--- a/serde_with_macros/tests/compile-fail/skip-none-always.stderr
+++ b/serde_with_macros/tests/compile-fail/skip-none-always.stderr
@@ -1,20 +1,17 @@
 error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field: `a`.
  --> $DIR/skip-none-always.rs:8:5
   |
-8 | /     #[serde(skip_serializing_if = "Option::is_none")]
-9 | |     a: Option<char>,
-  | |___________________^
+8 |     #[serde(skip_serializing_if = "Option::is_none")]
+  |     ^
 
 error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field.
   --> $DIR/skip-none-always.rs:16:5
    |
-16 | /     #[serde(skip_serializing_if = "Option::is_none")]
-17 | |     Option<char>,
-   | |________________^
+16 |     #[serde(skip_serializing_if = "Option::is_none")]
+   |     ^
 
 error: `serialize_always` may only be used on fields of type `Option`.
   --> $DIR/skip-none-always.rs:23:5
    |
-23 | /     #[serialize_always]
-24 | |     a: char,
-   | |___________^
+23 |     #[serialize_always]
+   |     ^

--- a/serde_with_macros/tests/compile-fail/skip-none-always.stderr
+++ b/serde_with_macros/tests/compile-fail/skip-none-always.stderr
@@ -1,23 +1,20 @@
 error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field: `a`.
- --> $DIR/skip-none-always.rs:4:1
+ --> $DIR/skip-none-always.rs:8:5
   |
-4 | #[skip_serializing_none]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+8 | /     #[serde(skip_serializing_if = "Option::is_none")]
+9 | |     a: Option<char>,
+  | |___________________^
 
 error: The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field.
-  --> $DIR/skip-none-always.rs:12:1
+  --> $DIR/skip-none-always.rs:16:5
    |
-12 | #[skip_serializing_none]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+16 | /     #[serde(skip_serializing_if = "Option::is_none")]
+17 | |     Option<char>,
+   | |________________^
 
 error: `serialize_always` may only be used on fields of type `Option`.
-  --> $DIR/skip-none-always.rs:20:1
+  --> $DIR/skip-none-always.rs:23:5
    |
-20 | #[skip_serializing_none]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+23 | /     #[serialize_always]
+24 | |     a: char,
+   | |___________^

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,5 +1,7 @@
 // This test fails for older compiler versions since the error messages are different.
 #[rustversion::attr(before(1.38), ignore)]
+// TODO The error messages are more detailed on nightly, thus breaking the test.
+#[rustversion::attr(nightly, ignore)]
 #[test]
 fn compile_test() {
     // This test does not work under tarpaulin, so skip it if detected


### PR DESCRIPTION

* Use as error location the field which causes the error instead of only the proc-macro location
* Allow reporting errors for all fields by merging them into one error.