### PR TITLE
Do not call `cargo test` with `--all-targets`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,17 +103,20 @@ jobs:
         name: Test "No Default Features" (${{ matrix.os }} / ${{ matrix.rust }})
         with:
           command: test
-          args: --workspace --no-default-features --all-targets
+          # cargo test --all-targets does NOT run doctests
+          # since doctests are important this should not be added
+          # https://github.com/rust-lang/cargo/issues/6669
+          args: --workspace --no-default-features
       - uses: actions-rs/cargo@v1
         name: Test "Default" (${{ matrix.os }} / ${{ matrix.rust }})
         with:
           command: test
-          args: --workspace --all-targets
+          args: --workspace
       - uses: actions-rs/cargo@v1
         name: Test "All Features" (${{ matrix.os }} / ${{ matrix.rust }})
         with:
           command: test
-          args: --workspace --all-features --all-targets
+          args: --workspace --all-features
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1829,7 +1829,8 @@ pub mod default_on_null {
 /// # use serde::Deserialize;
 /// use serde_with::rust::deserialize_ignore_any;
 ///
-/// #[derive(Deserialize, Debug)]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize)]
 /// #[serde(rename_all = "lowercase")]
 /// enum Item {
 ///     Foo(String),


### PR DESCRIPTION
The `--all-targets` flag for `cargo test` actually DISABLES doctests.
Doctests should of course be run, so removing the flag from the CI scrips.
There is a bug report for cargo about this behavior:
https://github.com/rust-lang/cargo/issues/6669

This fixes the changes done in #235 / 9a6c3bf9e5fdbf6c76a27534ee250628acf8e168.