### PR TITLE
Tiny cleanups and improvements

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,26 @@
+[advisories]
+ignore = [
+    # difference is unmaintained, is a dependency of pretty_assertions
+    "RUSTSEC-2020-0095",
+]
+# warn for categories of informational advisories
+informational_warnings = [
+    "unmaintained",
+    "unsound",
+]
+
+# Output Configuration
+[output]
+ # exit on error if unmaintained dependencies are found
+deny = [
+    "unmaintained",
+    "unsound",
+]
+# Only print information on error
+quiet = false
+# Show inverse dependency trees along with advisories (default: true)
+show_tree = true
+
+[yanked]
+enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+update_index = true # Auto-update the crates.io index (default: true)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
-merge_imports = true
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
+
+# format_code_in_doc_comments = true
+# format_strings = true
+imports_granularity = "Module"
+use_field_init_shorthand = true

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -284,7 +284,6 @@ where
 ///     a: Option<String>,
 /// }
 /// ```
-///
 #[proc_macro_attribute]
 pub fn skip_serializing_none(_args: TokenStream, input: TokenStream) -> TokenStream {
     let res = match apply_function_to_struct_and_enum_fields(

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1,5 +1,7 @@
+#![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
+    // missing_crate_level_docs, not available in MSRV
     missing_debug_implementations,
     missing_docs,
     trivial_casts,
@@ -10,6 +12,7 @@
     variant_size_differences
 )]
 #![warn(rust_2018_idioms)]
+#![doc(test(attr(forbid(unsafe_code))))]
 #![doc(test(attr(deny(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -41,17 +41,18 @@ extern crate proc_macro;
 
 mod utils;
 
-use crate::utils::IteratorExt as _;
+use crate::utils::{DeriveOptions, IteratorExt as _};
 use darling::{Error as DarlingError, FromField, FromMeta};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
+use syn::parse::Parser;
+use syn::punctuated::Pair;
+use syn::spanned::Spanned;
 use syn::{
-    parse::Parser, parse_macro_input, punctuated::Pair, spanned::Spanned, Attribute, AttributeArgs,
-    DeriveInput, Error, Field, Fields, GenericArgument, ItemEnum, ItemStruct, Meta, NestedMeta,
-    Path, PathArguments, ReturnType, Type,
+    parse_macro_input, Attribute, AttributeArgs, DeriveInput, Error, Field, Fields,
+    GenericArgument, ItemEnum, ItemStruct, Meta, NestedMeta, Path, PathArguments, ReturnType, Type,
 };
