### PR TITLE
Improve test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = { version = "1.0.1", optional = true }
 serde_with_macros = { path = "./serde_with_macros", version = "1.2.0-alpha.3", optional = true }
 
 [dev-dependencies]
+expect-test = "1.0.0"
 fnv = "1.0.6"
 glob = "0.3.0"
 mime = "0.3.16"

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,6 +1,7 @@
 mod utils;
 
-use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use crate::utils::{check_deserialization, check_error_deserialization_expect, is_equal_expect};
+use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{
     formats::{Lowercase, Uppercase},
@@ -12,32 +13,30 @@ use serde_with::{
 fn hex_vec() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    pub struct SomeBytes {
-        #[serde_as(as = "Vec<Hex>")]
-        bytes: Vec<Vec<u8>>,
-    }
-    is_equal(
-        SomeBytes {
-            bytes: vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]],
-        },
-        r#"{"bytes":["0001020d","0e050607"]}"#,
+    pub struct B(#[serde_as(as = "Vec<Hex>")] Vec<Vec<u8>>);
+
+    is_equal_expect(
+        B(vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]]),
+        expect![[r#"
+            [
+              "0001020d",
+              "0e050607"
+            ]"#]],
     );
 
     // Check mixed case deserialization
     check_deserialization(
-        SomeBytes {
-            bytes: vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]],
-        },
-        r#"{"bytes":["aaBCff","E07d"]}"#,
+        B(vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]]),
+        r#"["aaBCff","E07d"]"#,
     );
 
