### PR TITLE
Bump version to 1.7.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
         "Deque",
         "Deserialization",
         "Deserializes",
+        "MSRV",
+        "Milli",
         "NANOS",
         "accu",
         "btreemap",
@@ -40,5 +42,5 @@
         "markdown",
         "rust",
         "toml"
-    ]
+    ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.7.0] - 2021-03-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* Add support for arrays of arbitrary size.
+* Add support for arrays of arbitrary size. ([#272])
     This feature requires Rust 1.51+.
 
     ```rust
@@ -30,11 +30,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     2. Supports non-copy elements (see [serde-big-array#6][serde-big-array-copy]).
     3. Supports arbitrary nestings of arrays (see [serde-big-array#7][serde-big-array-nested]).
 
+[#272]: https://github.com/jonasbb/serde_with/pull/272
 [`serde-big-array`]: https://crates.io/crates/serde-big-array
 [serde-big-array-copy]: https://github.com/est31/serde-big-array/issues/6
 [serde-big-array-nested]: https://github.com/est31/serde-big-array/issues/7
 
-* Arrays with tuple elements can now be deserialized from  a map.
+* Arrays with tuple elements can now be deserialized from  a map. ([#272])
     This feature requires Rust 1.51+.
 
     ```rust
@@ -50,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     },
     ```
 
-* The `Bytes` type is heavily inspired by `serde_bytes` and ports it to the `serde_as` system.
+* The `Bytes` type is heavily inspired by `serde_bytes` and ports it to the `serde_as` system. ([#277])
 
     ```rust
     #[serde_as(as = "Bytes")]
@@ -62,7 +63,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     1. Integration with the `serde_as` annotation (see [serde-bytes#14][serde-bytes-complex]).
     2. Implementation for arrays of arbitrary size (Rust 1.51+) (see [serde-bytes#26][serde-bytes-arrays]).
 
-* The `OneOrMany` allows to deserialize a `Vec` from either a single element or a sequence.
+[#277]: https://github.com/jonasbb/serde_with/pull/277
+[serde-bytes-complex]: https://github.com/serde-rs/bytes/issues/14
+[serde-bytes-arrays]: https://github.com/serde-rs/bytes/issues/26
+
+* The `OneOrMany` allows to deserialize a `Vec` from either a single element or a sequence. ([#281])
 
     ```rust
     #[serde_as(as = "OneOrMany<_>")]
@@ -72,8 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     This allows to deserialize from either `cities: "Berlin"` or `cities: ["Berlin", "Paris"]`.
     The serialization can be configured to always emit a list with `PreferMany` or emit a single element with `PreferOne`.
 
-[serde-bytes-complex]: https://github.com/serde-rs/bytes/issues/14
-[serde-bytes-arrays]: https://github.com/serde-rs/bytes/issues/26
+[#281]: https://github.com/jonasbb/serde_with/pull/281
 
 ## [1.6.4] - 2021-02-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "Marcin Kaźmierczak",
 ]
 name = "serde_with"
-version = "1.6.4"
+version = "1.7.0"
 
 categories = ["encoding"]
 description = "Custom de/serialization functions for Rust's serde"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies.serde_with]
-version = "1.6.4"
+version = "1.7.0"
 features = [ "..." ]
 ```
 
@@ -124,13 +124,13 @@ Foo {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/1.6.4/serde_with/struct.DisplayFromStr.html
-[`with_prefix!`]: https://docs.rs/serde_with/1.6.4/serde_with/macro.with_prefix.html
-[display_fromstr]: https://docs.rs/serde_with/1.6.4/serde_with/rust/display_fromstr/index.html
-[feature flags]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/1.6.4/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/1.6.4/serde_with/rust/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/1.7.0/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/1.7.0/serde_with/macro.with_prefix.html
+[display_fromstr]: https://docs.rs/serde_with/1.7.0/serde_with/rust/display_fromstr/index.html
+[feature flags]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/1.7.0/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/1.7.0/serde_with/rust/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/1.7.0/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
 
 ## License

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -437,8 +437,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// }
 /// ```
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
-/// [re-exporting `serde_as`]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [`serde_as`]: https://docs.rs/serde_with/1.7.0/serde_with/guide/index.html
+/// [re-exporting `serde_as`]: https://docs.rs/serde_with/1.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(FromMeta, Debug)]
@@ -741,7 +741,7 @@ fn replace_infer_type_with_type(to_replace: Type, replacement: &Type) -> Type {
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/1.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(DeserializeFromStr, attributes(serde_with))]
 pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
@@ -851,7 +851,7 @@ fn deserialize_fromstr(input: DeriveInput, serde_with_crate_path: Path) -> Token
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/1.6.4/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/1.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(SerializeDisplay, attributes(serde_with))]
 pub fn derive_serialize_display(item: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/1.6.4")]
+#![doc(html_root_url = "https://docs.rs/serde_with/1.7.0")]
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Rust 1.45: introduction of `strip_prefix` used by clippy::manual_strip
@@ -61,7 +61,7 @@
 //!
 //! ```toml
 //! [dependencies.serde_with]
-//! version = "1.6.4"
+//! version = "1.7.0"
 //! features = [ "..." ]
 //! ```
 //!
@@ -200,13 +200,13 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/1.6.4/serde_with/struct.DisplayFromStr.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/1.6.4/serde_with/macro.with_prefix.html
-//! [display_fromstr]: https://docs.rs/serde_with/1.6.4/serde_with/rust/display_fromstr/index.html
-//! [feature flags]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/1.6.4/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/1.6.4/serde_with/rust/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/1.6.4/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/1.7.0/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/1.7.0/serde_with/macro.with_prefix.html
+//! [display_fromstr]: https://docs.rs/serde_with/1.7.0/serde_with/rust/display_fromstr/index.html
+//! [feature flags]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/1.7.0/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/1.7.0/serde_with/rust/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/1.7.0/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
 
 #[doc(hidden)]
@@ -342,7 +342,7 @@ impl Separator for CommaSeparator {
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/1.6.4/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/1.7.0/serde_with/attr.serde_as.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct As<T: ?Sized>(PhantomData<T>);
 
@@ -808,7 +808,7 @@ pub struct BytesOrString;
 /// ```
 ///
 /// [`chrono::Duration`]: chrono_crate::Duration
-/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
@@ -934,7 +934,7 @@ pub struct DurationSeconds<
 /// ```
 ///
 /// [`chrono::Duration`]: chrono_crate::Duration
-/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
@@ -1131,7 +1131,7 @@ pub struct DurationNanoSecondsWithFrac<
 ///
 /// [`SystemTime`]: std::time::SystemTime
 /// [DateTime]: chrono_crate::DateTime
-/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
@@ -1260,7 +1260,7 @@ pub struct TimestampSeconds<
 ///
 /// [`SystemTime`]: std::time::SystemTime
 /// [DateTime]: chrono_crate::DateTime
-/// [feature flag]: https://docs.rs/serde_with/1.6.4/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/1.7.0/serde_with/guide/feature_flags/index.html
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,


### PR DESCRIPTION
Bump the version to 1.7.0.
This includes all changes for the const-generics array support.