### PR TITLE
deserialize macro implements visit_bytes

### DIFF
--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -737,6 +737,14 @@ fn deserialize_fromstr(item: TokenStream) -> Result<proc_macro2::TokenStream, Er
                     {
                         value.parse::<Self::Value>().map_err(serde::de::Error::custom)
                     }
+
+                    fn visit_bytes<E>(self, value: &[u8]) -> std::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        let utf8 = std::str::from_utf8(value).map_err(serde::de::Error::custom)?;
+                        self.visit_str(utf8)
+                    }
                 }
 
                 deserializer.deserialize_str(Helper(std::marker::PhantomData))


### PR DESCRIPTION
I hit a problem when using  the `DeserializeFromStr` macro along with the `csv` crate, namely that `csv` tries to call `visit_bytes` to deserialize each column, and the macro does not implement this method. This PR adds it.

I have added a slightly convoluted test case which creates a `Deserializer` which can only handle bytes. This was necessary as the `serde_json` crate used elsewhere is 'too clever' for this test.
