### PR TITLE
Improve test UX a bit by using #[track_caller] when available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ fnv = "1.0.6"
 mime = "0.3.16"
 pretty_assertions = "0.6.1"
 ron = "0.6"
+rustversion = "1.0.0"
 serde_derive = "1.0.75"
 serde_json = { version = "1.0.25", features = [ "preserve_order" ] }
 version-sync = "0.8.1"

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,6 +4,7 @@ use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn is_equal<T>(value: T, s: &str)
 where
     T: Debug + DeserializeOwned + PartialEq + Serialize,
@@ -20,6 +21,7 @@ where
     );
 }
 
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn check_deserialization<T>(value: T, deserialize_from: &str)
 where
     T: Debug + DeserializeOwned + PartialEq,
@@ -31,6 +33,7 @@ where
     );
 }
 
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn check_serialization<T>(value: T, serialize_to: &str)
 where
     T: Debug + PartialEq + Serialize,
@@ -42,6 +45,7 @@ where
     );
 }
 
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: &str)
 where
     T: Debug + DeserializeOwned + PartialEq,


### PR DESCRIPTION

The tests/utils.rs functions show the wrong location when the attribute
is not given. In 1.46 the attribute will be stable so can be used.
Use rustversion as a dev-dependency to apply #[track_caller] when
running 1.46 or later.