### PR TITLE
Release serde_with_macros 1.2.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ doc-comment = { version = "0.3.3", optional = true }
 hex = { version = "0.4.2", optional = true }
 serde = "1.0.75"
 serde_json = { version = "1.0.1", optional = true }
-serde_with_macros = { path = "./serde_with_macros", version = "1.2.0-alpha.1", optional = true }
+serde_with_macros = { path = "./serde_with_macros", version = "1.2.0-alpha.2", optional = true }
 
 [dev-dependencies]
 fnv = "1.0.6"

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0-alpha.2]
+
+### Fixed
+
+* The `serde_as` macro now supports serde attributes and no longer panic on unrecognized values in the attribute.
+
 ## [1.2.0-alpha.1]
 
 ### Added

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_with_macros"
-version = "1.2.0-alpha.1"
+version = "1.2.0-alpha.2"
 authors = ["jonasbb"]
 
 categories = ["encoding"]

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -23,7 +23,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.2.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.2.0-alpha.2")]
 // FIXME: clippy bug https://github.com/rust-lang/rust-clippy/issues/5704
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::unnested_or_patterns)]


### PR DESCRIPTION

Release a new version with a serde_as macro which is actually usable.

* Update Changelog