### PR TITLE
Update `flattened_maybe` to better work with renamed crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "serde_with_macros",
+    "serde_with_test",
 ]
 
 [package]

--- a/serde_with_test/Cargo.toml
+++ b/serde_with_test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["Jonas Bushart <jonas@bushart.org>"]
+edition = "2018"
+name = "serde_with_test"
+publish = false
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+s = {package = "serde", version = "1.0.75", features = ["derive"]}
+s_json = {package = "serde_json", version = "1.0.59"}
+s_with = {package = "serde_with", path = ".."}

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+
+use s_with as serde_with;
+
+// Ensure that types from the environment do not infect the macro
+mod std {}
+type Option = ::std::option::Option<()>;
+type Result<T> = ::std::result::Result<T, ()>;
+
+// The macro creates custom deserialization code.
+// You need to specify a function name and the field name of the flattened field.
+s_with::flattened_maybe!(deserialize_t, "t");
+// Setup the types
+#[derive(s::Deserialize, Debug)]
+#[serde(crate = "s")]
+struct S {
+    #[serde(flatten, deserialize_with = "deserialize_t")]
+    t: T,
+}
+
+#[derive(s::Deserialize, Debug)]
+#[serde(crate = "s")]
+struct T {
+    i: i32,
+}
+
+#[test]
+fn flattened_maybe() {
+    // Supports both flattened
+    let j = r#" {"i":1} "#;
+    assert!(s_json::from_str::<S>(j).is_ok());
+
+    // and non-flattened versions.
+    let j = r#" {"t":{"i":1}} "#;
+    assert!(s_json::from_str::<S>(j).is_ok());
+
+    // Ensure that the value is given
+    let j = r#" {} "#;
+    assert!(s_json::from_str::<S>(j).is_err());
+
+    // and only occurs once, not multiple times.
+    let j = r#" {"i":1,"t":{"i":1}} "#;
+    assert!(s_json::from_str::<S>(j).is_err());
+}

--- a/src/flatten_maybe.rs
+++ b/src/flatten_maybe.rs
@@ -9,6 +9,10 @@
 /// required on the field such that the helper works. The serialization format will always be
 /// flattened.
 ///
+/// **Note**:
+/// This macro requires that the crate `serde_with` is in scope with that exact name.
+/// If you import `serde_with` with a different name, you need to temporarily rename it for this macro to work.
+///
 /// # Examples
 ///
 /// ```rust
@@ -53,24 +57,27 @@
 macro_rules! flattened_maybe {
     // TODO Change $field to literal, once the compiler version is bumped enough.
     ($fn:ident, $field:expr) => {
-        fn $fn<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+        fn $fn<'de, T, D>(deserializer: D) -> ::std::result::Result<T, D::Error>
         where
-            T: serde::Deserialize<'de>,
-            D: serde::Deserializer<'de>,
+            T: serde_with::serde::Deserialize<'de>,
+            D: serde_with::serde::Deserializer<'de>,
         {
-            #[derive(serde::Deserialize)]
-            struct Both<T> {
+            use ::std::option::Option::{self, None, Some};
+
+            #[derive(serde_with::serde::Deserialize)]
+            #[serde(crate = "serde_with::serde")]
+            pub struct Both<T> {
                 #[serde(flatten)]
                 flat: Option<T>,
                 #[serde(rename = $field)]
                 not_flat: Option<T>,
             }
 
-            let both: Both<T> = serde::Deserialize::deserialize(deserializer)?;
+            let both: Both<T> = serde_with::serde::Deserialize::deserialize(deserializer)?;
             match (both.flat, both.not_flat) {
                 (Some(t), None) | (None, Some(t)) => Ok(t),
-                (None, None) => Err(serde::de::Error::missing_field($field)),
-                (Some(_), Some(_)) => Err(serde::de::Error::custom(concat!(
+                (None, None) => Err(serde_with::serde::de::Error::missing_field($field)),
+                (Some(_), Some(_)) => Err(serde_with::serde::de::Error::custom(concat!(
                     "`",
                     $field,
                     "` is both flattened and not"


### PR DESCRIPTION
Due to the derive inside I found it impossible to make it crate name agnostic,
since I would need to specify something like
#[serde(crate = $crate"::serde")]
which does not work since that requires a string literal.

Providing a string literal to flattened_maybe also doesn't work, since then
the uses of Deserialize etc cannot work.

Part of #207