### PR TITLE
Add derive macros to implement De/Serialize based on Display and FromStr

### DIFF
--- a/serde_with_macros/tests/deserialize_fromstr.rs
+++ b/serde_with_macros/tests/deserialize_fromstr.rs
@@ -1,0 +1,57 @@
+use pretty_assertions::assert_eq;
+use serde_with_macros::DeserializeFromStr;
+use std::{
+    num::ParseIntError,
+    str::{FromStr, ParseBoolError},
+};
+
+#[derive(Debug, PartialEq, DeserializeFromStr)]
+struct A {
+    a: u32,
+    b: bool,
+}
+
+impl FromStr for A {
+    type Err = String;
+
+    /// Parse a value like `123<>true`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split("<>");
+        let number = parts
+            .next()
+            .ok_or_else(|| "Missing first value".to_string())?
+            .parse()
+            .map_err(|err: ParseIntError| err.to_string())?;
+        let bool = parts
+            .next()
+            .ok_or_else(|| "Missing second value".to_string())?
+            .parse()
+            .map_err(|err: ParseBoolError| err.to_string())?;
+        Ok(Self { a: number, b: bool })
+    }
+}
+
+#[test]
+fn test_deserialize_fromstr() {
+    let a: A = serde_json::from_str("\"159<>true\"").unwrap();
+    assert_eq!(A { a: 159, b: true }, a);
+    let a: A = serde_json::from_str("\"999<>false\"").unwrap();
+    assert_eq!(A { a: 999, b: false }, a);
+    let a: A = serde_json::from_str("\"0<>true\"").unwrap();
+    assert_eq!(A { a: 0, b: true }, a);
+}
+
+#[test]
+fn test_deserialize_fromstr_in_vec() {
+    let json = r#"[
+  "123<>false",
+  "0<>true",
+  "999<>true"
+]"#;
+    let expected = vec![
+        A { a: 123, b: false },
+        A { a: 0, b: true },
+        A { a: 999, b: true },
+    ];
+    assert_eq!(expected, serde_json::from_str::<Vec<A>>(&json).unwrap());
+}

--- a/serde_with_macros/tests/serialize_display.rs
+++ b/serde_with_macros/tests/serialize_display.rs
@@ -1,0 +1,40 @@
+use pretty_assertions::assert_eq;
+use serde_with_macros::SerializeDisplay;
+use std::fmt;
+
+#[derive(SerializeDisplay)]
+struct A {
+    a: u32,
+    b: bool,
+}
+
+impl fmt::Display for A {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "->{} <> {}<-", self.a, self.b)
+    }
+}
+
+#[test]
+fn test_serialize_display() {
+    let a = A { a: 123, b: false };
+    assert_eq!(r#""->123 <> false<-""#, serde_json::to_string(&a).unwrap());
+    let a = A { a: 0, b: true };
+    assert_eq!(r#""->0 <> true<-""#, serde_json::to_string(&a).unwrap());
+    let a = A { a: 999, b: true };
+    assert_eq!(r#""->999 <> true<-""#, serde_json::to_string(&a).unwrap());
+}
+
+#[test]
+fn test_serialize_display_in_vec() {
+    let v = vec![
+        A { a: 123, b: false },
+        A { a: 0, b: true },
+        A { a: 999, b: true },
+    ];
+    let expected = r#"[
+  "->123 <> false<-",
+  "->0 <> true<-",
+  "->999 <> true<-"
+]"#;
+    assert_eq!(expected, serde_json::to_string_pretty(&v).unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,9 @@ pub struct Same;
 /// Another use case is types with [`Display`] and [`FromStr`] implementations, but without serde
 /// support, which can be found in some crates.
 ///
+/// If you control the type you want to de/serialize, you can instead use the two derive macros, [`SerializeDisplay`] and [`DeserializeFromStr`].
+/// They properly implement the traits [`Serialize`] and [`Deserialize`] such that user of the type no longer have to use the `serde_as` system.
+///
 /// The same functionality is also available as [`serde_with::rust::display_fromstr`][crate::rust::display_fromstr] compatible with serde's with-annotation.
 ///
 /// # Examples

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -21,6 +21,9 @@ use std::{
 /// It can be very useful for serialization formats like JSON, which do not support integer
 /// numbers and have to resort to strings to represent them.
 ///
+/// If you control the type you want to de/serialize, you can instead use the two derive macros, [`SerializeDisplay`] and [`DeserializeFromStr`].
+/// They properly implement the traits [`Serialize`] and [`Deserialize`] such that user of the type no longer have to use the with-attribute.
+///
 /// The same functionality is also available as [`serde_with::DisplayFromStr`][crate::DisplayFromStr] compatible with serde's with-annotation.
 ///
 /// # Examples


### PR DESCRIPTION

The crate already supports using Display and FromStr for de/serializing,
but only using the with-attribute and the serde_as system. Implementing
De/Serialize still required manual code.
This derive closes that gap.

Fixes #86
Closes https://github.com/serde-rs/serde/issues/908