### PR TITLE
namespace Result to std::result

### DIFF
--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -714,7 +714,7 @@ fn deserialize_fromstr(item: TokenStream) -> Result<proc_macro2::TokenStream, Er
             Self: std::str::FromStr,
             <Self as FromStr>::Err: std::fmt::Display,
         {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -731,7 +731,7 @@ fn deserialize_fromstr(item: TokenStream) -> Result<proc_macro2::TokenStream, Er
                         write!(formatter, "string")
                     }
 
-                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
                     where
                         E: serde::de::Error,
                     {
@@ -798,7 +798,7 @@ fn serialize_display(item: TokenStream) -> Result<proc_macro2::TokenStream, Erro
         where
             Self: std::fmt::Display,
         {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
             {

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -712,7 +712,7 @@ fn deserialize_fromstr(item: TokenStream) -> Result<proc_macro2::TokenStream, Er
         impl<'de> serde::Deserialize<'de> for #ident
         where
             Self: std::str::FromStr,
-            <Self as FromStr>::Err: std::fmt::Display,
+            <Self as std::str::FromStr>::Err: std::fmt::Display,
         {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
@@ -722,7 +722,7 @@ fn deserialize_fromstr(item: TokenStream) -> Result<proc_macro2::TokenStream, Er
 
                 impl<'de, S> serde::de::Visitor<'de> for Helper<S>
                 where
-                    S: FromStr,
+                    S: std::str::FromStr,
                     <S as std::str::FromStr>::Err: std::fmt::Display,
                 {
                     type Value = S;

--- a/serde_with_macros/tests/no_imports_or_clobbering.rs
+++ b/serde_with_macros/tests/no_imports_or_clobbering.rs
@@ -11,8 +11,6 @@ struct A;
 
 impl std::str::FromStr for A {
     type Err = String;
-
-    /// Parse a value like `123<>true`
     fn from_str(_: &str) -> std::result::Result<Self, Self::Err> {
         unimplemented!()
     }

--- a/serde_with_macros/tests/no_imports_or_clobbering.rs
+++ b/serde_with_macros/tests/no_imports_or_clobbering.rs
@@ -1,0 +1,25 @@
+use serde_with_macros::{DeserializeFromStr, SerializeDisplay};
+
+// We check that the macros result in valid code even in
+// absence of a FromStr import and with a clobbered Result type
+
+#[allow(dead_code)]
+type Result = ();
+
+#[derive(DeserializeFromStr, SerializeDisplay)]
+struct A;
+
+impl std::str::FromStr for A {
+    type Err = String;
+
+    /// Parse a value like `123<>true`
+    fn from_str(_: &str) -> std::result::Result<Self, Self::Err> {
+        unimplemented!()
+    }
+}
+
+impl std::fmt::Display for A {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}

--- a/serde_with_macros/tests/no_imports_or_clobbering.rs
+++ b/serde_with_macros/tests/no_imports_or_clobbering.rs
@@ -6,6 +6,7 @@ use serde_with_macros::{DeserializeFromStr, SerializeDisplay};
 #[allow(dead_code)]
 type Result = ();
 
+#[allow(dead_code)]
 #[derive(DeserializeFromStr, SerializeDisplay)]
 struct A;
 


### PR DESCRIPTION
I often like to alias `type Result<T> = std::result::Result<T, MyError>`.

Unfortunately this doesn't work with the proc-macros as they assume `Result` == `std::result::Result`. The fix is to fully namespace them. 