### PR TITLE
Explicitly test the expansion of the proc-macros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ on:
   pull_request:
   push:
     branches:
-    - master
-    - staging
-    - trying
+      - master
+      - staging
+      - trying
 
 env:
   CARGO_INCREMENTAL: 0
@@ -97,7 +97,18 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          components: rustfmt
           override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-expand
+          version: latest
+        if: matrix.rust == 'nightly'
+
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          version: latest
       - uses: actions-rs/cargo@v1
         name: Build (${{ matrix.os }} / ${{ matrix.rust }})
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,8 @@ jobs:
   clippy_check:
     strategy:
       matrix:
-        os: [
-          "ubuntu-latest",
-          "windows-latest",
-        ]
-        rust: [
-          "stable",
-          "nightly",
-        ]
+        os: ["ubuntu-latest", "windows-latest"]
+        rust: ["stable", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.1
@@ -74,22 +68,11 @@ jobs:
 
   build_and_test:
     name: Build and Test
-    needs: [
-      "rustfmt",
-      "clippy_check",
-    ]
+    needs: ["rustfmt", "clippy_check"]
     strategy:
       matrix:
-        os: [
-          "ubuntu-latest",
-          "windows-latest",
-        ]
-        rust: [
-          "1.36.0",
-          "stable",
-          "beta",
-          "nightly",
-        ]
+        os: ["ubuntu-latest", "windows-latest"]
+        rust: ["1.36.0", "stable", "beta", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.1
@@ -105,10 +88,6 @@ jobs:
           version: latest
         if: matrix.rust == 'nightly'
 
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-audit
-          version: latest
       - uses: actions-rs/cargo@v1
         name: Build (${{ matrix.os }} / ${{ matrix.rust }})
         with:

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -34,6 +34,7 @@ features = [
 ]
 
 [dev-dependencies]
+macrotest = "1.0.2"
 pretty_assertions = "0.6.1"
 rustversion = "1.0.0"
 serde = { version = "1.0.75", features = [ "derive" ] }

--- a/serde_with_macros/tests/expand.rs
+++ b/serde_with_macros/tests/expand.rs
@@ -1,4 +1,4 @@
-// #[rustversion::attr(not(nightly), ignore)]
+#[rustversion::attr(not(nightly), ignore)]
 #[test]
 fn expandtest() {
     macrotest::expand("tests/expand/*.rs");

--- a/serde_with_macros/tests/expand.rs
+++ b/serde_with_macros/tests/expand.rs
@@ -1,0 +1,5 @@
+// #[rustversion::attr(not(nightly), ignore)]
+#[test]
+fn expandtest() {
+    macrotest::expand("tests/expand/*.rs");
+}

--- a/serde_with_macros/tests/expand/serde_as.expanded.rs
+++ b/serde_with_macros/tests/expand/serde_as.expanded.rs
@@ -1,0 +1,47 @@
+use serde_with_macros::serde_as;
+/// Test correct replacement of the infer type
+struct DataInferTypeReplacement {
+    #[serde(with = "::serde_with::As::<:: serde_with :: Same>")]
+    a: u32,
+    #[serde(with = "::serde_with::As::<std :: vec :: Vec < :: serde_with :: Same >>")]
+    b: Vec<u32>,
+    #[serde(with = "::serde_with::As::<Vec < (:: serde_with :: Same, :: serde_with :: Same) >>")]
+    c: Vec<(u32, String)>,
+    #[serde(with = "::serde_with::As::<[:: serde_with :: Same ; 2]>")]
+    d: [u32; 2],
+    #[serde(with = "::serde_with::As::<Box < [:: serde_with :: Same] >>")]
+    e: Box<[u32]>,
+}
+/// Test different variants of *as annotation
+struct DataVariants {
+    #[serde(with = "::serde_with::As::<:: serde_with :: Same>")]
+    a: u32,
+    #[serde(
+        deserialize_with = "::serde_with::As::<std :: vec :: Vec < :: serde_with :: Same >>::deserialize"
+    )]
+    #[serde(serialize_with = "::serde_with::As::<:: serde_with :: Same>::serialize")]
+    b: Vec<u32>,
+    #[serde(
+        serialize_with = "::serde_with::As::<HashMap < :: serde_with :: Same, :: serde_with :: Same >>::serialize"
+    )]
+    c: Vec<(u32, String)>,
+    #[serde(deserialize_with = "::serde_with::As::<[:: serde_with :: Same ; 2]>::deserialize")]
+    d: [u32; 2],
+    #[serde(with = "::serde_with::As::<Box < [:: serde_with :: Same] >>")]
+    e: Box<[u32]>,
+}
+/// Test replacement in enums
+enum DataEnumWithStructVariants {
+    Var1 {
+        #[serde(with = "::serde_with::As::<:: serde_with :: Same>")]
+        a: u32,
+    },
+    Var2 {
+        #[serde(with = "::serde_with::As::<:: serde_with :: Same>")]
+        b: u32,
+        #[serde(deserialize_with = "::serde_with::As::<Abc>::deserialize")]
+        #[serde(serialize_with = "::serde_with::As::<Def>::serialize")]
+        c: String,
+    },
+    Unit,
+}

