### PR TITLE
Improve CI parts

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -4,10 +4,12 @@ on:
     paths:
       - Cargo.toml'
       - '**/Cargo.toml'
+  # Bors related branches
   push:
-    paths:
-      - 'Cargo.toml'
-      - '**/Cargo.toml'
+    branches:
+    - master
+    - staging
+    - trying
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,5 +1,9 @@
 name: Security audit
 on:
+  pull_request:
+    paths:
+      - Cargo.toml'
+      - '**/Cargo.toml'
   push:
     paths:
       - 'Cargo.toml'
@@ -8,6 +12,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   security_audit:
+    name: Rustsec Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,16 @@
 name: Rust CI
 on:
+  # Always test pull requests
   pull_request:
+  # Bors related branches
   push:
     branches:
     - master
     - staging
     - trying
+  # Test once per week: Monday at 00:00
+  schedule:
+    - cron: "0 0 * * 1"
 
 env:
   CARGO_INCREMENTAL: 0
@@ -14,6 +19,7 @@ env:
 jobs:
   clippy_check:
     strategy:
+      fail-fast: false
       matrix:
         os: [
           "ubuntu-latest",
@@ -74,10 +80,6 @@ jobs:
 
   build_and_test:
     name: Build and Test
-    needs: [
-      "rustfmt",
-      "clippy_check",
-    ]
     strategy:
       matrix:
         os: [
@@ -86,6 +88,8 @@ jobs:
         ]
         rust: [
           "1.36.0",
+          "1.40.0",
+          "1.45.2",
           "stable",
           "beta",
           "nightly",
@@ -126,4 +130,23 @@ jobs:
           args: "--workspace --all-features -- --test-threads 1"
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.13
-        if: matrix.rust == 'stable'  && matrix.os == 'ubuntu-latest'
+        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
+
+  # Added to summarize the matrix (otherwise we would need to list every single
+  # job in bors.toml)
+  # https://forum.bors.tech/t/bors-with-github-workflows/426
+  tests-result:
+    name: Tests result
+    if: always()
+    needs:
+      - rustfmt
+      - clippy_check
+      - build_and_test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the job as a success
+        if: needs.tests.result == 'success'
+        run: exit 0
+      - name: Mark the job as a failure
+        if: needs.tests.result == 'failure'
+        run: exit 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,35 +1,7 @@
 # List of commit statuses that must pass on the merge commit before it is pushed to master.
 status = [
-  "Rustfmt (stable)",
-
-  # Clippy Ubuntu
-  "clippy \"No Default Features\" (ubuntu-latest / stable)",
-  "clippy \"Default\" (ubuntu-latest / stable)",
-  "clippy \"All Features\" (ubuntu-latest / stable)",
-
-  "clippy \"No Default Features\" (ubuntu-latest / nightly)",
-  "clippy \"Default\" (ubuntu-latest / nightly)",
-  "clippy \"All Features\" (ubuntu-latest / nightly)",
-
-  # Clippy Windows
-  "clippy \"No Default Features\" (windows-latest / stable)",
-  "clippy \"Default\" (windows-latest / stable)",
-  "clippy \"All Features\" (windows-latest / stable)",
-
-  "clippy \"No Default Features\" (windows-latest / nightly)",
-  "clippy \"Default\" (windows-latest / nightly)",
-  "clippy \"All Features\" (windows-latest / nightly)",
-
-  # Ubuntu/Windows
-  "Build and Test (ubuntu-latest, 1.36.0)",
-  "Build and Test (ubuntu-latest, stable)",
-  "Build and Test (ubuntu-latest, beta)",
-  "Build and Test (ubuntu-latest, nightly)",
-
-  "Build and Test (windows-latest, 1.36.0)",
-  "Build and Test (windows-latest, stable)",
-  "Build and Test (windows-latest, beta)",
-  "Build and Test (windows-latest, nightly)",
+  "Tests result",
+  "Rustsec Audit",
 ]
 # If set to true, and if the PR branch is on the same repository that bors-ng itself is on, the branch will be deleted.
 delete_merged_branches = true

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,7 +1,7 @@
 // This test fails for older compiler versions since the error messages are different.
-#[rustversion::attr(before(1.38), ignore)]
+#[rustversion::attr(before(1.43), ignore)]
 #[cfg_attr(tarpaulin, ignore)]
-// TODO The error messages are more detailed on nightly, thus breaking the test.
+// The error messages are more detailed on nightly, thus breaking the test.
 #[rustversion::attr(nightly, ignore)]
 #[test]
 fn compile_test() {


### PR DESCRIPTION

* Run on more Rust versions. Include not only the minimal supported Rust
  version but all versions in 5 step increments.
* Run the build_and_test phase directly instead of waiting for clippy
  and rustfmt. That should improve overall build times.
* Add a Test status action. This only succeeds if all other tests
  succeed and is mainly for bors
* Run CI once every week
* Simplify bors script using the new status and add the audit action
  also as a requirement.