### PR TITLE
Add `OneOrMany` type which deserializes a `Vec` from a list or a single element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     1. Integration with the `serde_as` annotation (see [serde-bytes#14][serde-bytes-complex]).
     2. Implementation for arrays of arbitrary size (Rust 1.51+) (see [serde-bytes#26][serde-bytes-arrays]).
 
+* The `OneOrMany` allows to deserialize a `Vec` from either a single element or a sequence.
+
+    ```rust
+    #[serde_as(as = "OneOrMany<_>")]
+    cities: Vec<String>,
+    ```
+
+    This allows to deserialize from either `cities: "Berlin"` or `cities: ["Berlin", "Paris"]`.
+    The serialization can be configured to always emit a list with `PreferMany` or emit a single element with `PreferOne`.
+
 [serde-bytes-complex]: https://github.com/serde-rs/bytes/issues/14
 [serde-bytes-arrays]: https://github.com/serde-rs/bytes/issues/26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ chrono_crate = {package = "chrono", version = "0.4.1", features = ["serde"], opt
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.2", optional = true}
 rustversion = "1.0.0"
-serde = {version = "1.0.75", features = ["derive"]}
+serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "./serde_with_macros", version = "1.4.1", optional = true}
 
@@ -54,7 +54,7 @@ pretty_assertions = "0.7.1"
 regex = {version = "1.3.9", default-features = false, features = ["std"]}
 ron = "0.6"
 serde-xml-rs = "0.4.1"
-serde_derive = "1.0.75"
+serde_derive = "1.0.122"
 serde_json = {version = "1.0.25", features = ["preserve_order"]}
 serde_test = "1.0.124"
 version-sync = "0.9.1"

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -66,6 +66,11 @@ create_format!(
     Uppercase
     /// Use lowercase characters
     Lowercase
+
+    /// Use in combination with [`OneOrMany`]. Emit single element for lists of size 1.
+    PreferOne
+    /// Use in combination with [`OneOrMany`]. Always emit the list form.
+    PreferMany
 );
 
 /// Specify how lenient the deserialization process should be

--- a/src/guide/serde_as.md
+++ b/src/guide/serde_as.md
@@ -26,9 +26,10 @@ The basic design of the system was done by [@markazmierczak](https://github.com/
     8. [`Maps` to `Vec` of tuples](#maps-to-vec-of-tuples)
     9. [`NaiveDateTime` like UTC timestamp](#naivedatetime-like-utc-timestamp)
     10. [`None` as empty `String`](#none-as-empty-string)
-    11. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
-    12. [Value into JSON String](#value-into-json-string)
-    13. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
+    11. [One or many elements into `Vec`](#one-or-many-elements-into-vec)
+    12. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
+    13. [Value into JSON String](#value-into-json-string)
+    14. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
 
 ## Switching from serde's with to `serde_as`
 
@@ -454,6 +455,21 @@ value: Option<String>,
 "value": "Hello World!", // converts to Some
 ```
 
+### One or many elements into `Vec`
+
+[`OneOrMany`]
+
+```ignore
+// Rust
+#[serde_as(as = "serde_with::OneOrMany<_>")]
+value: Vec<String>,
+
+// JSON
+"value": "", // Deserializes single elements
+
+"value": ["Hello", "World!"], // or lists of many
+```
+
 ### Timestamps as seconds since UNIX epoch
 
 [`TimestampSeconds`]
@@ -545,6 +561,7 @@ The [inverse operation](#maps-to-vec-of-tuples) is also available.
 [`Hex`]: crate::hex::Hex
 [`JsonString`]: crate::json::JsonString
 [`NoneAsEmptyString`]: crate::NoneAsEmptyString
+[`OneOrMany`]: crate::OneOrMany
 [`SerializeAs`]: crate::SerializeAs
 [bytes to string converter]: crate::BytesOrString
 [duration to UNIX epoch]: crate::DurationSeconds

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -413,3 +413,31 @@ impl<'a> SerializeAs<Cow<'a, [u8]>> for Bytes {
         serializer.serialize_bytes(bytes)
     }
 }
+
+impl<T, U> SerializeAs<Vec<T>> for OneOrMany<U, formats::PreferOne>
+where
+    U: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match source.len() {
+            1 => SerializeAsWrap::<T, U>::new(source.iter().next().expect("Cannot be empty"))
+                .serialize(serializer),
+            _ => SerializeAsWrap::<Vec<T>, Vec<U>>::new(source).serialize(serializer),
+        }
+    }
+}
+
+impl<T, U> SerializeAs<Vec<T>> for OneOrMany<U, formats::PreferMany>
+where
+    U: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<Vec<T>, Vec<U>>::new(source).serialize(serializer)
+    }
+}

--- a/tests/serde_as.rs
+++ b/tests/serde_as.rs
@@ -1565,7 +1565,7 @@ fn test_one_or_many_prefer_one() {
 
 #[test]
 fn test_one_or_many_prefer_many() {
-    use serde_with::formats::{PreferMany, PreferOne};
+    use serde_with::formats::PreferMany;
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
```rust
#[serde_as(as = "OneOrMany<_>")]
cities: Vec<String>,
```

This allows to deserialize from either `cities: "Berlin"` or `cities: ["Berlin", "Paris"]`.
The serialization can be configured to always emit a list with `PreferMany` or emit a single element with `PreferOne`.

This is a features which keeps getting asked:
* https://github.com/serde-rs/serde/issues/889
* https://github.com/serde-rs/serde/issues/1891
* https://github.com/serde-rs/serde/issues/1907
* https://www.reddit.com/r/rust/comments/l3exvd/question_how_to_deserialize_either_a_vec_of_enum/