### PR TITLE
Add a `Bytes` type for more efficient byte sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     },
     ```
 
+* The `Bytes` type is heavily inspired by `serde_bytes` and ports it to the `serde_as` system.
+
+    ```rust
+    #[serde_as(as = "Bytes")]
+    value: Vec<u8>,
+    ```
+
+    Compared to `serde_bytes` these improvements are available
+
+    1. Integration with the `serde_as` annotation (see [serde-bytes#14][serde-bytes-complex]).
+    2. Implementation for arrays of arbitrary size (Rust 1.51+) (see [serde-bytes#26][serde-bytes-arrays]).
+
+[serde-bytes-complex]: https://github.com/serde-rs/bytes/issues/14
+[serde-bytes-arrays]: https://github.com/serde-rs/bytes/issues/26
+
 ## [1.6.4] - 2021-02-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ron = "0.6"
 serde-xml-rs = "0.4.1"
 serde_derive = "1.0.75"
 serde_json = {version = "1.0.25", features = ["preserve_order"]}
+serde_test = "1.0.124"
 version-sync = "0.9.1"
 
 [[test]]

--- a/src/guide/serde_as.md
+++ b/src/guide/serde_as.md
@@ -17,17 +17,18 @@ The basic design of the system was done by [@markazmierczak](https://github.com/
     5. [Re-exporting `serde_as`](#re-exporting-serde_as)
 2. [De/Serialize Implementations Available](#deserialize-implementations-available)
     1. [Big Array support (Rust 1.51+)](#big-array-support-rust-151)
-    2. [Bytes / `Vec<u8>` to hex string](#bytes--vecu8-to-hex-string)
-    3. [`Default` from `null`](#default-from-null)
-    4. [De/Serialize with `FromStr` and `Display`](#deserialize-with-fromstr-and-display)
-    5. [`Duration` as seconds](#duration-as-seconds)
-    6. [Ignore deserialization errors](#ignore-deserialization-errors)
-    7. [`Maps` to `Vec` of tuples](#maps-to-vec-of-tuples)
-    8. [`NaiveDateTime` like UTC timestamp](#naivedatetime-like-utc-timestamp)
-    9. [`None` as empty `String`](#none-as-empty-string)
-    10. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
-    11. [Value into JSON String](#value-into-json-string)
-    12. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
+    2. [`Bytes` with more efficiency](#bytes-with-more-efficiency)
+    3. [Bytes / `Vec<u8>` to hex string](#bytes--vecu8-to-hex-string)
+    4. [`Default` from `null`](#default-from-null)
+    5. [De/Serialize with `FromStr` and `Display`](#deserialize-with-fromstr-and-display)
+    6. [`Duration` as seconds](#duration-as-seconds)
+    7. [Ignore deserialization errors](#ignore-deserialization-errors)
+    8. [`Maps` to `Vec` of tuples](#maps-to-vec-of-tuples)
+    9. [`NaiveDateTime` like UTC timestamp](#naivedatetime-like-utc-timestamp)
+    10. [`None` as empty `String`](#none-as-empty-string)
+    11. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
+    12. [Value into JSON String](#value-into-json-string)
+    13. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
 
 ## Switching from serde's with to `serde_as`
 
@@ -300,6 +301,21 @@ value: [[u8; 64]; 33],
 "value": [[0,0,0,0,0,...], [0,0,0,...], ...],
 ```
 
+### `Bytes` with more efficiency
+
+[`Bytes`]
+
+More efficient serialization for byte slices and similar.
+
+```ignore
+// Rust
+#[serde_as(as = "Bytes")]
+value: Vec<u8>,
+
+// JSON
+"value": [0, 1, 2, 3, ...],
+```
+
 ### Bytes / `Vec<u8>` to hex string
 
 [`Hex`]
