### PR TITLE
Fix #139: Do not panic on darling errors

### DIFF
--- a/serde_with_macros/tests/compile-fail/serde_as.rs
+++ b/serde_with_macros/tests/compile-fail/serde_as.rs
@@ -48,4 +48,16 @@ struct ConflictingWithAnnotations {
     i: u32,
 }
 
+/// Test error message for unknown fields for the [serde_as] macro
+#[serde_as]
+#[derive(Serialize)]
+struct ConflictingAsAnnotations {
+    #[serde_as(as = "_")]
+    normal_field: u32,
+    #[serde_as(does_not_exist = "123")]
+    unknown: u32,
+    #[serde_as(unknwn1 = "Hello", unknw2 = "World")]
+    two_unkowns: u32,
+}
+
 fn main() {}

--- a/serde_with_macros/tests/compile-fail/serde_as.stderr
+++ b/serde_with_macros/tests/compile-fail/serde_as.stderr
@@ -69,3 +69,21 @@ error: Cannot combine `serde_as` with serde's `with`, `deserialize_with`, or `se
    |
 47 |     #[serde(serialize_with = "u32")]
    |     ^
+
+error: Unknown field: `does_not_exist`
+  --> $DIR/serde_as.rs:57:16
+   |
+57 |     #[serde_as(does_not_exist = "123")]
+   |                ^^^^^^^^^^^^^^
+
+error: Unknown field: `unknwn1`
+  --> $DIR/serde_as.rs:59:16
+   |
+59 |     #[serde_as(unknwn1 = "Hello", unknw2 = "World")]
+   |                ^^^^^^^
+
+error: Unknown field: `unknw2`
+  --> $DIR/serde_as.rs:59:35
+   |
+59 |     #[serde_as(unknwn1 = "Hello", unknw2 = "World")]
+   |                                   ^^^^^^


### PR DESCRIPTION

Refactor the serde_as macro code to pass through the darling::Errors
such that the code no longer panics and produces nice error messages.

Add UI test which shows the error messages.