### PR TITLE
Fix: Correctly handle when the serde_as field attr is split into multiple parts

### DIFF
--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -500,20 +500,25 @@ fn serde_as_add_attr_to_field(
     let serde_with_options = SerdeWithOptions::from_field(field)?;
 
     // Find index of serde_as attribute
-    let serde_as_idx = field.attrs.iter().enumerate().find_map(|(idx, attr)| {
-        if attr.path.is_ident("serde_as") {
-            Some(idx)
-        } else {
-            None
-        }
-    });
-    if serde_as_idx.is_none() {
+    let serde_as_idxs: Vec<_> = field
+        .attrs
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, attr)| {
+            if attr.path.is_ident("serde_as") {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if serde_as_idxs.is_empty() {
         return Ok(());
     }
-    let serde_as_idx = serde_as_idx.expect("Just checked that the value is Some");
-
-    // serde_as Attribute
-    field.attrs.remove(serde_as_idx);
+    // remove serde_as Attribute as otherwise they cause compile errors
+    for idx in serde_as_idxs.into_iter().rev() {
+        field.attrs.remove(idx);
+    }
 
     // Check if there are any conflicting attributes
     if serde_as_options.has_any_set() && serde_with_options.has_any_set() {

--- a/tests/serde_as_macro.rs
+++ b/tests/serde_as_macro.rs
@@ -170,3 +170,23 @@ fn test_serde_as_macro_serialize_deserialize() {
     assert_eq!(expected, serde_json::to_string_pretty(&data).unwrap());
     assert_eq!(data, serde_json::from_str(expected).unwrap());
 }
+
+/// Test that the [`serde_as`] macro works correctly if applied multiple times to a field
+#[test]
+fn test_serde_as_macro_multiple_field_attributes() {
+    #[serde_as]
+    #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Data {
+        #[serde_as(serialize_as = "DisplayFromStr")]
+        #[serde_as(deserialize_as = "DisplayFromStr")]
+        a: u32,
+    }
+
+    let data = Data { a: 10 };
+    let expected = r##"{
+  "a": "10"
+}"##;
+
+    assert_eq!(expected, serde_json::to_string_pretty(&data).unwrap());
+    assert_eq!(data, serde_json::from_str(expected).unwrap());
+}


### PR DESCRIPTION
This used to cause a compile error as the field attributes did not all get removed.