@@ -516,6 +532,7 @@ This includes `BinaryHeap<(K, V)>`, `BTreeSet<(K, V)>`, `HashSet<(K, V)>`, `Link
 
 The [inverse operation](#maps-to-vec-of-tuples) is also available.
 
+[`Bytes`]: crate::Bytes
 [`chrono::DateTime<Local>`]: chrono_crate::DateTime
 [`chrono::DateTime<Utc>`]: chrono_crate::DateTime
 [`chrono::Duration`]: https://docs.rs/chrono/latest/chrono/struct.Duration.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1349,6 +1349,7 @@ pub struct TimestampNanoSecondsWithFrac<
 /// # #[derive(Debug, PartialEq)]
 /// #[derive(Deserialize, Serialize)]
 /// struct Test<'a> {
+/// #   #[cfg(FALSE)]
 ///     #[serde_as(as = "Bytes")]
 ///     array: [u8; 15],
 ///     #[serde_as(as = "Bytes")]
@@ -1361,6 +1362,7 @@ pub struct TimestampNanoSecondsWithFrac<
 /// }
 ///
 /// let value = Test {
+/// #   #[cfg(FALSE)]
 ///     array: b"0123456789ABCDE".clone(),
 ///     boxed: b"...".to_vec().into_boxed_slice(),
 ///     cow: Cow::Borrowed(b"FooBar"),
@@ -1372,6 +1374,13 @@ pub struct TimestampNanoSecondsWithFrac<
 ///     cow: "Rm9vQmFy",
 ///     vec: "QWEh",
 /// )"#;
+/// # drop(expected);
+/// # // Create a fake expected value without the array to make the test compile without const generics
+/// # let expected = r#"(
+/// #     boxed: "Li4u",
+/// #     cow: "Rm9vQmFy",
+/// #     vec: "QWEh",
+/// # )"#;
 ///
 /// # let pretty_config = ron::ser::PrettyConfig::new()
 /// #     .with_new_line("\n".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1320,3 +1320,109 @@ pub struct TimestampNanoSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
 >(PhantomData<(FORMAT, STRICTNESS)>);
+
+/// Optimized handling of owned and borrowed byte representations.
+///
+/// Serialization of byte sequences like `&[u8]` or `Vec<u8>` is quite inefficient since each value will be serialized individually.
+/// This converter type optimizes the serialization and deserialization.
+///
+/// This is a port of the `serde_bytes` crate making it compatible with the `serde_as`-annotation, which allows it to be used in more cases than provided by `serde_bytes`.
+///
+/// The type provides de-/serialization for these types:
+///
+/// * `[u8; N]`, Rust 1.51+, not possible using `serde_bytes`
+/// * `&[u8]`
+/// * `Box<[u8; N]>`, Rust 1.51+, not possible using `serde_bytes`
+/// * `Box<[u8]>`
+/// * `Vec<u8>`
+/// * `Cow<'_, [u8]>`
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_with::{serde_as, Bytes};
+/// # use std::borrow::Cow;
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct Test<'a> {
+///     #[serde_as(as = "Bytes")]
+///     array: [u8; 15],
+///     #[serde_as(as = "Bytes")]
+///     boxed: Box<[u8]>,
+///     #[serde_as(as = "Bytes")]
+///     #[serde(borrow)]
+///     cow: Cow<'a, [u8]>,
+///     #[serde_as(as = "Bytes")]
+///     vec: Vec<u8>,
+/// }
+///
+/// let value = Test {
+///     array: b"0123456789ABCDE".clone(),
+///     boxed: b"...".to_vec().into_boxed_slice(),
+///     cow: Cow::Borrowed(b"FooBar"),
+///     vec: vec![0x41, 0x61, 0x21],
+/// };
+/// let expected = r#"(
+///     array: "MDEyMzQ1Njc4OUFCQ0RF",
+///     boxed: "Li4u",
+///     cow: "Rm9vQmFy",
+///     vec: "QWEh",
+/// )"#;
+///
+/// # let pretty_config = ron::ser::PrettyConfig::new()
+/// #     .with_new_line("\n".into());
+/// assert_eq!(expected, ron::ser::to_string_pretty(&value, pretty_config).unwrap());
+/// assert_eq!(value, ron::from_str(&expected).unwrap());
+/// # }
+/// ```
+///
+/// ## Alternative to [`BytesOrString`]
+///
+/// The [`Bytes`] can replace [`BytesOrString`].
+/// [`Bytes`] is implemented for more types, which makes it better.
+/// The serialization behavior of [`Bytes`] differes from [`BytesOrString`], therefore only `deserialize_as` should be used.
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde::Deserialize;
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, Bytes};
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, serde::Serialize)]
+/// struct Test {
+///     #[serde_as(deserialize_as = "Bytes")]
+///     from_bytes: Vec<u8>,
+///     #[serde_as(deserialize_as = "Bytes")]
+///     from_str: Vec<u8>,
+/// }
+///
+/// // Different serialized values ...
+/// let j = json!({
+///     "from_bytes": [70,111,111,45,66,97,114],
+///     "from_str": "Foo-Bar",
+/// });
+///
+/// // can be deserialized ...
+/// let test = Test {
+///     from_bytes: b"Foo-Bar".to_vec(),
+///     from_str: b"Foo-Bar".to_vec(),
+/// };
+/// assert_eq!(test, serde_json::from_value(j).unwrap());
+///
+/// // and serialization will always be a byte sequence
+/// # assert_eq!(json!(
+/// {
+///     "from_bytes": [70,111,111,45,66,97,114],
+///     "from_str": [70,111,111,45,66,97,114],
+/// }
+/// # ), serde_json::to_value(&test).unwrap());
+/// # }
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Bytes;