--- a/serde_with_macros/tests/expand/serde_as.rs
+++ b/serde_with_macros/tests/expand/serde_as.rs
@@ -1,0 +1,47 @@
+use serde_with_macros::serde_as;
+
+/// Test correct replacement of the infer type
+#[serde_as]
+struct DataInferTypeReplacement {
+    #[serde_as(as = "_")]
+    a: u32,
+    #[serde_as(as = "std::vec::Vec<_>")]
+    b: Vec<u32>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    c: Vec<(u32, String)>,
+    #[serde_as(as = "[_; 2]")]
+    d: [u32; 2],
+    #[serde_as(as = "Box<[_]>")]
+    e: Box<[u32]>,
+}
+
+/// Test different variants of *as annotation
+#[serde_as]
+struct DataVariants {
+    #[serde_as(as = "_")]
+    a: u32,
+    #[serde_as(deserialize_as = "std::vec::Vec<_>", serialize_as = "_")]
+    b: Vec<u32>,
+    #[serde_as(serialize_as = "HashMap<_, _>")]
+    c: Vec<(u32, String)>,
+    #[serde_as(deserialize_as = "[_; 2]")]
+    d: [u32; 2],
+    #[serde_as(as = "Box<[_]>")]
+    e: Box<[u32]>,
+}
+
+/// Test replacement in enums
+#[serde_as]
+enum DataEnumWithStructVariants {
+    Var1 {
+        #[serde_as(as = "_")]
+        a: u32,
+    },
+    Var2 {
+        #[serde_as(as = "_")]
+        b: u32,
+        #[serde_as(deserialize_as = "Abc", serialize_as = "Def")]
+        c: String,
+    },
+    Unit,
+}

--- a/serde_with_macros/tests/expand/skip_serializing_null.expanded.rs
+++ b/serde_with_macros/tests/expand/skip_serializing_null.expanded.rs
@@ -1,0 +1,31 @@
+use serde_with_macros::skip_serializing_none;
+fn never<T>(_t: &T) -> bool {
+    false
+}
+/// Test different ways to write [`Option`] and the `serialize_always` attribute.
+struct Data {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: ::std::option::Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b: std::option::Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    c: ::std::option::Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    d: core::option::Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    e: Option<u8>,
+    f: Option<u8>,
+}
+/// Test how [`skip_serializing_none`][] works with existing annotations.
+struct DataExistingAnnotation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "abc")]
+    b: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    c: Option<String>,
+    #[serde(skip_serializing_if = "never")]
+    #[serde(rename = "name")]
+    d: Option<String>,
+}

--- a/serde_with_macros/tests/expand/skip_serializing_null.rs
+++ b/serde_with_macros/tests/expand/skip_serializing_null.rs
@@ -1,0 +1,32 @@
+use serde_with_macros::skip_serializing_none;
+
+fn never<T>(_t: &T) -> bool {
+    false
+}
+
+/// Test different ways to write [`Option`] and the `serialize_always` attribute.
+#[skip_serializing_none]
+struct Data {
+    a: ::std::option::Option<String>,
+    b: std::option::Option<String>,
+    c: ::std::option::Option<i64>,
+    d: core::option::Option<i64>,
+
+    e: Option<u8>,
+    #[serialize_always]
+    f: Option<u8>,
+}
+
+/// Test how [`skip_serializing_none`][] works with existing annotations.
+#[skip_serializing_none]
+struct DataExistingAnnotation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "abc")]
+    b: Option<String>,
+    #[serde(default)]
+    c: Option<String>,
+    #[serde(skip_serializing_if = "never")]
+    #[serde(rename = "name")]
+    d: Option<String>,
+}

--- a/serde_with_macros/tests/skip_serializing_null.rs
+++ b/serde_with_macros/tests/skip_serializing_null.rs
@@ -57,6 +57,7 @@ fn never<T>(_t: &T) -> bool {
     false
 }
 
+/// Test how [`skip_serializing_none`][] works with existing annotations
 #[skip_serializing_none]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DataExistingAnnotation {


### PR DESCRIPTION

This makes the proc-macros better testable, as now the ouput of them can be compared.
This is in addition to the functional tests already existing.