### PR TITLE
Deprecate `sets_first_value_wins` in favour of `sets_last_value_wins`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added some `serialize` functions to modules which previously had none.
     This makes it easier to use the conversion when also deriving `Serialialize`.
     The functions simply pass through to the underlying `Serialize` implementation.
-    This affects `sets_duplicate_value_is_error`, `maps_duplicate_key_is_error`, `sets_first_value_wins`, `maps_first_key_wins`, `default_on_error`, and `default_on_null`.
+    This affects `sets_duplicate_value_is_error`, `maps_duplicate_key_is_error`, `maps_first_key_wins`, `default_on_error`, and `default_on_null`.
+* `sets_last_value_wins` as a replacement for `sets_first_value_wins` which is deprecated now.
+    The default behavior of serde is to prefer the first value of a set so the opposite is taking the last value.
+
+### Changed
+
+* Deprecate `sets_first_value_wins`.
+    The default behavior of serde is to take the first value, so this module is not necessary.
 
 ## [1.5.0-alpha.2]
 

--- a/src/duplicate_key_impls/first_value_wins.rs
+++ b/src/duplicate_key_impls/first_value_wins.rs
@@ -3,6 +3,7 @@ use std::{
     hash::{BuildHasher, Hash},
 };
 
+#[deprecated = "This is serde's default behavior."]
 pub trait DuplicateInsertsFirstWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;
 
@@ -17,6 +18,7 @@ pub trait DuplicateInsertsFirstWinsMap<K, V> {
     fn insert(&mut self, key: K, value: V);
 }
 
+#[allow(deprecated)]
 impl<T, S> DuplicateInsertsFirstWinsSet<T> for HashSet<T, S>
 where
     T: Eq + Hash,
@@ -37,6 +39,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DuplicateInsertsFirstWinsSet<T> for BTreeSet<T>
 where
     T: Ord,

--- a/src/duplicate_key_impls/last_value_wins.rs
+++ b/src/duplicate_key_impls/last_value_wins.rs
@@ -1,0 +1,47 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    hash::{BuildHasher, Hash},
+};
+
+pub trait DuplicateInsertsLastWinsSet<T> {
+    fn new(size_hint: Option<usize>) -> Self;
+
+    /// Insert or replace the existing value
+    fn replace(&mut self, value: T);
+}
+
+impl<T, S> DuplicateInsertsLastWinsSet<T> for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn replace(&mut self, value: T) {
+        // Hashset already fullfils the contract
+        self.replace(value);
+    }
+}
+
+impl<T> DuplicateInsertsLastWinsSet<T> for BTreeSet<T>
+where
+    T: Ord,
+{
+    #[inline]
+    fn new(_size_hint: Option<usize>) -> Self {
+        Self::new()
+    }
+
+    #[inline]
+    fn replace(&mut self, value: T) {
+        // BTreeSet already fullfils the contract
+        self.replace(value);
+    }
+}

--- a/src/duplicate_key_impls/mod.rs
+++ b/src/duplicate_key_impls/mod.rs
@@ -1,7 +1,10 @@
 mod error_on_duplicate;
 mod first_value_wins;
+mod last_value_wins;
 
+#[allow(deprecated)]
 pub use self::{
     error_on_duplicate::{PreventDuplicateInsertsMap, PreventDuplicateInsertsSet},
     first_value_wins::{DuplicateInsertsFirstWinsMap, DuplicateInsertsFirstWinsSet},
+    last_value_wins::DuplicateInsertsLastWinsSet,
 };


### PR DESCRIPTION

The first is already the default behavior of serde, so it can be
deprecated.
Instead add a module which does the opposite of serde's behavior.