### PR TITLE
Cleanup cfg features for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,18 @@ serde_json = { version = "1.0.25", features = [ "preserve_order" ] }
 version-sync = "0.8.1"
 
 [[test]]
+name = "chrono"
+required-features = ["chrono, macros"]
+
+[[test]]
+name = "hex"
+required-features = ["hex, macros"]
+
+[[test]]
+name = "json"
+required-features = ["json, macros"]
+
+[[test]]
 name = "serde_as"
 required-features = ["macros"]
 

--- a/tests/chrono.rs
+++ b/tests/chrono.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "chrono")]
-
 mod utils;
 
 use crate::utils::{

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "hex")]
-
 mod utils;
 
 use crate::utils::is_equal;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "json")]
-
 mod utils;
 
 use crate::utils::is_equal;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 


### PR DESCRIPTION

Replace the #![cfg()] with required-features in Cargo.toml