-use utils::DeriveOptions;
 
 /// Apply function on every field of structs or enums
 fn apply_function_to_struct_and_enum_fields<F>(

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -4,15 +4,13 @@
 //!
 //! [chrono]: https://docs.rs/chrono/
 
-use crate::{
-    de::DeserializeAs,
-    formats::{Flexible, Format, Strict, Strictness},
-    ser::SerializeAs,
-    utils, DurationSeconds, DurationSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
-};
+use crate::de::DeserializeAs;
+use crate::formats::{Flexible, Format, Strict, Strictness};
+use crate::ser::SerializeAs;
+use crate::utils::duration::{DurationSigned, Sign};
+use crate::{DurationSeconds, DurationSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac};
 use chrono_crate::{DateTime, Duration, Local, NaiveDateTime, Utc};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use utils::duration::{DurationSigned, Sign};
 
 /// Create a [`DateTime`] for the Unix Epoch using the [`Utc`] timezone
 fn unix_epoch_utc() -> DateTime<Utc> {

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -45,7 +45,6 @@ fn unix_epoch_local() -> DateTime<Local> {
 /// // and strings with numbers, for high-precision values
 /// assert!(serde_json::from_str::<S>(r#"{ "date": "1478563200.123" }"#).is_ok());
 /// ```
-///
 pub mod datetime_utc_ts_seconds_from_any {
     use chrono_crate::{DateTime, NaiveDateTime, Utc};
     use serde::de::{Deserializer, Error, Unexpected, Visitor};

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -1,20 +1,16 @@
 use super::*;
-use crate::{
-    formats::{Flexible, Format, Strict},
-    rust::StringWithSeparator,
-    utils,
-    utils::duration::DurationSigned,
-};
+use crate::formats::{Flexible, Format, Strict};
+use crate::rust::StringWithSeparator;
+use crate::utils;
+use crate::utils::duration::DurationSigned;
 use serde::de::*;
-use std::{
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    convert::From,
-    fmt::{self, Display},
-    hash::{BuildHasher, Hash},
-    iter::FromIterator,
-    str::FromStr,
-    time::{Duration, SystemTime},
-};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+use std::convert::From;
+use std::fmt::{self, Display};
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime};
 
 impl<'de, T, U> DeserializeAs<'de, Box<T>> for Box<U>
 where

--- a/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,7 +1,5 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{BuildHasher, Hash};
 
 pub trait PreventDuplicateInsertsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/src/duplicate_key_impls/first_value_wins.rs
+++ b/src/duplicate_key_impls/first_value_wins.rs
@@ -1,7 +1,5 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{BuildHasher, Hash};
 
 #[deprecated = "This is serde's default behavior."]
 pub trait DuplicateInsertsFirstWinsSet<T> {

--- a/src/duplicate_key_impls/last_value_wins.rs
+++ b/src/duplicate_key_impls/last_value_wins.rs
@@ -1,7 +1,5 @@
-use std::{
-    collections::{BTreeSet, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::{BTreeSet, HashSet};
+use std::hash::{BuildHasher, Hash};
 
 pub trait DuplicateInsertsLastWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/src/flatten_maybe.rs
+++ b/src/flatten_maybe.rs
@@ -62,10 +62,8 @@ macro_rules! flattened_maybe {
             T: serde_with::serde::Deserialize<'de>,
             D: serde_with::serde::Deserializer<'de>,
         {
-            use ::std::{
-                option::Option::{self, None, Some},
-                result::Result::{self, Err, Ok},
-            };
+            use ::std::option::Option::{self, None, Some};
+            use ::std::result::Result::{self, Err, Ok};
 
             #[derive(serde_with::serde::Deserialize)]
             #[serde(crate = "serde_with::serde")]

--- a/src/flatten_maybe.rs
+++ b/src/flatten_maybe.rs
@@ -34,7 +34,6 @@
 /// // You need to specify a function name and the field name of the flattened field.
 /// serde_with::flattened_maybe!(deserialize_t, "t");
 ///
-///
 /// # fn main() {
 /// // Supports both flattened
 /// let j = r#" {"i":1} "#;

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -2,13 +2,13 @@
 //!
 //! This modules is only available when using the `hex` feature of the crate.
 
-use crate::{
-    de::DeserializeAs,
-    formats::{Format, Lowercase, Uppercase},
-    ser::SerializeAs,
-};
-use serde::{de::Error, Deserialize, Deserializer, Serializer};
-use std::{borrow::Cow, marker::PhantomData};
+use crate::de::DeserializeAs;
+use crate::formats::{Format, Lowercase, Uppercase};
+use crate::ser::SerializeAs;
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serializer};
+use std::borrow::Cow;
+use std::marker::PhantomData;
 
 /// Serialize bytes as a hex string
 ///

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -22,7 +22,6 @@ use std::marker::PhantomData;
 /// # Example
 ///
 /// ```rust
-///
 /// # #[cfg(feature = "macros")] {
 /// # use serde_derive::{Deserialize, Serialize};
 /// # use serde_json::json;
@@ -48,13 +47,25 @@ use std::marker::PhantomData;
 /// let b = b"Hello World!";
 ///
 /// // Hex with lowercase letters
-/// assert_eq!(json!("48656c6c6f20576f726c6421"), serde_json::to_value(BytesLowercase(b.to_vec())).unwrap());
+/// assert_eq!(
+///     json!("48656c6c6f20576f726c6421"),
+///     serde_json::to_value(BytesLowercase(b.to_vec())).unwrap()
+/// );
 /// // Hex with uppercase letters
-/// assert_eq!(json!("48656C6C6F20576F726C6421"), serde_json::to_value(BytesUppercase(b.to_vec())).unwrap());
+/// assert_eq!(
+///     json!("48656C6C6F20576F726C6421"),
+///     serde_json::to_value(BytesUppercase(b.to_vec())).unwrap()
+/// );
 ///
 /// // Serialization always work from lower- and uppercase characters, even mixed case.
-/// assert_eq!(BytesLowercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]), serde_json::from_value(json!("00aAbc99FF")).unwrap());
-/// assert_eq!(BytesUppercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]), serde_json::from_value(json!("00aAbc99FF")).unwrap());
+/// assert_eq!(
+///     BytesLowercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]),
+///     serde_json::from_value(json!("00aAbc99FF")).unwrap()
+/// );
+/// assert_eq!(
+///     BytesUppercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]),
+///     serde_json::from_value(json!("00aAbc99FF")).unwrap()
+/// );
 /// # }
 /// ```
 #[derive(Copy, Clone, Debug, Default)]

--- a/src/json.rs
+++ b/src/json.rs
@@ -2,8 +2,10 @@
 //!
 //! This modules is only available when using the `json` feature of the crate.
 
-use crate::{de::DeserializeAs, ser::SerializeAs};
-use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
+use crate::de::DeserializeAs;
+use crate::ser::SerializeAs;
+use serde::de::DeserializeOwned;
+use serde::{Deserializer, Serialize, Serializer};
 
 /// Serialize value as string containing JSON
 ///
@@ -33,11 +35,10 @@ use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
 /// assert_eq!(r#"{"other_struct":"{\"value\":10}"}"#, serde_json::to_string(&x).unwrap());
 /// ```
 pub mod nested {
-    use serde::{
-        de::{DeserializeOwned, Deserializer, Error, Visitor},
-        ser::{self, Serialize, Serializer},
-    };
-    use std::{fmt, marker::PhantomData};
+    use serde::de::{DeserializeOwned, Deserializer, Error, Visitor};
+    use serde::ser::{self, Serialize, Serializer};
+    use std::fmt;
+    use std::marker::PhantomData;
 
     /// Deserialize value from a string which is valid JSON
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/src/json.rs
+++ b/src/json.rs
@@ -32,7 +32,10 @@ use serde::{Deserializer, Serialize, Serializer};
 /// let x = A {
 ///     other_struct: B { value: 10 },
 /// };
-/// assert_eq!(r#"{"other_struct":"{\"value\":10}"}"#, serde_json::to_string(&x).unwrap());
+/// assert_eq!(
+///     r#"{"other_struct":"{\"value\":10}"}"#,
+///     serde_json::to_string(&x).unwrap()
+/// );
 /// ```
 pub mod nested {
     use serde::de::{DeserializeOwned, Deserializer, Error, Visitor};
@@ -114,7 +117,10 @@ pub mod nested {
 /// let x = A {
 ///     other_struct: B { value: 10 },
 /// };
-/// assert_eq!(r#"{"other_struct":"{\"value\":10}"}"#, serde_json::to_string(&x).unwrap());
+/// assert_eq!(
+///     r#"{"other_struct":"{\"value\":10}"}"#,
+///     serde_json::to_string(&x).unwrap()
+/// );
 /// # }
 /// ```
 #[derive(Copy, Clone, Debug, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,7 @@ pub struct NoneAsEmptyString;
 /// # use serde_with::{serde_as, DefaultOnError};
 /// #
 /// #[serde_as]
-/// #[derive(Deserialize,  Debug)]
+/// #[derive(Deserialize, Debug)]
 /// struct A {
 ///     #[serde_as(deserialize_as = "DefaultOnError")]
 ///     value: u32,
@@ -538,7 +538,6 @@ pub struct NoneAsEmptyString;
 ///     #[serde(default)]
 ///     value: u32,
 /// }
-///
 ///
 /// let b: B = serde_json::from_str(r#"{  }"#).unwrap();
 /// assert_eq!(0, b.value);
@@ -588,7 +587,7 @@ pub struct DefaultOnError<T = Same>(PhantomData<T>);
 /// # use serde_with::{serde_as, DefaultOnNull};
 /// #
 /// #[serde_as]
-/// #[derive(Deserialize,  Debug)]
+/// #[derive(Deserialize, Debug)]
 /// struct A {
 ///     #[serde_as(deserialize_as = "DefaultOnNull")]
 ///     value: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+#![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
+    // missing_crate_level_docs, not available in MSRV
     missing_debug_implementations,
     missing_docs,
     trivial_casts,
@@ -10,6 +12,7 @@
     variant_size_differences
 )]
 #![warn(rust_2018_idioms)]
+#![doc(test(attr(forbid(unsafe_code))))]
 #![doc(test(attr(deny(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -64,7 +64,10 @@ use std::str::FromStr;
 ///     mime: mime::STAR_STAR,
 ///     number: 777,
 /// };
-/// assert_eq!(r#"{"mime":"*/*","number":"777"}"#, serde_json::to_string(&x).unwrap());
+/// assert_eq!(
+///     r#"{"mime":"*/*","number":"777"}"#,
+///     serde_json::to_string(&x).unwrap()
+/// );
 /// ```
 ///
 /// [`DeserializeFromStr`]: serde_with_macros::DeserializeFromStr
@@ -177,7 +180,10 @@ pub mod display_fromstr {
 ///     ].into_iter().collect(),
 ///     bs: vec![false, true],
 /// };
-/// assert_eq!(r#"{"addresses":["127.53.0.1","127.53.0.2","127.53.1.1"],"bs":["false","true"]}"#, serde_json::to_string(&x).unwrap());
+/// assert_eq!(
+///     r#"{"addresses":["127.53.0.1","127.53.0.2","127.53.1.1"],"bs":["false","true"]}"#,
+///     serde_json::to_string(&x).unwrap()
+/// );
 /// ```
 ///
 /// [`DisplayFromStr`]: crate::DisplayFromStr
@@ -304,7 +310,10 @@ pub mod seq_display_fromstr {
 ///     tags: vec!["1".to_string(), "2".to_string(), "3".to_string()],
 ///     more_tags: BTreeSet::new(),
 /// };
-/// assert_eq!(r#"{"tags":"1 2 3","more_tags":""}"#, serde_json::to_string(&x).unwrap());
+/// assert_eq!(
+///     r#"{"tags":"1 2 3","more_tags":""}"#,
+///     serde_json::to_string(&x).unwrap()
+/// );
 /// ```
 ///
 /// [`serde_as`]: crate::guide::serde_as
@@ -383,18 +392,18 @@ where
 /// }
 /// // Missing Value
 /// let s = r#"{}"#;
-/// assert_eq!(Doc {a: None}, serde_json::from_str(s).unwrap());
-/// assert_eq!(s, serde_json::to_string(&Doc {a: None}).unwrap());
+/// assert_eq!(Doc { a: None }, serde_json::from_str(s).unwrap());
+/// assert_eq!(s, serde_json::to_string(&Doc { a: None }).unwrap());
 ///
 /// // Unset Value
 /// let s = r#"{"a":null}"#;
-/// assert_eq!(Doc {a: Some(None)}, serde_json::from_str(s).unwrap());
-/// assert_eq!(s, serde_json::to_string(&Doc {a: Some(None)}).unwrap());
+/// assert_eq!(Doc { a: Some(None) }, serde_json::from_str(s).unwrap());
+/// assert_eq!(s, serde_json::to_string(&Doc { a: Some(None) }).unwrap());
 ///
 /// // Existing Value
 /// let s = r#"{"a":5}"#;
-/// assert_eq!(Doc {a: Some(Some(5))}, serde_json::from_str(s).unwrap());
-/// assert_eq!(s, serde_json::to_string(&Doc {a: Some(Some(5))}).unwrap());
+/// assert_eq!(Doc { a: Some(Some(5)) }, serde_json::from_str(s).unwrap());
+/// assert_eq!(s, serde_json::to_string(&Doc { a: Some(Some(5)) }).unwrap());
 /// ```
 #[allow(clippy::option_option)]
 pub mod double_option {
@@ -1686,7 +1695,6 @@ pub mod bytes_or_string {
 ///     #[serde(default, deserialize_with = "serde_with::rust::default_on_error::deserialize")]
 ///     value: u32,
 /// }
-///
 ///
 /// let b: B = serde_json::from_str(r#"{  }"#).unwrap();
 /// assert_eq!(0, b.value);

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1,19 +1,17 @@
 //! De/Serialization for Rust's builtin and std types
 
 use crate::Separator;
-use serde::{
-    de::{Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor},
-    ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
+use serde::de::{
+    Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor,
 };
-use std::{
-    cmp::Eq,
-    collections::{BTreeMap, HashMap},
-    fmt::{self, Display},
-    hash::{BuildHasher, Hash},
-    iter::FromIterator,
-    marker::PhantomData,
-    str::FromStr,
-};
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use std::cmp::Eq;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::{self, Display};
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::marker::PhantomData;
+use std::str::FromStr;
 
 /// De/Serialize using [`Display`] and [`FromStr`] implementation
 ///
@@ -185,16 +183,12 @@ pub mod display_fromstr {
 /// [`DisplayFromStr`]: crate::DisplayFromStr
 /// [`serde_as`]: crate::guide::serde_as
 pub mod seq_display_fromstr {
-    use serde::{
-        de::{Deserializer, Error, SeqAccess, Visitor},
-        ser::{SerializeSeq, Serializer},
-    };
-    use std::{
-        fmt::{self, Display},
-        iter::{FromIterator, IntoIterator},
-        marker::PhantomData,
-        str::FromStr,
-    };
+    use serde::de::{Deserializer, Error, SeqAccess, Visitor};
+    use serde::ser::{SerializeSeq, Serializer};
+    use std::fmt::{self, Display};
+    use std::iter::{FromIterator, IntoIterator};
+    use std::marker::PhantomData;
+    use std::str::FromStr;
 
     /// Deserialize collection T using [FromIterator] and [FromStr] for each element
     pub fn deserialize<'de, D, T, I>(deserializer: D) -> Result<T, D::Error>

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -1,13 +1,12 @@
-use utils::duration::DurationSigned;
-
 use super::*;
-use crate::{formats::Strictness, rust::StringWithSeparator, Separator};
-use std::{
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    fmt::Display,
-    hash::{BuildHasher, Hash},
-    time::{Duration, SystemTime},
-};
+use crate::formats::Strictness;
+use crate::rust::StringWithSeparator;
+use crate::utils::duration::DurationSigned;
+use crate::Separator;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
+use std::fmt::Display;
+use std::hash::{BuildHasher, Hash};
+use std::time::{Duration, SystemTime};
 
 impl<'a, T, U> SerializeAs<&'a T> for &'a U
 where

--- a/src/utils/duration.rs
+++ b/src/utils/duration.rs
@@ -1,20 +1,16 @@
 //! Internal Helper types
 
+use crate::formats::{Flexible, Format, Strict, Strictness};
 use crate::{
-    formats::{Flexible, Format, Strict, Strictness},
     utils, DeserializeAs, DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
     DurationSeconds, DurationSecondsWithFrac, SerializeAs,
 };
-use serde::{
-    de::{self, Unexpected, Visitor},
-    ser, Deserialize, Deserializer, Serialize, Serializer,
-};
-use std::{
-    fmt,
-    ops::Neg,
-    time::{Duration, SystemTime},
-};
+use serde::de::{self, Unexpected, Visitor};
+use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::ops::Neg;
+use std::time::{Duration, SystemTime};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Sign {

--- a/src/with_prefix.rs
+++ b/src/with_prefix.rs
@@ -1,10 +1,9 @@
-use std::fmt;
-
-use serde::{
-    de::{self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor},
-    forward_to_deserialize_any,
-    ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer},
+use serde::de::{
+    self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor,
 };
+use serde::forward_to_deserialize_any;
+use serde::ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
+use std::fmt;
 
 /// Serialize with an added prefix on every field name and deserialize by
 /// trimming away the prefix.
@@ -105,10 +104,8 @@ use serde::{
 macro_rules! with_prefix {
     ($module:ident $prefix:expr) => {
         mod $module {
-            use $crate::{
-                serde::{Deserialize, Deserializer, Serialize, Serializer},
-                with_prefix::WithPrefix,
-            };
+            use $crate::serde::{Deserialize, Deserializer, Serialize, Serializer};
+            use $crate::with_prefix::WithPrefix;
 
             #[allow(dead_code)]
             pub fn serialize<T, S>(object: &T, serializer: S) -> Result<S::Ok, S::Error>

--- a/tests/chrono.rs
+++ b/tests/chrono.rs
@@ -6,11 +6,13 @@ use crate::utils::{
 use chrono_crate::{DateTime, Duration, NaiveDateTime, Utc};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
+use serde_with::formats::Flexible;
 use serde_with::{
-    formats::Flexible, serde_as, DurationSeconds, DurationSecondsWithFrac, TimestampSeconds,
-    TimestampSecondsWithFrac,
+    serde_as, DurationSeconds, DurationSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
 };
-use std::{collections::BTreeMap, iter::FromIterator, str::FromStr};
+use std::collections::BTreeMap;
+use std::iter::FromIterator;
+use std::str::FromStr;
 
 fn new_datetime(secs: i64, nsecs: u32) -> DateTime<Utc> {
     DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nsecs), Utc)

--- a/tests/deserialize_fromstr.rs
+++ b/tests/deserialize_fromstr.rs
@@ -1,9 +1,7 @@
 use pretty_assertions::assert_eq;
 use serde_with::DeserializeFromStr;
-use std::{
-    num::ParseIntError,
-    str::{FromStr, ParseBoolError},
-};
+use std::num::ParseIntError;
+use std::str::{FromStr, ParseBoolError};
 
 #[derive(Debug, PartialEq, DeserializeFromStr)]
 struct A {
@@ -43,7 +41,8 @@ fn test_deserialize_fromstr() {
 
 #[test]
 fn test_deserialize_from_bytes() {
-    use serde::de::{value::Error, Deserialize, Deserializer, Visitor};
+    use serde::de::value::Error;
+    use serde::de::{Deserialize, Deserializer, Visitor};
 
     // Unfortunately serde_json is too clever (i.e. handles bytes gracefully)
     // so instead create a custom deserializer which can only deserialize bytes.

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -3,11 +3,9 @@ mod utils;
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::{
-    formats::{Lowercase, Uppercase},
-    hex::Hex,
-    serde_as,
-};
+use serde_with::formats::{Lowercase, Uppercase};
+use serde_with::hex::Hex;
+use serde_with::serde_as;
 
 #[test]
 fn hex_vec() {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -3,7 +3,8 @@ mod utils;
 use crate::utils::is_equal;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::{json::JsonString, serde_as, DisplayFromStr};
+use serde_with::json::JsonString;
+use serde_with::{serde_as, DisplayFromStr};
 
 #[test]
 fn test_nested_json() {

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -4,13 +4,12 @@ use crate::utils::{check_deserialization, check_error_deserialization, is_equal}
 use expect_test::expect;
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use pretty_assertions::assert_eq;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use serde_with::CommaSeparator;
-use std::{
-    cmp,
-    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
-    iter::FromIterator as _,
-};
+use std::cmp;
+use std::collections::{BTreeMap, BTreeSet, LinkedList, VecDeque};
+use std::iter::FromIterator as _;
 
 #[test]
 fn string_collection() {

--- a/tests/serde_as.rs
+++ b/tests/serde_as.rs
@@ -10,17 +10,15 @@ use crate::utils::{
 };
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
+use serde_with::formats::Flexible;
 use serde_with::{
-    formats::Flexible, serde_as, BytesOrString, DefaultOnError, DefaultOnNull, DisplayFromStr,
-    DurationSeconds, DurationSecondsWithFrac, NoneAsEmptyString, Same, TimestampSeconds,
-    TimestampSecondsWithFrac,
+    serde_as, BytesOrString, DefaultOnError, DefaultOnNull, DisplayFromStr, DurationSeconds,
+    DurationSecondsWithFrac, NoneAsEmptyString, Same, TimestampSeconds, TimestampSecondsWithFrac,
 };
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, LinkedList, VecDeque},
-    rc::Rc,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, LinkedList, VecDeque};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 #[test]
 fn test_box() {
@@ -394,7 +392,8 @@ fn test_map_as_tuple_list() {
 
 #[test]
 fn test_tuple_list_as_map() {
-    use std::{collections::HashMap, net::IpAddr};
+    use std::collections::HashMap;
+    use std::net::IpAddr;
     let ip = "1.2.3.4".parse().unwrap();
     let ip2 = "255.255.255.255".parse().unwrap();
 
@@ -810,7 +809,8 @@ fn test_duration_seconds_with_frac() {
 
 #[test]
 fn string_with_separator() {
-    use serde_with::{rust::StringWithSeparator, CommaSeparator, SpaceSeparator};
+    use serde_with::rust::StringWithSeparator;
+    use serde_with::{CommaSeparator, SpaceSeparator};
 
     #[serde_as]
     #[derive(Deserialize, Serialize)]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -2,7 +2,8 @@
 
 use expect_test::Expect;
 use pretty_assertions::assert_eq;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 
 #[rustversion::attr(since(1.46), track_caller)]

--- a/tests/with_prefix.rs
+++ b/tests/with_prefix.rs
@@ -4,10 +4,8 @@ use crate::utils::is_equal;
 use expect_test::expect;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::with_prefix;
-use std::{
-    collections::{BTreeMap, HashMap},
-    iter::FromIterator,
-};
+use std::collections::{BTreeMap, HashMap};
+use std::iter::FromIterator;
 
 #[test]
 fn test_flatten_with_prefix() {


### PR DESCRIPTION
Change some rustfmt settings for the imports.
Cleanup some whitespace in doc tests.
Add a cargo audit config to enable warning about unsound dependencies.

bors r+