### PR TITLE
Fix compilation with serde_as if there is a field without annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.4]
+
+### Fixed
+
+* Fix compiling when having a struct field without the `serde_as` annotation by updating `serde_with_macros`.
+    This broke in 1.4.0 of `serde_with_macros`. [#267](https://github.com/jonasbb/serde_with/issues/267)
+
 ## [1.6.3]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 authors = ["Jonas Bushart"]
 name = "serde_with"
-version = "1.6.3"
+version = "1.6.4"
 
 categories = ["encoding"]
 description = "Custom de/serialization functions for Rust's serde"
@@ -38,7 +38,7 @@ doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.2", optional = true}
 serde = {version = "1.0.75", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
-serde_with_macros = {path = "./serde_with_macros", version = "1.4.0", optional = true}
+serde_with_macros = {path = "./serde_with_macros", version = "1.4.1", optional = true}
 
 [dev-dependencies]
 expect-test = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies.serde_with]
-version = "1.6.3"
+version = "1.6.4"
 features = [ "..." ]
 ```
 
@@ -124,13 +124,13 @@ Foo {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/1.6.3/serde_with/struct.DisplayFromStr.html
-[`with_prefix!`]: https://docs.rs/serde_with/1.6.3/serde_with/macro.with_prefix.html
-[display_fromstr]: https://docs.rs/serde_with/1.6.3/serde_with/rust/display_fromstr/index.html
-[feature flags]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/1.6.3/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/1.6.3/serde_with/rust/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/1.6.3/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/1.6.4/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/1.6.4/serde_with/macro.with_prefix.html
+[display_fromstr]: https://docs.rs/serde_with/1.6.4/serde_with/rust/display_fromstr/index.html
+[feature flags]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/1.6.4/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/1.6.4/serde_with/rust/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
 
 ## License

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.1]
+
+### Fixed
+
+* Fix compiling when having a struct field without the `serde_as` annotation.
+    This broke in 1.4.0 [#267](https://github.com/jonasbb/serde_with/issues/267)
+
 ## [1.4.0]
 
 ### Changed

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jonas Bushart"]
 name = "serde_with_macros"
-version = "1.4.0"
+version = "1.4.1"
 
 categories = ["encoding"]
 description = "proc-macro library for serde_with"

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -512,6 +512,14 @@ fn serde_as_add_attr_to_field(
         }
     }
 
+    // Check if there even is any `serde_as` attribute and exit early if not.
+    if !field
+        .attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("serde_as"))
+    {
+        return Ok(());
+    }
     let serde_as_options = SerdeAsOptions::from_field(field)?;
     let serde_with_options = SerdeWithOptions::from_field(field)?;
 

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -23,7 +23,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.4.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/1.4.1")]
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Necessary for nightly clippy lints
@@ -434,8 +434,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// }
 /// ```
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/1.6.3/serde_with/guide/index.html
-/// [re-exporting `serde_as`]: https://docs.rs/serde_with/1.6.3/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [`serde_as`]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
+/// [re-exporting `serde_as`]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(FromMeta, Debug)]
@@ -738,7 +738,7 @@ fn replace_infer_type_with_type(to_replace: Type, replacement: &Type) -> Type {
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/1.6.3/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(DeserializeFromStr, attributes(serde_with))]
 pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
@@ -848,7 +848,7 @@ fn deserialize_fromstr(input: DeriveInput, serde_with_crate_path: Path) -> Token
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/1.6.3/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(SerializeDisplay, attributes(serde_with))]
 pub fn derive_serialize_display(item: TokenStream) -> TokenStream {

--- a/serde_with_macros/tests/serde_as_issue_267.rs
+++ b/serde_with_macros/tests/serde_as_issue_267.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+use serde_with_macros::serde_as;
+
+// The field has no serde_as annotation and should not trigger any error
+#[serde_as(crate = "serde_with_macros")]
+#[derive(Serialize)]
+pub struct Thing {
+    pub id: u8,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/1.6.3")]
+#![doc(html_root_url = "https://docs.rs/serde_with/1.6.4")]
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Rust 1.45: introduction of `strip_prefix` used by clippy::manual_strip
@@ -59,7 +59,7 @@
 //!
 //! ```toml
 //! [dependencies.serde_with]
-//! version = "1.6.3"
+//! version = "1.6.4"
 //! features = [ "..." ]
 //! ```
 //!
@@ -198,13 +198,13 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/1.6.3/serde_with/struct.DisplayFromStr.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/1.6.3/serde_with/macro.with_prefix.html
-//! [display_fromstr]: https://docs.rs/serde_with/1.6.3/serde_with/rust/display_fromstr/index.html
-//! [feature flags]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/1.6.3/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/1.6.3/serde_with/rust/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/1.6.3/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/1.6.4/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/1.6.4/serde_with/macro.with_prefix.html
+//! [display_fromstr]: https://docs.rs/serde_with/1.6.4/serde_with/rust/display_fromstr/index.html
+//! [feature flags]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/1.6.4/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/1.6.4/serde_with/rust/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
 
 #[doc(hidden)]
@@ -340,7 +340,7 @@ impl Separator for CommaSeparator {
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/1.6.3/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/1.6.4/serde_with/attr.serde_as.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct As<T: ?Sized>(PhantomData<T>);
 
@@ -807,7 +807,7 @@ pub struct BytesOrString;
 /// ```
 ///
 /// [`chrono::Duration`]: chrono_crate::Duration
-/// [feature flag]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
@@ -933,7 +933,7 @@ pub struct DurationSeconds<
 /// ```
 ///
 /// [`chrono::Duration`]: chrono_crate::Duration
-/// [feature flag]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
@@ -1130,7 +1130,7 @@ pub struct DurationNanoSecondsWithFrac<
 ///
 /// [`SystemTime`]: std::time::SystemTime
 /// [DateTime]: chrono_crate::DateTime
-/// [feature flag]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
@@ -1259,7 +1259,7 @@ pub struct TimestampSeconds<
 ///
 /// [`SystemTime`]: std::time::SystemTime
 /// [DateTime]: chrono_crate::DateTime
-/// [feature flag]: https://docs.rs/serde_with/1.6.3/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,


### PR DESCRIPTION
This broke in 1.4.0 due to removing the check if there are any `serde_as` attributes.
Add a test case for a struct with an un-annotated field.
    
Fixes #267

Bump versions to release bugfix.

bors r+