### PR TITLE
Add SerializeAs implementation for references and support unsized types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add new types similar to `DurationSeconds` and `TimestampSeconds` but for base units of milliseconds, microseconds, and nanoseconds.
     The `*WithFrac` variants also exist.
+* Add `SerializeAs` implementation for references.
+
+### Changed
+
+* Release `Sized` trait bound from `As`, `Same`, `SerializeAs`, and `SerializeAsWrap`.
+    Only the serialize part is relaxed.
 
 ## [1.6.0]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,9 +337,9 @@ impl Separator for CommaSeparator {
 ///
 /// [serde_as]: https://docs.rs/serde_with/1.6.0/serde_with/attr.serde_as.html
 #[derive(Copy, Clone, Debug, Default)]
-pub struct As<T>(PhantomData<T>);
+pub struct As<T: ?Sized>(PhantomData<T>);
 
-impl<T> As<T> {
+impl<T: ?Sized> As<T> {
     /// Serialize type `T` using [`SerializeAs`][]
     ///
     /// The function signature is compatible with [serde's with-annotation][with-annotation].
@@ -349,6 +349,7 @@ impl<T> As<T> {
     where
         S: Serializer,
         T: SerializeAs<I>,
+        I: ?Sized,
     {
         T::serialize_as(value, serializer)
     }

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -9,6 +9,20 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+impl<'a, T, U> SerializeAs<&'a T> for &'a U
+where
+    U: SerializeAs<T>,
+    T: ?Sized,
+    U: ?Sized,
+{
+    fn serialize_as<S>(source: &&'a T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<T, U>::new(source).serialize(serializer)
+    }
+}
+
 impl<T, U> SerializeAs<Box<T>> for Box<U>
 where
     U: SerializeAs<T>,
@@ -55,11 +69,13 @@ macro_rules! seq_impl {
 }
 
 type BoxedSlice<T> = Box<[T]>;
+type Slice<T> = [T];
 seq_impl!(BinaryHeap<T: Ord + Sized>);
 seq_impl!(BoxedSlice<T>);
 seq_impl!(BTreeSet<T: Ord + Sized>);
 seq_impl!(HashSet<T: Eq + Hash + Sized, H: BuildHasher + Sized>);
 seq_impl!(LinkedList<T>);
+seq_impl!(Slice<T>);
 seq_impl!(Vec<T>);
 seq_impl!(VecDeque<T>);
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -100,7 +100,7 @@ use super::*;
 /// [`Display`]: std::fmt::Display
 /// [`Duration`]: std::time::Duration
 /// [impl-serialize]: https://serde.rs/impl-serialize.html
-pub trait SerializeAs<T> {
+pub trait SerializeAs<T: ?Sized> {
     /// Serialize this value into the given Serde serializer.
     fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -109,12 +109,16 @@ pub trait SerializeAs<T> {
 
 /// Helper type to implement [`SerializeAs`] for container-like types.
 #[derive(Debug)]
-pub struct SerializeAsWrap<'a, T, U> {
+pub struct SerializeAsWrap<'a, T: ?Sized, U: ?Sized> {
     value: &'a T,
     marker: PhantomData<U>,
 }
 
-impl<'a, T, U> SerializeAsWrap<'a, T, U> {
+impl<'a, T, U> SerializeAsWrap<'a, T, U>
+where
+    T: ?Sized,
+    U: ?Sized,
+{
     /// Create new instance with provided value.
     pub fn new(value: &'a T) -> Self {
         Self {
@@ -126,6 +130,8 @@ impl<'a, T, U> SerializeAsWrap<'a, T, U> {
 
 impl<'a, T, U> Serialize for SerializeAsWrap<'a, T, U>
 where
+    T: ?Sized,
+    U: ?Sized,
     U: SerializeAs<T>,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -138,6 +144,8 @@ where
 
 impl<'a, T, U> From<&'a T> for SerializeAsWrap<'a, T, U>
 where
+    T: ?Sized,
+    U: ?Sized,
     U: SerializeAs<T>,
 {
     fn from(value: &'a T) -> Self {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -34,7 +34,7 @@ where
 #[rustversion::attr(since(1.46), track_caller)]
 pub fn check_serialization<T>(value: T, serialize_to: Expect)
 where
-    T: Debug + PartialEq + Serialize,
+    T: Debug + Serialize,
 {
     serialize_to.assert_eq(&serde_json::to_string_pretty(&value).unwrap());
 }
@@ -42,7 +42,7 @@ where
 #[rustversion::attr(since(1.46), track_caller)]
 pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: Expect)
 where
-    T: Debug + DeserializeOwned + PartialEq,
+    T: Debug + DeserializeOwned,
 {
     error_msg.assert_eq(
         &serde_json::from_str::<T>(deserialize_from)


### PR DESCRIPTION
This PR relaxes various serialization related trait bounds, for example in `As`, `Same`, or `SerializeAs` to allow for unsized types.
It then adds `SerializeAs` implementations for references and for slices.

This allows to write code like:
```rust
#[serde_as]
#[derive(Serialize)]
struct S<'a>
    #[serde_as(as = "&[DisplayFromStr]")]
    slice: &'a [u32],
}
```

bors r+