### PR TITLE
Add converters for (Try)From/Into similar to serde-rs/serde#1623

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Added `FromInto` and `TryFromInto` adapters, which enable serialization by converting into a proxy type.
+
+    ```ignore
+    // Rust
+    #[serde_as(as = "FromInto<(u8, u8, u8)>")]
+    value: Rgb,
+
+    impl From<(u8, u8, u8)> for Rgb { ... }
+    impl From<Rgb> for (u8, u8, u8) { ... }
+
+    // JSON
+    "value": [128, 64, 32],
+    ```
+
 ## [1.8.1] - 2021-04-19
 
 ### Added

--- a/src/guide/serde_as.md
+++ b/src/guide/serde_as.md
@@ -19,18 +19,20 @@ The basic design of the system was done by [@markazmierczak](https://github.com/
     1. [Big Array support (Rust 1.51+)](#big-array-support-rust-151)
     2. [`Bytes` with more efficiency](#bytes-with-more-efficiency)
     3. [Bytes / `Vec<u8>` to hex string](#bytes--vecu8-to-hex-string)
-    4. [`Default` from `null`](#default-from-null)
-    5. [De/Serialize with `FromStr` and `Display`](#deserialize-with-fromstr-and-display)
-    6. [`Duration` as seconds](#duration-as-seconds)
-    7. [Ignore deserialization errors](#ignore-deserialization-errors)
-    8. [`Maps` to `Vec` of tuples](#maps-to-vec-of-tuples)
-    9. [`NaiveDateTime` like UTC timestamp](#naivedatetime-like-utc-timestamp)
-    10. [`None` as empty `String`](#none-as-empty-string)
-    11. [One or many elements into `Vec`](#one-or-many-elements-into-vec)
-    12. [Pick first successful deserialization](#pick-first-successful-deserialization)
-    13. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
-    14. [Value into JSON String](#value-into-json-string)
-    15. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
+    4. [Convert to an intermediate type using `Into`](#convert-to-an-intermediate-type-using-into)
+    5. [Convert to an intermediate type using `TryInto`](#convert-to-an-intermediate-type-using-tryinto)
+    6. [`Default` from `null`](#default-from-null)
+    7. [De/Serialize with `FromStr` and `Display`](#deserialize-with-fromstr-and-display)
+    8. [`Duration` as seconds](#duration-as-seconds)
+    9. [Ignore deserialization errors](#ignore-deserialization-errors)
+    10. [`Maps` to `Vec` of tuples](#maps-to-vec-of-tuples)
+    11. [`NaiveDateTime` like UTC timestamp](#naivedatetime-like-utc-timestamp)
+    12. [`None` as empty `String`](#none-as-empty-string)
+    13. [One or many elements into `Vec`](#one-or-many-elements-into-vec)
+    14. [Pick first successful deserialization](#pick-first-successful-deserialization)
+    15. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
+    16. [Value into JSON String](#value-into-json-string)
+    17. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
 
 ## Switching from serde's with to `serde_as`
 
@@ -342,6 +344,35 @@ value: Vec<u8>,
 "value": "deadbeef",
 ```
 
+### Convert to an intermediate type using `Into`
+
+[`FromInto`]
+
+```ignore
+// Rust
+#[serde_as(as = "FromInto<(u8, u8, u8)>")]
+value: Rgb,
+
+impl From<(u8, u8, u8)> for Rgb { ... }
+impl From<Rgb> for (u8, u8, u8) { ... }
+
+// JSON
+"value": [128, 64, 32],
+```
+
+### Convert to an intermediate type using `TryInto`
+
+[`TryFromInto`]
+
+```ignore
+// Rust
+#[serde_as(as = "TryFromInto<i8>")]
+value: u8,
+
+// JSON
+"value": 127,
+```
+
 ### `Default` from `null`
 
 [`DefaultOnNull`]
@@ -585,12 +616,14 @@ The [inverse operation](#maps-to-vec-of-tuples) is also available.
 [`DisplayFromStr`]: crate::DisplayFromStr
 [`DurationSeconds`]: crate::DurationSeconds
 [`DurationSecondsWithFrac`]: crate::DurationSecondsWithFrac
+[`FromInto`]: crate::FromInto
 [`Hex`]: crate::hex::Hex
 [`JsonString`]: crate::json::JsonString
 [`NoneAsEmptyString`]: crate::NoneAsEmptyString
 [`OneOrMany`]: crate::OneOrMany
 [`PickFirst`]: crate::PickFirst
 [`SerializeAs`]: crate::SerializeAs
+[`TryFromInto`]: crate::TryFromInto
 [bytes to string converter]: crate::BytesOrString
 [duration to UNIX epoch]: crate::DurationSeconds
 [hex strings]: crate::hex::Hex

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1556,3 +1556,11 @@ pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomDat
 /// ```
 #[derive(Copy, Clone, Debug, Default)]
 pub struct PickFirst<T>(PhantomData<T>);
+
+/// TODO
+#[derive(Debug)]
+pub struct FromInto<T>(PhantomData<T>);
+
+/// TODO
+#[derive(Debug)]
+pub struct TryFromInto<T>(PhantomData<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1512,13 +1512,13 @@ pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomDat
 ///
 /// ```rust
 /// # #[cfg(feature = "macros")] {
-/// # use serde::Deserialize;
+/// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, DisplayFromStr, PickFirst};
 /// #
 /// #[serde_as]
 /// # #[derive(Debug, PartialEq)]
-/// #[derive(Deserialize, serde::Serialize)]
+/// #[derive(Deserialize, Serialize)]
 /// struct Data {
 ///     #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
 ///     as_number: u32,
@@ -1557,10 +1557,176 @@ pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomDat
 #[derive(Copy, Clone, Debug, Default)]
 pub struct PickFirst<T>(PhantomData<T>);
 
-/// TODO
-#[derive(Debug)]
+/// Serialize value by converting to/from a proxy type with serde support.
+///
+/// This adapter serializes a type `O` by converting it into a second type `T` and serializing `T`.
+/// Deserializing works analogue, by deserializing a `T` and then converting into `O`.
+///
+/// ```rust
+/// # #[cfg(FALSE)] {
+/// struct S {
+///     #[serde_as(as = "FromInto<T>")]
+///     value: O,
+/// }
+/// # }
+/// ```
+///
+/// For serialization `O` needs to be `O: Into<T> + Clone`.
+/// For deserialization the opposite `T: Into<O>` is required.
+/// The `Clone` bound is required since `serialize` operates on a reference but `Into` implementations on references are uncommon.
+///
+/// **Note**: [`TryFromInto`] is the more generalized version of this adapter which uses the [`TryInto`](std::convert::TryInto) trait instead.
+///
+/// # Example
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, FromInto};
+/// #
+/// #[derive(Clone, Debug, PartialEq)]
+/// struct Rgb {
+///     red: u8,
+///     green: u8,
+///     blue: u8,
+/// }
+///
+/// # /*
+/// impl From<(u8, u8, u8)> for Rgb { ... }
+/// impl From<Rgb> for (u8, u8, u8) { ... }
+/// # */
+/// #
+/// # impl From<(u8, u8, u8)> for Rgb {
+/// #     fn from(v: (u8, u8, u8)) -> Self {
+/// #         Rgb {
+/// #             red: v.0,
+/// #             green: v.1,
+/// #             blue: v.2,
+/// #         }
+/// #     }
+/// # }
+/// #
+/// # impl From<Rgb> for (u8, u8, u8) {
+/// #     fn from(v: Rgb) -> Self {
+/// #         (v.red, v.green, v.blue)
+/// #     }
+/// # }
+///
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct Color {
+///     #[serde_as(as = "FromInto<(u8, u8, u8)>")]
+///     rgb: Rgb,
+/// }
+/// let color = Color {
+///     rgb: Rgb {
+///         red: 128,
+///         green: 64,
+///         blue: 32,
+///     },
+/// };
+///
+/// // Define our expected JSON form
+/// let j = json!({
+///     "rgb": [128, 64, 32],
+/// });
+/// // Ensure serialization and deserialization produce the expected results
+/// assert_eq!(j, serde_json::to_value(&color).unwrap());
+/// assert_eq!(color, serde_json::from_value(j).unwrap());
+/// # }
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
 pub struct FromInto<T>(PhantomData<T>);
 
-/// TODO
-#[derive(Debug)]
+/// Serialize value by converting to/from a proxy type with serde support.
+///
+/// This adapter serializes a type `O` by converting it into a second type `T` and serializing `T`.
+/// Deserializing works analogue, by deserializing a `T` and then converting into `O`.
+///
+/// ```rust
+/// # #[cfg(FALSE)] {
+/// struct S {
+///     #[serde_as(as = "TryFromInto<T>")]
+///     value: O,
+/// }
+/// # }
+/// ```
+///
+/// For serialization `O` needs to be `O: TryInto<T> + Clone`.
+/// For deserialization the opposite `T: TryInto<O>` is required.
+/// The `Clone` bound is required since `serialize` operates on a reference but `TryInto` implementations on references are uncommon.
+/// In both cases the `TryInto::Error` type must implement [`Display`](std::fmt::Display).
+///
+/// **Note**: [`FromInto`] is the more specialized version of this adapter which uses the infallible [`Into`] trait instead.
+/// [`TryFromInto`] is strictly more general and can also be used where [`FromInto`] is applicable.
+/// The example shows a use case, when only the deserialization behavior is fallible, but not serializing.
+///
+/// # Example
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, TryFromInto};
+/// # use std::convert::TryFrom;
+/// #
+/// #[derive(Clone, Debug, PartialEq)]
+/// enum Boollike {
+///     True,
+///     False,
+/// }
+///
+/// # /*
+/// impl From<Boollike> for u8 { ... }
+/// # */
+/// #
+/// impl TryFrom<u8> for Boollike {
+///     type Error = String;
+///     fn try_from(v: u8) -> Result<Self, Self::Error> {
+///         match v {
+///             0 => Ok(Boollike::False),
+///             1 => Ok(Boollike::True),
+///             _ => Err(format!("Boolikes can only be constructed from 0 or 1 but found {}", v))
+///         }
+///     }
+/// }
+/// #
+/// # impl From<Boollike> for u8 {
+/// #     fn from(v: Boollike) -> Self {
+/// #        match v {
+/// #            Boollike::True => 1,
+/// #            Boollike::False => 0,
+/// #        }
+/// #     }
+/// # }
+///
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct Data {
+///     #[serde_as(as = "TryFromInto<u8>")]
+///     b: Boollike,
+/// }
+/// let data = Data {
+///     b: Boollike::True,
+/// };
+///
+/// // Define our expected JSON form
+/// let j = json!({
+///     "b": 1,
+/// });
+/// // Ensure serialization and deserialization produce the expected results
+/// assert_eq!(j, serde_json::to_value(&data).unwrap());
+/// assert_eq!(data, serde_json::from_value(j).unwrap());
+///
+/// // Numbers besides 0 or 1 should be an error
+/// let j = json!({
+///     "b": 2,
+/// });
+/// assert_eq!("Boolikes can only be constructed from 0 or 1 but found 2", serde_json::from_value::<Data>(j).unwrap_err().to_string());
+/// # }
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
 pub struct TryFromInto<T>(PhantomData<T>);

--- a/tests/serde_as/frominto.rs
+++ b/tests/serde_as/frominto.rs
@@ -1,0 +1,130 @@
+use super::*;
+use serde_with::{FromInto, TryFromInto};
+
+#[derive(Clone, Debug, PartialEq)]
+enum IntoSerializable {
+    A,
+    B,
+    C,
+}
+
+impl From<IntoSerializable> for String {
+    fn from(value: IntoSerializable) -> Self {
+        match value {
+            IntoSerializable::A => "String A",
+            IntoSerializable::B => "Some other value",
+            IntoSerializable::C => "Looks like 123",
+        }
+        .to_string()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum FromDeserializable {
+    Zero,
+    Odd(u32),
+    Even(u32),
+}
+
+impl From<u32> for FromDeserializable {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => FromDeserializable::Zero,
+            e if e % 2 == 0 => FromDeserializable::Even(e),
+            o => FromDeserializable::Odd(o),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum LikeBool {
+    Trueish,
+    Falseisch,
+}
+
+impl From<bool> for LikeBool {
+    fn from(b: bool) -> Self {
+        if b {
+            LikeBool::Trueish
+        } else {
+            LikeBool::Falseisch
+        }
+    }
+}
+
+impl From<LikeBool> for bool {
+    fn from(lb: LikeBool) -> Self {
+        match lb {
+            LikeBool::Trueish => true,
+            LikeBool::Falseisch => false,
+        }
+    }
+}
+
+#[test]
+fn test_frominto_ser() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Serialize)]
+    struct S(#[serde_as(serialize_as = "FromInto<String>")] IntoSerializable);
+
+    check_serialization(S(IntoSerializable::A), expect![[r#""String A""#]]);
+    check_serialization(S(IntoSerializable::B), expect![[r#""Some other value""#]]);
+    check_serialization(S(IntoSerializable::C), expect![[r#""Looks like 123""#]]);
+}
+
+#[test]
+fn test_tryfrominto_ser() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Serialize)]
+    struct S(#[serde_as(serialize_as = "TryFromInto<String>")] IntoSerializable);
+
+    check_serialization(S(IntoSerializable::A), expect![[r#""String A""#]]);
+    check_serialization(S(IntoSerializable::B), expect![[r#""Some other value""#]]);
+    check_serialization(S(IntoSerializable::C), expect![[r#""Looks like 123""#]]);
+}
+
+#[test]
+fn test_frominto_de() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct S(#[serde_as(deserialize_as = "FromInto<u32>")] FromDeserializable);
+
+    check_deserialization(S(FromDeserializable::Zero), "0");
+    check_deserialization(S(FromDeserializable::Odd(1)), "1");
+    check_deserialization(S(FromDeserializable::Odd(101)), "101");
+    check_deserialization(S(FromDeserializable::Even(2)), "2");
+    check_deserialization(S(FromDeserializable::Even(202)), "202");
+}
+
+#[test]
+fn test_tryfrominto_de() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct S(#[serde_as(deserialize_as = "TryFromInto<u32>")] FromDeserializable);
+
+    check_deserialization(S(FromDeserializable::Zero), "0");
+    check_deserialization(S(FromDeserializable::Odd(1)), "1");
+    check_deserialization(S(FromDeserializable::Odd(101)), "101");
+    check_deserialization(S(FromDeserializable::Even(2)), "2");
+    check_deserialization(S(FromDeserializable::Even(202)), "202");
+}
+
+#[test]
+fn test_frominto_de_and_ser() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde_as(as = "FromInto<bool>")] LikeBool);
+
+    is_equal(S(LikeBool::Trueish), expect![[r#"true"#]]);
+    is_equal(S(LikeBool::Falseisch), expect![[r#"false"#]]);
+}
+
+#[test]
+fn test_tryfrominto_de_and_ser() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde_as(as = "TryFromInto<bool>")] LikeBool);
+
+    is_equal(S(LikeBool::Trueish), expect![[r#"true"#]]);
+    is_equal(S(LikeBool::Falseisch), expect![[r#"false"#]]);
+}

--- a/tests/serde_as/lib.rs
+++ b/tests/serde_as/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 mod default_on;
+mod frominto;
 mod map_tuple_list;
 mod pickfirst;
 mod serde_as_macro;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -56,6 +56,18 @@ where
 }
 
 #[rustversion::attr(since(1.46), track_caller)]
+pub fn check_error_serialization<T>(value: T, error_msg: Expect)
+where
+    T: Debug + Serialize,
+{
+    error_msg.assert_eq(
+        &serde_json::to_string_pretty(&value)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[rustversion::attr(since(1.46), track_caller)]
 pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: Expect)
 where
     T: Debug + DeserializeOwned,


### PR DESCRIPTION
This PR is supposed to show that the conversions can be implemented without adding new functionality to the derive macro.
If there is sufficient interest this can be finished into a full feature.

Missing:
* [x] Documentation on the structs `FromInto` and `TryFromInto`.
* [x] Documentation in the guide and changelog.
* [x] Add tests for `TryFromInto`.