-    check_error_deserialization::<SomeBytes>(
-        r#"{"bytes":["0"]}"#,
-        "Odd number of digits at line 1 column 14",
+    check_error_deserialization_expect::<B>(
+        r#"["0"]"#,
+        expect![[r#"Odd number of digits at line 1 column 5"#]],
     );
-    check_error_deserialization::<SomeBytes>(
-        r#"{"bytes":["zz"]}"#,
-        "Invalid character \'z\' at position 0 at line 1 column 15",
+    check_error_deserialization_expect::<B>(
+        r#"["zz"]"#,
+        expect![[r#"Invalid character 'z' at position 0 at line 1 column 6"#]],
     );
 }
 
@@ -45,23 +44,21 @@ fn hex_vec() {
 fn hex_vec_lowercase() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    pub struct SomeBytes {
-        #[serde_as(as = "Vec<Hex<Lowercase>>")]
-        bytes: Vec<Vec<u8>>,
-    }
-    is_equal(
-        SomeBytes {
-            bytes: vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]],
-        },
-        r#"{"bytes":["0001020d","0e050607"]}"#,
+    pub struct B(#[serde_as(as = "Vec<Hex<Lowercase>>")] Vec<Vec<u8>>);
+
+    is_equal_expect(
+        B(vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]]),
+        expect![[r#"
+            [
+              "0001020d",
+              "0e050607"
+            ]"#]],
     );
 
     // Check mixed case deserialization
     check_deserialization(
-        SomeBytes {
-            bytes: vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]],
-        },
-        r#"{"bytes":["aaBCff","E07d"]}"#,
+        B(vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]]),
+        r#"["aaBCff","E07d"]"#,
     );
 }
 
@@ -69,22 +66,20 @@ fn hex_vec_lowercase() {
 fn hex_vec_uppercase() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    pub struct SomeBytes {
-        #[serde_as(as = "Vec<Hex<Uppercase>>")]
-        bytes: Vec<Vec<u8>>,
-    }
-    is_equal(
-        SomeBytes {
-            bytes: vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]],
-        },
-        r#"{"bytes":["0001020D","0E050607"]}"#,
+    pub struct B(#[serde_as(as = "Vec<Hex<Uppercase>>")] Vec<Vec<u8>>);
+
+    is_equal_expect(
+        B(vec![vec![0, 1, 2, 13], vec![14, 5, 6, 7]]),
+        expect![[r#"
+            [
+              "0001020D",
+              "0E050607"
+            ]"#]],
     );
 
     // Check mixed case deserialization
     check_deserialization(
-        SomeBytes {
-            bytes: vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]],
-        },
-        r#"{"bytes":["aaBCff","E07d"]}"#,
+        B(vec![vec![0xaa, 0xbc, 0xff], vec![0xe0, 0x7d]]),
+        r#"["aaBCff","E07d"]"#,
     );
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,6 +1,7 @@
 mod utils;
 
-use crate::utils::is_equal;
+use crate::utils::is_equal_expect;
+use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{json::JsonString, serde_as, DisplayFromStr};
 
@@ -20,10 +21,13 @@ fn test_nested_json() {
         value: u32,
     }
 
-    is_equal(
+    is_equal_expect(
         Struct {
             value: Nested { value: 444 },
         },
-        r#"{"value":"{\"value\":\"444\"}"}"#,
+        expect![[r#"
+            {
+              "value": "{\"value\":\"444\"}"
+            }"#]],
     );
 }

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -1,566 +1,416 @@
-use fnv::FnvHashMap;
-use pretty_assertions::assert_eq;
+mod utils;
+
+use crate::utils::{check_deserialization, check_error_deserialization_expect, is_equal_expect};
+use expect_test::expect;
+use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use serde_derive::{Deserialize, Serialize};
-use serde_json::error::Category;
 use serde_with::CommaSeparator;
-use std::collections::{BTreeMap, HashMap, LinkedList, VecDeque};
+use std::{
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
+    iter::FromIterator as _,
+};
 
 #[test]
 fn string_collection() {
-    #[derive(Debug, Deserialize)]
-    struct S {
-        #[serde(with = "serde_with::rust::StringWithSeparator::<CommaSeparator>")]
-        s: Vec<String>,
-    }
-    let from = r#"[
-        { "s": "A,B,C,D" },
-        { "s": ",," },
-        { "s": "AVeryLongString" }
-    ]"#;
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "serde_with::rust::StringWithSeparator::<CommaSeparator>")] Vec<String>,
+    );
 
-    let res: Vec<S> = serde_json::from_str(from).unwrap();
-    assert_eq!(
-        vec![
+    is_equal_expect(S(vec![]), expect![[r#""""#]]);
+    is_equal_expect(
+        S(vec![
             "A".to_string(),
             "B".to_string(),
-            "C".to_string(),
+            "c".to_string(),
             "D".to_string(),
-        ],
-        res[0].s
+        ]),
+        expect![[r#""A,B,c,D""#]],
     );
-    assert_eq!(
-        vec!["".to_string(), "".to_string(), "".to_string()],
-        res[1].s
+    is_equal_expect(
+        S(vec!["".to_string(), "".to_string(), "".to_string()]),
+        expect![[r#"",,""#]],
     );
-    assert_eq!(vec!["AVeryLongString".to_string()], res[2].s);
-}
-
-#[test]
-fn string_collection_non_existing() {
-    #[derive(Debug, Deserialize, Serialize)]
-    struct S {
-        #[serde(with = "serde_with::rust::StringWithSeparator::<CommaSeparator>")]
-        s: Vec<String>,
-    }
-    let from = r#"[
-        { "s": "" }
-    ]"#;
-
-    let res: Vec<S> = serde_json::from_str(from).unwrap();
-    assert_eq!(Vec::<String>::new(), res[0].s);
-
-    assert_eq!(r#"{"s":""}"#, serde_json::to_string(&res[0]).unwrap());
+    is_equal_expect(
+        S(vec!["AVeryLongString".to_string()]),
+        expect![[r#""AVeryLongString""#]],
+    );
 }
 
 #[test]
 fn prohibit_duplicate_value_hashset() {
-    use std::{collections::HashSet, iter::FromIterator};
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")]
-        set: HashSet<usize>,
-    }
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] HashSet<usize>);
 
-    let s = r#"{"set": [1, 2, 3, 4]}"#;
-    let v = Doc {
-        set: HashSet::from_iter(vec![1, 2, 3, 4]),
-    };
-    assert_eq!(v, serde_json::from_str(s).unwrap());
-
-    let s = r#"{"set": [1, 2, 3, 4, 1]}"#;
-    let res: Result<Doc, _> = serde_json::from_str(s);
-    assert!(res.is_err());
+    is_equal_expect(
+        S(HashSet::from_iter(vec![1, 2, 3, 4])),
+        expect![[r#"
+            [
+              4,
+              1,
+              3,
+              2
+            ]"#]],
+    );
+    check_error_deserialization_expect::<S>(
+        r#"[1, 2, 3, 4, 1]"#,
+        expect![[r#"invalid entry: found duplicate value at line 1 column 15"#]],
+    );
 }
 
 #[test]
 fn prohibit_duplicate_value_btreeset() {
-    use std::{collections::BTreeSet, iter::FromIterator};
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")]
-        set: BTreeSet<usize>,
-    }
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] BTreeSet<usize>);
 
-    let s = r#"{"set": [1, 2, 3, 4]}"#;
-    let v = Doc {
-        set: BTreeSet::from_iter(vec![1, 2, 3, 4]),
-    };
-    assert_eq!(v, serde_json::from_str(s).unwrap());
-
-    let s = r#"{"set": [1, 2, 3, 4, 1]}"#;
-    let res: Result<Doc, _> = serde_json::from_str(s);
-    assert!(res.is_err());
+    is_equal_expect(
+        S(BTreeSet::from_iter(vec![1, 2, 3, 4])),
+        expect![[r#"
+            [
+              1,
+              2,
+              3,
+              4
+            ]"#]],
+    );
+    check_error_deserialization_expect::<S>(
+        r#"[1, 2, 3, 4, 1]"#,
+        expect![[r#"invalid entry: found duplicate value at line 1 column 15"#]],
+    );
 }
 
 #[test]
-fn prohibit_duplicate_value_hashmap() {
-    use std::collections::HashMap;
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-        map: HashMap<usize, usize>,
-    }
+fn prohibit_duplicate_key_hashmap() {
+    #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")] HashMap<usize, usize>,
+    );
 
     // Different value and key always works
-    let s = r#"{"map": {"1": 1, "2": 2, "3": 3}}"#;
-    let mut v = Doc {
-        map: HashMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    v.map.insert(3, 3);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "3": 3,
+              "2": 2
+            }"#]],
+    );
 
     // Same value for different keys is ok
-    let s = r#"{"map": {"1": 1, "2": 1, "3": 1}}"#;
-    let mut v = Doc {
-        map: HashMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 1);
-    v.map.insert(3, 1);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(HashMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "3": 1,
+              "2": 1
+            }"#]],
+    );
 
     // Duplicate keys are an error
-    let s = r#"{"map": {"1": 1, "2": 2, "1": 3}}"#;
-    let res: Result<Doc, _> = serde_json::from_str(s);
-    assert!(res.is_err());
+    check_error_deserialization_expect::<S>(
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+        expect![[r#"invalid entry: found duplicate key at line 1 column 24"#]],
+    );
 }
 
 #[test]
-fn prohibit_duplicate_value_btreemap() {
-    use std::collections::BTreeMap;
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-        map: BTreeMap<usize, usize>,
-    }
+fn prohibit_duplicate_key_btreemap() {
+    #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")] BTreeMap<usize, usize>,
+    );
 
     // Different value and key always works
-    let s = r#"{"map": {"1": 1, "2": 2, "3": 3}}"#;
-    let mut v = Doc {
-        map: BTreeMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    v.map.insert(3, 3);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
 
     // Same value for different keys is ok
-    let s = r#"{"map": {"1": 1, "2": 1, "3": 1}}"#;
-    let mut v = Doc {
-        map: BTreeMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 1);
-    v.map.insert(3, 1);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
 
     // Duplicate keys are an error
-    let s = r#"{"map": {"1": 1, "2": 2, "1": 3}}"#;
-    let res: Result<Doc, _> = serde_json::from_str(s);
-    assert!(res.is_err());
+    check_error_deserialization_expect::<S>(
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+        expect![[r#"invalid entry: found duplicate key at line 1 column 24"#]],
+    );
 }
 
 #[test]
 fn duplicate_key_first_wins_hashmap() {
-    use std::collections::HashMap;
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::maps_first_key_wins")]
-        map: HashMap<usize, usize>,
-    }
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::maps_first_key_wins")] HashMap<usize, usize>);
 
     // Different value and key always works
-    let s = r#"{"map": {"1": 1, "2": 2, "3": 3}}"#;
-    let mut v = Doc {
-        map: HashMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    v.map.insert(3, 3);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "3": 3,
+              "2": 2
+            }"#]],
+    );
 
     // Same value for different keys is ok
-    let s = r#"{"map": {"1": 1, "2": 1, "3": 1}}"#;
-    let mut v = Doc {
-        map: HashMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 1);
-    v.map.insert(3, 1);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(HashMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "3": 1,
+              "2": 1
+            }"#]],
+    );
 
     // Duplicate keys, the first one is used
-    let s = r#"{"map": {"1": 1, "2": 2, "1": 3}}"#;
-    let mut v = Doc {
-        map: HashMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    check_deserialization(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2)])),
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+    );
 }
 
 #[test]
 fn duplicate_key_first_wins_btreemap() {
-    use std::collections::BTreeMap;
-    #[derive(Debug, Eq, PartialEq, Deserialize)]
-    struct Doc {
-        #[serde(with = "::serde_with::rust::maps_first_key_wins")]
-        map: BTreeMap<usize, usize>,
-    }
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::maps_first_key_wins")] BTreeMap<usize, usize>);
 
     // Different value and key always works
-    let s = r#"{"map": {"1": 1, "2": 2, "3": 3}}"#;
-    let mut v = Doc {
-        map: BTreeMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    v.map.insert(3, 3);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
 
     // Same value for different keys is ok
-    let s = r#"{"map": {"1": 1, "2": 1, "3": 1}}"#;
-    let mut v = Doc {
-        map: BTreeMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 1);
-    v.map.insert(3, 1);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
 
     // Duplicate keys, the first one is used
-    let s = r#"{"map": {"1": 1, "2": 2, "1": 3}}"#;
-    let mut v = Doc {
-        map: BTreeMap::new(),
-    };
-    v.map.insert(1, 1);
-    v.map.insert(2, 2);
-    assert_eq!(v, serde_json::from_str(s).unwrap());
+    check_deserialization(
+        S(BTreeMap::from_iter(vec![(1, 1), (2, 2)])),
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+    );
 }
 
 #[test]
 fn test_hashmap_as_tuple_list() {
-    #[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
-    struct S {
-        #[serde(with = "serde_with::rust::hashmap_as_tuple_list")]
-        s: HashMap<String, u8>,
-    }
-    let from = r#"{
-        "s": [
-            ["ABC", 1],
-            ["Hello", 0],
-            ["World", 20]
-        ]
-    }"#;
-    let mut expected = S::default();
-    expected.s.insert("ABC".to_string(), 1);
-    expected.s.insert("Hello".to_string(), 0);
-    expected.s.insert("World".to_string(), 20);
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct S(#[serde(with = "serde_with::rust::hashmap_as_tuple_list")] HashMap<String, u8>);
 
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
+    is_equal_expect(
+        S(HashMap::from_iter(vec![
+            ("ABC".to_string(), 1),
+            ("Hello".to_string(), 0),
+            ("World".to_string(), 20),
+        ])),
+        expect![[r#"
+            [
+              [
+                "ABC",
+                1
+              ],
+              [
+                "Hello",
+                0
+              ],
+              [
+                "World",
+                20
+              ]
+            ]"#]],
+    );
+    is_equal_expect(
+        S(HashMap::from_iter(vec![("Hello".to_string(), 0)])),
+        expect![[r#"
+            [
+              [
+                "Hello",
+                0
+              ]
+            ]"#]],
+    );
+    is_equal_expect(S(HashMap::default()), expect![[r#"[]"#]]);
 
-    let from = r#"{
-  "s": [
-    [
-      "Hello",
-      0
-    ]
-  ]
-}"#;
-    let mut expected = S::default();
-    expected.s.insert("Hello".to_string(), 0);
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
-    // We can only do this with a HashMap of size 1 as otherwise the iteration order is unspecified
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": []
-}"#;
-    let expected = S::default();
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    // Test parse error
-    let from = r#"{
-  "s": [ [1] ]
-}"#;
-    let res: Result<S, _> = serde_json::from_str(from);
-    assert!(res.is_err());
-    let err = res.unwrap_err();
-    println!("{:?}", err);
-    assert!(err.is_data());
-}
-
-#[test]
-fn test_hashmap_as_tuple_list_fnv() {
-    #[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
-    struct S {
-        #[serde(with = "serde_with::rust::hashmap_as_tuple_list")]
-        s: FnvHashMap<String, u8>,
-    }
-    let from = r#"{
-        "s": [
-            ["ABC", 1],
-            ["Hello", 0],
-            ["World", 20]
-        ]
-    }"#;
-    let mut expected = S::default();
-    expected.s.insert("ABC".to_string(), 1);
-    expected.s.insert("Hello".to_string(), 0);
-    expected.s.insert("World".to_string(), 20);
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
-
-    let from = r#"{
-  "s": [
-    [
-      "Hello",
-      0
-    ]
-  ]
-}"#;
-    let mut expected = S::default();
-    expected.s.insert("Hello".to_string(), 0);
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
-    // We can only do this with a HashMap of size 1 as otherwise the iteration order is unspecified
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": []
-}"#;
-    let expected = S::default();
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    // Test parse error
-    let from = r#"{
-  "s": [ [1] ]
-}"#;
-    let res: Result<S, _> = serde_json::from_str(from);
-    assert!(res.is_err());
-    let err = res.unwrap_err();
-    println!("{:?}", err);
-    assert!(err.is_data());
+    // Test parse error, only single element instead of tuple
+    check_error_deserialization_expect::<S>(
+        r#"[ [1] ]"#,
+        expect![[r#"invalid type: integer `1`, expected a string at line 1 column 4"#]],
+    );
 }
 
 #[test]
 fn test_btreemap_as_tuple_list() {
-    #[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
-    struct S {
-        #[serde(with = "serde_with::rust::btreemap_as_tuple_list")]
-        s: BTreeMap<String, u8>,
-    }
-    let from = r#"{
-  "s": [
-    [
-      "ABC",
-      1
-    ],
-    [
-      "Hello",
-      0
-    ],
-    [
-      "World",
-      20
-    ]
-  ]
-}"#;
-    let mut expected = S::default();
-    expected.s.insert("ABC".to_string(), 1);
-    expected.s.insert("Hello".to_string(), 0);
-    expected.s.insert("World".to_string(), 20);
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct S(#[serde(with = "serde_with::rust::btreemap_as_tuple_list")] BTreeMap<String, u8>);
 
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![
+            ("ABC".to_string(), 1),
+            ("Hello".to_string(), 0),
+            ("World".to_string(), 20),
+        ])),
+        expect![[r#"
+            [
+              [
+                "ABC",
+                1
+              ],
+              [
+                "Hello",
+                0
+              ],
+              [
+                "World",
+                20
+              ]
+            ]"#]],
+    );
+    is_equal_expect(
+        S(BTreeMap::from_iter(vec![("Hello".to_string(), 0)])),
+        expect![[r#"
+            [
+              [
+                "Hello",
+                0
+              ]
+            ]"#]],
+    );
+    is_equal_expect(S(BTreeMap::default()), expect![[r#"[]"#]]);
 
-    let from = r#"{
-  "s": [
-    [
-      "Hello",
-      0
-    ]
-  ]
-}"#;
-    let mut expected = S::default();
-    expected.s.insert("Hello".to_string(), 0);
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert_eq!(expected, res);
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": []
-}"#;
-    let expected = S::default();
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    // Test parse error
-    let from = r#"{
-  "s": [ [1] ]
-}"#;
-    let res: Result<S, _> = serde_json::from_str(from);
-    assert!(res.is_err());
-    let err = res.unwrap_err();
-    println!("{:?}", err);
-    assert!(err.is_data());
+    // Test parse error, only single element instead of tuple
+    check_error_deserialization_expect::<S>(
+        r#"[ [1] ]"#,
+        expect![[r#"invalid type: integer `1`, expected a string at line 1 column 4"#]],
+    );
 }
 
 #[test]
 fn tuple_list_as_map_vec() {
-    #[derive(Debug, Deserialize, Serialize, Default)]
-    struct S {
-        #[serde(with = "serde_with::rust::tuple_list_as_map")]
-        s: Vec<(Wrapper<i32>, Wrapper<String>)>,
-    }
-
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "serde_with::rust::tuple_list_as_map")] Vec<(Wrapper<i32>, Wrapper<String>)>,
+    );
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct Wrapper<T>(T);
 
-    let from = r#"{
-  "s": {
-    "1": "Hi",
-    "2": "Cake",
-    "99": "Lie"
-  }
-}"#;
-    let mut expected = S::default();
-    expected.s.push((Wrapper(1), Wrapper("Hi".into())));
-    expected.s.push((Wrapper(2), Wrapper("Cake".into())));
-    expected.s.push((Wrapper(99), Wrapper("Lie".into())));
-
-    let res: S = serde_json::from_str(from).unwrap();
-    for ((exp_k, exp_v), (res_k, res_v)) in expected.s.iter().zip(&res.s) {
-        assert_eq!(exp_k.0, res_k.0);
-        assert_eq!(exp_v.0, res_v.0);
-    }
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": {}
-}"#;
-    let expected = S::default();
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": []
-}"#;
-    let res: Result<S, _> = serde_json::from_str(from);
-    let res = res.unwrap_err();
-    assert_eq!(Category::Data, res.classify());
-    assert_eq!(
-        "invalid type: sequence, expected a map at line 2 column 7",
-        res.to_string()
+    is_equal_expect(
+        S(vec![
+            (Wrapper(1), Wrapper("Hi".into())),
+            (Wrapper(2), Wrapper("Cake".into())),
+            (Wrapper(99), Wrapper("Lie".into())),
+        ]),
+        expect![[r#"
+            {
+              "1": "Hi",
+              "2": "Cake",
+              "99": "Lie"
+            }"#]],
     );
-
-    let from = r#"{
-  "s": null
-}"#;
-    let res: Result<S, _> = serde_json::from_str(from);
-    let res = res.unwrap_err();
-    assert_eq!(Category::Data, res.classify());
-    assert_eq!(
-        "invalid type: null, expected a map at line 2 column 11",
-        res.to_string()
+    is_equal_expect(S(Vec::new()), expect![[r#"{}"#]]);
+    check_error_deserialization_expect::<S>(
+        r#"[]"#,
+        expect![[r#"invalid type: sequence, expected a map at line 1 column 0"#]],
+    );
+    check_error_deserialization_expect::<S>(
+        r#"null"#,
+        expect![[r#"invalid type: null, expected a map at line 1 column 4"#]],
     );
 }
 
 #[test]
 fn tuple_list_as_map_linkedlist() {
-    #[derive(Debug, Deserialize, Serialize, Default)]
-    struct S {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(
         #[serde(with = "serde_with::rust::tuple_list_as_map")]
-        s: LinkedList<(Wrapper<i32>, Wrapper<String>)>,
-    }
-
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+        LinkedList<(Wrapper<i32>, Wrapper<String>)>,
+    );
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct Wrapper<T>(T);
 
-    let from = r#"{
-  "s": {
-    "1": "Hi",
-    "2": "Cake",
-    "99": "Lie"
-  }
-}"#;
-    let mut expected = S::default();
-    expected.s.push_back((Wrapper(1), Wrapper("Hi".into())));
-    expected.s.push_back((Wrapper(2), Wrapper("Cake".into())));
-    expected.s.push_back((Wrapper(99), Wrapper("Lie".into())));
-
-    let res: S = serde_json::from_str(from).unwrap();
-    for ((exp_k, exp_v), (res_k, res_v)) in expected.s.iter().zip(&res.s) {
-        assert_eq!(exp_k.0, res_k.0);
-        assert_eq!(exp_v.0, res_v.0);
-    }
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": {}
-}"#;
-    let expected = S::default();
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
+    is_equal_expect(
+        S(LinkedList::from_iter(vec![
+            (Wrapper(1), Wrapper("Hi".into())),
+            (Wrapper(2), Wrapper("Cake".into())),
+            (Wrapper(99), Wrapper("Lie".into())),
+        ])),
+        expect![[r#"
+            {
+              "1": "Hi",
+              "2": "Cake",
+              "99": "Lie"
+            }"#]],
+    );
+    is_equal_expect(S(LinkedList::new()), expect![[r#"{}"#]]);
+    check_error_deserialization_expect::<S>(
+        r#"[]"#,
+        expect![[r#"invalid type: sequence, expected a map at line 1 column 0"#]],
+    );
+    check_error_deserialization_expect::<S>(
+        r#"null"#,
+        expect![[r#"invalid type: null, expected a map at line 1 column 4"#]],
+    );
 }
 
 #[test]
 fn tuple_list_as_map_vecdeque() {
-    #[derive(Debug, Deserialize, Serialize, Default)]
-    struct S {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(
         #[serde(with = "serde_with::rust::tuple_list_as_map")]
-        s: VecDeque<(Wrapper<i32>, Wrapper<String>)>,
-    }
-
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+        VecDeque<(Wrapper<i32>, Wrapper<String>)>,
+    );
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct Wrapper<T>(T);
 
-    let from = r#"{
-  "s": {
-    "1": "Hi",
-    "2": "Cake",
-    "99": "Lie"
-  }
-}"#;
-    let mut expected = S::default();
-    expected.s.push_back((Wrapper(1), Wrapper("Hi".into())));
-    expected.s.push_back((Wrapper(2), Wrapper("Cake".into())));
-    expected.s.push_back((Wrapper(99), Wrapper("Lie".into())));
-
-    let res: S = serde_json::from_str(from).unwrap();
-    for ((exp_k, exp_v), (res_k, res_v)) in expected.s.iter().zip(&res.s) {
-        assert_eq!(exp_k.0, res_k.0);
-        assert_eq!(exp_v.0, res_v.0);
-    }
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
-
-    let from = r#"{
-  "s": {}
-}"#;
-    let expected = S::default();
-
-    let res: S = serde_json::from_str(from).unwrap();
-    assert!(res.s.is_empty());
-    assert_eq!(from, serde_json::to_string_pretty(&expected).unwrap());
+    is_equal_expect(
+        S(VecDeque::from_iter(vec![
+            (Wrapper(1), Wrapper("Hi".into())),
+            (Wrapper(2), Wrapper("Cake".into())),
+            (Wrapper(99), Wrapper("Lie".into())),
+        ])),
+        expect![[r#"
+            {
+              "1": "Hi",
+              "2": "Cake",
+              "99": "Lie"
+            }"#]],
+    );
+    is_equal_expect(S(VecDeque::new()), expect![[r#"{}"#]]);
+    check_error_deserialization_expect::<S>(
+        r#"[]"#,
+        expect![[r#"invalid type: sequence, expected a map at line 1 column 0"#]],
+    );
+    check_error_deserialization_expect::<S>(
+        r#"null"#,
+        expect![[r#"invalid type: null, expected a map at line 1 column 4"#]],
+    );
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use expect_test::Expect;
 use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
@@ -18,6 +19,20 @@ where
         serde_json::to_string(&value).unwrap(),
         s,
         "Serialization differs from expected value."
+    );
+}
+
+#[rustversion::attr(since(1.46), track_caller)]
+pub fn is_equal_expect<T>(value: T, expected: Expect)
+where
+    T: Debug + DeserializeOwned + PartialEq + Serialize,
+{
+    let serialized = serde_json::to_string_pretty(&value).unwrap();
+    expected.assert_eq(&serialized);
+    assert_eq!(
+        serde_json::from_str::<T>(&serialized).unwrap(),
+        value,
+        "Deserialization differs from expected value."
     );
 }
 
@@ -46,6 +61,14 @@ where
 }
 
 #[rustversion::attr(since(1.46), track_caller)]
+pub fn check_serialization_expect<T>(value: T, serialize_to: Expect)
+where
+    T: Debug + PartialEq + Serialize,
+{
+    serialize_to.assert_eq(&serde_json::to_string_pretty(&value).unwrap());
+}
+
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: &str)
 where
     T: Debug + DeserializeOwned + PartialEq,
@@ -55,5 +78,17 @@ where
             .unwrap_err()
             .to_string(),
         error_msg
+    )
+}
+
+#[rustversion::attr(since(1.46), track_caller)]
+pub fn check_error_deserialization_expect<T>(deserialize_from: &str, error_msg: Expect)
+where
+    T: Debug + DeserializeOwned + PartialEq,
+{
+    error_msg.assert_eq(
+        &serde_json::from_str::<T>(deserialize_from)
+            .unwrap_err()
+            .to_string(),
     )
 }


### PR DESCRIPTION
Add `*_expect` versions to `tests/utils.rs` to make use of `expect_test`.

Rewrite many of the old tests (not doc-tests) to use the functions from utils and also the `expect` variants.