--- a/src/ser/const_arrays.rs
+++ b/src/ser/const_arrays.rs
@@ -42,3 +42,21 @@ macro_rules! tuple_seq_as_map_impl_intern {
 }
 tuple_seq_as_map_impl_intern!([(K, V); N], BTreeMap<K, V>);
 tuple_seq_as_map_impl_intern!([(K, V); N], HashMap<K, V>);
+
+impl<'a, const N: usize> SerializeAs<[u8; N]> for Bytes {
+    fn serialize_as<S>(bytes: &[u8; N], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
+    }
+}
+
+impl<'a, const N: usize> SerializeAs<Box<[u8; N]>> for Bytes {
+    fn serialize_as<S>(bytes: &Box<[u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&**bytes)
+    }
+}

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -3,6 +3,7 @@ use crate::formats::Strictness;
 use crate::rust::StringWithSeparator;
 use crate::utils::duration::DurationSigned;
 use crate::Separator;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::fmt::Display;
 use std::hash::{BuildHasher, Hash};
@@ -374,5 +375,41 @@ where
         S: Serializer,
     {
         serializer.serialize_some(&SerializeAsWrap::<T, U>::new(source))
+    }
+}
+
+impl SerializeAs<&[u8]> for Bytes {
+    fn serialize_as<S>(bytes: &&[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
+    }
+}
+
+impl SerializeAs<Vec<u8>> for Bytes {
+    fn serialize_as<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
+    }
+}
+
+impl SerializeAs<Box<[u8]>> for Bytes {
+    fn serialize_as<S>(bytes: &Box<[u8]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
+    }
+}
+
+impl<'a> SerializeAs<Cow<'a, [u8]>> for Bytes {
+    fn serialize_as<S>(bytes: &Cow<'a, [u8]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
     }
 }


### PR DESCRIPTION
The `Bytes` type is heavily inspired by `serde_bytes` and ports it to the
serde_as system.

```rust
#[serde_as(as = "Bytes")]
value: Vec<u8>,
```

Compared to `serde_bytes` these improvements are available

1. Integration with the `serde_as` annotation.
    /cc https://github.com/serde-rs/bytes/issues/14
2. Implementation for arrays of arbitrary size (Rust 1.51+).
    /cc https://github.com/serde-rs/bytes/issues/26