### PR TITLE
Fix nightly warning legacy_derive_helpers

### DIFF
--- a/serde_with_test/tests/serde_as_crate_path.rs
+++ b/serde_with_test/tests/serde_as_crate_path.rs
@@ -18,9 +18,9 @@ enum Option {
     Err,
 }
 
-#[serde(crate = "s")]
 #[serde_as(crate = "s_with")]
 #[derive(Deserialize, Serialize)]
+#[serde(crate = "s")]
 struct Data {
     #[serde_as(as = "_")]
     a: u32,


### PR DESCRIPTION
Sort inert attributes after the derive.

https://github.com/rust-lang/rust/issues/79202

bors r+