### PR TITLE
codecov: Remove target from tests, as this currenlty uses the global coverage and not the test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ coverage:
       # declare a new status context "serde_with"
       serde_with:
         paths:
-          - "src"
+          - "src/"
         # Use the coverage from the base commit as baseline
         target: auto
         # Allow the coverage to change by up to 5%
@@ -31,10 +31,11 @@ coverage:
       serde_with_tests:
         # Only include coverage of the "tests/" folder
         paths:
-          - "tests"
+          - "tests/"
         # We cannot require 100%, as tarpaulin has some issues in counting lines
         # Require at least 90% to pass this check
-        target: 90%
+        # FIXME: target is currently broken: https://community.codecov.io/t/github-check-not-properly-handling-subsets-of-files/1853
+        # target: 90%
         # Allow the coverage to change by up to 5%
         threshold: "5%"
 
@@ -42,16 +43,17 @@ coverage:
       # declare a new status context "serde_with_macros"
       serde_with_macros:
         paths:
-          - "serde_with_macros/src"
+          - "serde_with_macros/src/"
         informational: true
 
       # declare a new status context "serde_with_macros_test"
       serde_with_macros_test:
         paths:
-          - "serde_with_macros/tests"
+          - "serde_with_macros/tests/"
         # We cannot require 100%, as tarpaulin has some issues in counting lines
         # Require at least 90% to pass this check
-        target: 90%
+        # FIXME: target is currently broken: https://community.codecov.io/t/github-check-not-properly-handling-subsets-of-files/1853
+        # target: 90%
         # Allow the coverage to change by up to 5%
         threshold: "5%"
 


### PR DESCRIPTION
https://community.codecov.io/t/github-check-not-properly-handling-subsets-of-files/1853