### PR TITLE
Cleanup assembling and parsing of attributes during `serde_as` processing.

### DIFF
--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Improve error messages when `#[serde_as(..)]` is misused as a field attribute.
     Thanks to @Lehona for reporting the bug in #233.
+* Internal cleanup for assembling and parsing attributes during `serde_as` processing.
 
 ## [1.3.0]
 


### PR DESCRIPTION
Rely more on the quote! macro (quasi-quoting) and remove cases of
string-interpolation and string parsing.

bors r+