### PR TITLE
Improve documentation for serde_as types and traits

### DIFF
--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -29,7 +29,9 @@ where
     where
         D: Deserializer<'de>,
     {
-        Ok(Box::new(U::deserialize_as(deserializer)?))
+        Ok(Box::new(
+            DeserializeAsWrap::<T, U>::deserialize(deserializer)?.into_inner(),
+        ))
     }
 }
 
@@ -182,32 +184,6 @@ seq_impl!(
     VecDeque::with_capacity(utils::size_hint_cautious(seq.size_hint())),
     push_back
 );
-
-pub(crate) struct DeserializeAsWrap<T, U> {
-    value: T,
-    marker: PhantomData<U>,
-}
-
-impl<T, U> DeserializeAsWrap<T, U> {
-    pub(crate) fn into_inner(self) -> T {
-        self.value
-    }
-}
-
-impl<'de, T, U> Deserialize<'de> for DeserializeAsWrap<T, U>
-where
-    U: DeserializeAs<'de, T>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        U::deserialize_as(deserializer).map(|value| Self {
-            value,
-            marker: PhantomData,
-        })
-    }
-}
 
 macro_rules! map_impl2 {
     (

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,11 +1,101 @@
-use super::*;
+//! Module for [`DeserializeAs`][] implementations
+//!
+//! The module contains the [`DeserializeAs`][] trait and helper code.
+//! Additionally, it contains implementations of [`DeserializeAs`][] for types defined in the Rust Standard Library or this crate.
+//!
+//! You can find more details on how to implement this trait for your types in the documentation of the [`DeserializeAs`][] trait and details about the usage in the [user guide][].
+//!
+//! [user guide]: crate::guide
 
 pub(crate) mod impls;
 
+use super::*;
+use serde::Deserialize;
+
+/// A **data structure** that can be deserialized from any data format supported by Serde, analoge to [`Deserialize`].
+///
+/// The trait is analoge to the [`serde::Deserialize`][`Deserialize`] trait, with the same meaning of input and output arguments.
+/// It can and should the implemented using the same code structure as the [`Deserialize`] trait.
+/// As such, the same advice for [implementing `Deserialize`][impl-deserialize] applies here.
+///
+/// # Differences to [`Deserialize`]
+///
+/// The trait is only required for container-like types or types implementing specific conversion functions.
+/// Container-like types are [`Vec`][], [`BTreeMap`][], but also [`Option`][] and [`Box`][].
+/// Conversion types deserialize into a different Rust type.
+/// For example, [`DisplayFromStr`] uses the [`FromStr`] trait after deserializing a string and [`DurationSeconds`] creates a [`Duration`] from either String or integer values.
+///
+/// This code shows how to implement [`Deserialize`] for [`Box`]:
+///
+/// ```rust,ignore
+/// impl<'de, T: Deserialize<'de>> Deserialize<'de> for Box<T> {
+///     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+///     where
+///         D: Deserializer<'de>,
+///     {
+///         Ok(Box::new(Deserialize::deserialize(deserializer)?))
+///     }
+/// }
+/// ```
+///
+/// and this code shows how to do the same using [`DeserializeAs`][]:
+///
+/// ```rust,ignore
+/// impl<'de, T, U> DeserializeAs<'de, Box<T>> for Box<U>
+/// where
+///     U: DeserializeAs<'de, T>,
+/// {
+///     fn deserialize_as<D>(deserializer: D) -> Result<Box<T>, D::Error>
+///     where
+///         D: Deserializer<'de>,
+///     {
+///         Ok(Box::new(
+///             DeserializeAsWrap::<T, U>::deserialize(deserializer)?.into_inner(),
+///         ))
+///     }
+/// }
+/// ```
+///
+/// It uses two type parameters, `T` and `U` instead of only one and performs the deserialization step using the `DeserialzieAsWrap` type.
+/// The `T` type is the on the Rust side after deserialization, whereas the `U` type determines how the value will be deserialized.
+/// These two changes are usually enough to make a container type implement [`DeserializeAs`][].
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
+/// [`Deserialize`]: serde::Deserialize
+/// [`Duration`]: std::time::Duration
+/// [`FromStr`]: std::str::FromStr
+/// [impl-deserialize]: https://serde.rs/impl-deserialize.html
 pub trait DeserializeAs<'de, T>: Sized {
     fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>;
+}
 
-    // TODO: deserialize_as_into
+/// Helper type to implement [`DeserializeAs`] for container-like types.
+#[derive(Debug)]
+pub struct DeserializeAsWrap<T, U> {
+    value: T,
+    marker: PhantomData<U>,
+}
+
+impl<'de, T, U> DeserializeAsWrap<T, U> {
+    /// Return the inner value of type `T`.
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<'de, T, U> Deserialize<'de> for DeserializeAsWrap<T, U>
+where
+    U: DeserializeAs<'de, T>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        U::deserialize_as(deserializer).map(|value| Self {
+            value,
+            marker: PhantomData,
+        })
+    }
 }

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
     fmt::Display,
     hash::{BuildHasher, Hash},
