### PR TITLE
Fix and document DefaultOnError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,7 @@ pub struct NoneAsEmptyString;
 /// # Examples
 ///
 /// ```
+/// # #[cfg(feature = "macros")] {
 /// # use serde_derive::Deserialize;
 /// # use serde_with::{serde_as, DefaultOnError};
 /// #
@@ -504,11 +505,13 @@ pub struct NoneAsEmptyString;
 ///
 /// // Missing entries still cause errors
 /// assert!(serde_json::from_str::<A>(r#"{  }"#).is_err());
+/// # }
 /// ```
 ///
 /// Deserializing missing values can be supported by adding the `default` field attribute:
 ///
 /// ```
+/// # #[cfg(feature = "macros")] {
 /// # use serde_derive::Deserialize;
 /// # use serde_with::{serde_as, DefaultOnError};
 /// #
@@ -523,6 +526,7 @@ pub struct NoneAsEmptyString;
 ///
 /// let b: B = serde_json::from_str(r#"{  }"#).unwrap();
 /// assert_eq!(0, b.value);
+/// # }
 /// ```
 ///
 /// `DefaultOnError` can be combined with other convertion methods.
@@ -530,6 +534,7 @@ pub struct NoneAsEmptyString;
 /// If the string does not parse as a number, then we get the default value of 0.
 ///
 /// ```rust
+/// # #[cfg(feature = "macros")] {
 /// # use serde_derive::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, DefaultOnError, DisplayFromStr};
@@ -545,6 +550,7 @@ pub struct NoneAsEmptyString;
 ///     "value": ["1", "2", "a3", "", {}, "6"]
 /// })).unwrap();
 /// assert_eq!(vec![1, 2, 0, 0, 0, 6], c.value);
+/// # }
 /// ```
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DefaultOnError<T = Same>(PhantomData<T>);

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1431,6 +1431,25 @@ pub mod bytes_or_string {
 /// Instead of erroring, it simply deserializes the [`Default`] variant of the type.
 /// It is not possible to find the error location, i.e., which field had a deserialization error, with this method.
 ///
+/// ## Converting to `serde_as`:
+///
+/// The same functionality can be expressed more clearly using the `serde_as` macro.
+/// The `_` is a placeholder which works for any type which implements [`Serialize`]/[`Deserialize`], such as the tuple and `u32` type.
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde_derive::Deserialize;
+/// # use serde_with::{serde_as, DefaultOnError};
+/// #
+/// #[serde_as]
+/// #[derive(Deserialize)]
+/// struct A {
+///     #[serde_as(deserialize_as = "DefaultOnError<_>")]
+///     value: u32,
+/// }
+/// # }
+/// ```
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION

Use the `GoodOrError` enum from the legacy implementation to correctly
deserialize lists and maps. Otherwise the deserializer gets stuck on
invalid syntax because the value is not properly consumed.

Document `DefaultOnError` and put a link to the serde_as version on the legacy item.