### PR TITLE
Ensure that docs.rs links always point to the current version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,10 @@ serde_with_macros = { path = "./serde_with_macros", version = "1.2.0-alpha.2", o
 
 [dev-dependencies]
 fnv = "1.0.6"
+glob = "0.3.0"
 mime = "0.3.16"
 pretty_assertions = "0.6.1"
+regex = { version = "1.3.9", default-features = false, features=["std"] }
 ron = "0.6"
 rustversion = "1.0.0"
 serde_derive = "1.0.75"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][]-annotation.
+This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][user guide]-annotation.
 Some common use cases are:
 
 * De/Serializing a type using the `Display` and `FromStr` traits, e.g., for `u8`, `url::Url`, or `mime::Mime`.
@@ -84,7 +84,6 @@ Foo {a: None, b: None, c: None, d: Some(4), e: None, f: None, g: Some(7)}
 This example is mainly supposed to highlight the flexibility of the `serde_as`-annotation compared to [serde's with-annotation][with-annotation].
 More details about `serde_as` can be found in the [user guide][].
 
-
 ```rust
 #[serde_as]
 #[derive(Deserialize, Serialize)]
@@ -120,14 +119,13 @@ Foo {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/*/serde_with/struct.DisplayFromStr.html
-[`serde_as`]: https://docs.rs/serde_with/*/serde_with/guide/index.html
-[`with_prefix!`]: https://docs.rs/serde_with/*/serde_with/macro.with_prefix.html
-[display_fromstr]: https://docs.rs/serde_with/*/serde_with/rust/display_fromstr/index.html
-[feature flags]: https://docs.rs/serde_with/*/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/*/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/*/serde_with/rust/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/*/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/macro.with_prefix.html
+[display_fromstr]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/rust/display_fromstr/index.html
+[feature flags]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/rust/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
 
 ## License

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -425,7 +425,7 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// This macro cannot be used outside of the [`serde_with`] crate, since it relies on types defined therein.
 /// The [`serde_with`] crate has to be available in the root namespace under `::serde_with`.
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/*/serde_with/guide/index.html
+/// [`serde_as`]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/index.html
 /// [`serde_with`]: https://crates.io/crates/serde_with/
 #[proc_macro_attribute]
 pub fn serde_as(_args: TokenStream, input: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ---
 //!
-//! This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][]-annotation.
+//! This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][user guide]-annotation.
 //! Some common use cases are:
 //!
 //! * De/Serializing a type using the `Display` and `FromStr` traits, e.g., for `u8`, `url::Url`, or `mime::Mime`.
@@ -189,14 +189,13 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/*/serde_with/struct.DisplayFromStr.html
-//! [`serde_as`]: https://docs.rs/serde_with/*/serde_with/guide/index.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/*/serde_with/macro.with_prefix.html
-//! [display_fromstr]: https://docs.rs/serde_with/*/serde_with/rust/display_fromstr/index.html
-//! [feature flags]: https://docs.rs/serde_with/*/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/*/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/*/serde_with/rust/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/*/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/macro.with_prefix.html
+//! [display_fromstr]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/rust/display_fromstr/index.html
+//! [feature flags]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/rust/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
 
 #[doc(hidden)]
@@ -332,7 +331,7 @@ impl Separator for CommaSeparator {
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/*/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/attr.serde_as.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct As<T>(PhantomData<T>);
 
@@ -734,7 +733,7 @@ pub struct BytesOrString;
 /// # }
 /// ```
 ///
-/// [feature flag]: https://docs.rs/serde_with/*/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
@@ -861,7 +860,7 @@ pub struct DurationSeconds<
 /// # }
 /// ```
 ///
-/// [feature flag]: https://docs.rs/serde_with/*/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -16,3 +16,56 @@ fn test_readme_deps_in_lib() {
 fn test_html_root_url() {
     assert_html_root_url_updated!("src/lib.rs");
 }
+
+/// Check that all docs.rs links point to the current version
+///
+/// Parse all docs.rs links in `*.rs` and `*.md` files and check that they point to the current version.
+/// If a link should point to latest version this can be done by using `latest` in the version.
+/// The `*` version specifier is not allowed.
+///
+/// Arguably this should be part of version-sync. There is an open issue for this feature:
+/// https://github.com/mgeisler/version-sync/issues/72
+#[test]
+fn test_docs_rs_url_point_to_current_version() -> Result<(), Box<dyn std::error::Error>> {
+    let pkg_name = env!("CARGO_PKG_NAME");
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    let re = regex::Regex::new(&format!(
+        "https?://docs.rs/{}/((\\d[^/]+|\\*|latest))/",
+        pkg_name
+    ))?;
+    let mut error = false;
+
+    for entry in glob::glob("**/*.rs")?.chain(glob::glob("**/*.md")?) {
+        let entry = entry?;
+        let content = std::fs::read_to_string(&entry)?;
+        for (line_number, line) in content.split('\n').enumerate() {
+            for capture in re.captures_iter(&line) {
+                match capture
+                    .get(1)
+                    .expect("Will exist if regex matches")
+                    .as_str()
+                {
+                    "latest" => {}
+                    version if version != pkg_version => {
+                        error = true;
+                        println!(
+                            "{}:{} pkg_version is {} but found URL {}",
+                            entry.display(),
+                            line_number + 1,
+                            pkg_version,
+                            capture.get(0).expect("Group 0 always exists").as_str()
+                        )
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    if error {
+        panic!("Found wrong URLs in file(s)");
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION

The links were pointing to the * version which equals to the latests.
But the latest version might now have the same types as the version in
master.
This already caused frustration with the user guide not being available
in #137.

Fixes #137