-    marker::PhantomData,
     time::Duration,
 };
 
@@ -42,32 +41,6 @@ where
             Some(ref value) => serializer.serialize_some(&SerializeAsWrap::<T, U>::new(value)),
             None => serializer.serialize_none(),
         }
-    }
-}
-
-pub(crate) struct SerializeAsWrap<'a, T, U> {
-    value: &'a T,
-    marker: PhantomData<U>,
-}
-
-impl<'a, T, U> SerializeAsWrap<'a, T, U> {
-    pub(crate) fn new(value: &'a T) -> Self {
-        Self {
-            value,
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<'a, T, U> Serialize for SerializeAsWrap<'a, T, U>
-where
-    U: SerializeAs<T>,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        U::serialize_as(self.value, serializer)
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,9 +1,111 @@
-use super::*;
+//! Module for [`SerializeAs`][] implementations
+//!
+//! The module contains the [`SerializeAs`][] trait and helper code.
+//! Additionally, it contains implementations of [`SerializeAs`][] for types defined in the Rust Standard Library or this crate.
+//!
+//! You can find more details on how to implement this trait for your types in the documentation of the [`SerializeAs`][] trait and details about the usage in the [user guide][].
+//!
+//! [user guide]: serde_with::guide
 
 mod impls;
 
+use super::*;
+
+/// A **data structure** that can be serialized into any data format supported by Serde, analoge to [`Serialize`].
+///
+/// The trait is analoge to the [`serde::Serialize`][`Serialize`] trait, with the same meaning of input and output arguments.
+/// It can and should the implemented using the same code structure as the [`Serialize`] trait.
+/// As such, the same advice for [implementing `Serialize`][impl-serialize] applies here.
+///
+/// # Differences to [`Deserialize`]
+///
+/// The trait is only required for container-like types or types implementing specific conversion functions.
+/// Container-like types are [`Vec`][], [`BTreeMap`][], but also [`Option`][] and [`Box`][].
+/// Conversion types serialize into a different serde data type.
+/// For example, [`DisplayFromStr`] uses the [`Display`] trait to serialize a String and [`DurationSeconds`] converts a [`Duration`] into either String or integer values.
+///
+/// This code shows how to implement [`Serialize`] for [`Box`]:
+///
+/// ```rust,ignore
+/// impl<T> Serialize for Box<T>
+/// where
+///     T: Serialize,
+/// {
+///     #[inline]
+///     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+///     where
+///         S: Serializer,
+///     {
+///         (**self).serialize(serializer)
+///     }
+/// }
+/// ```
+///
+/// and this code shows how to do the same using [`SerializeAs`][]:
+///
+/// ```rust,ignore
+/// impl<T, U> SerializeAs<Box<T>> for Box<U>
+/// where
+///     U: SerializeAs<T>,
+/// {
+///     fn serialize_as<S>(source: &Box<T>, serializer: S) -> Result<S::Ok, S::Error>
+///     where
+///         S: Serializer,
+///     {
+///         SerializeAsWrap::<T, U>::new(source).serialize(serializer)
+///     }
+/// }
+/// ```
+///
+/// It uses two type parameters, `T` and `U` instead of only one and performs the serialization step using the `SerialzieAsWrap` type.
+/// The `T` type is the on the Rust side before serialization, whereas the `U` type determines how the value will be serialized.
+/// These two changes are usually enough to make a container type implement [`SerializeAs`][].
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
+/// [`Deserialize`]: serde::Deserialize
+/// [`Duration`]: std::time::Duration
+/// [`FromStr`]: std::str::FromStr
+/// [impl-serialize]: https://serde.rs/impl-serialize.html
 pub trait SerializeAs<T> {
     fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer;
+}
+
+/// Helper type to implement [`SerializeAs`] for container-like types.
+#[derive(Debug)]
+pub struct SerializeAsWrap<'a, T, U> {
+    value: &'a T,
+    marker: PhantomData<U>,
+}
+
+impl<'a, T, U> SerializeAsWrap<'a, T, U> {
+    /// Create new instance with provided value.
+    pub fn new(value: &'a T) -> Self {
+        Self {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, U> Serialize for SerializeAsWrap<'a, T, U>
+where
+    U: SerializeAs<T>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        U::serialize_as(self.value, serializer)
+    }
+}
+
+impl<'a, T, U> From<&'a T> for SerializeAsWrap<'a, T, U>
+where
+    U: SerializeAs<T>,
+{
+    fn from(value: &'a T) -> Self {
+        Self::new(value)
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::de::{impls::DeserializeAsWrap, DeserializeAs};
+use crate::de::{DeserializeAs, DeserializeAsWrap};
 use serde::de::{MapAccess, SeqAccess};
 use std::marker::PhantomData;
 


### PR DESCRIPTION

* Add documentation to the `de` and `ser` modules.
* Expose the types `SerializeAsWrap` and `DeserializeAsWrap`. These
  types, or similar ones, are necessary to implement `SerializeAs` for
  container types, as the wrapper allows to change how the inner types
  get serialized.
* Add documentation to the traits `SerializeAs` and `DeserializeAs`.