### PR TITLE
Improve and merge the `btreemap_as_tuple_list` and `hashmap_as_tuple_list` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* Add a new `serde_with::rust::map_as_tuple_list` module as a replacement for `serde_with::rust::btreemap_as_tuple_list` and `serde_with::rust::hashmap_as_tuple_list`.
+    The new module uses `IntoIterator` and `FromIterator` as trait bound making it usable in more sitations.
+    The old names continue to exist but are marked as deprecated.
+
+### Deprecated
+
+* Deprecated the module names `serde_with::rust::btreemap_as_tuple_list` and `serde_with::rust::hashmap_as_tuple_list`.
+    You can use `serde_with::rust::map_as_tuple_list` as a replacement.
+
 ## [1.7.0] - 2021-03-24
 
 ### Added

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -406,12 +406,12 @@ fn duplicate_value_last_wins_btreeset() {
 }
 
 #[test]
-fn test_hashmap_as_tuple_list() {
+fn test_map_as_tuple_list() {
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    struct S(#[serde(with = "serde_with::rust::hashmap_as_tuple_list")] HashMap<String, u8>);
+    struct Hash(#[serde(with = "serde_with::rust::map_as_tuple_list")] HashMap<String, u8>);
 
     is_equal(
-        S(HashMap::from_iter(vec![
+        Hash(HashMap::from_iter(vec![
             ("ABC".to_string(), 1),
             ("Hello".to_string(), 0),
             ("World".to_string(), 20),
@@ -433,7 +433,7 @@ fn test_hashmap_as_tuple_list() {
             ]"#]],
     );
     is_equal(
-        S(HashMap::from_iter(vec![("Hello".to_string(), 0)])),
+        Hash(HashMap::from_iter(vec![("Hello".to_string(), 0)])),
         expect![[r#"
             [
               [
@@ -442,22 +442,19 @@ fn test_hashmap_as_tuple_list() {
               ]
             ]"#]],
     );
-    is_equal(S(HashMap::default()), expect![[r#"[]"#]]);
+    is_equal(Hash(HashMap::default()), expect![[r#"[]"#]]);
 
     // Test parse error, only single element instead of tuple
-    check_error_deserialization::<S>(
+    check_error_deserialization::<Hash>(
         r#"[ [1] ]"#,
         expect![[r#"invalid type: integer `1`, expected a string at line 1 column 4"#]],
     );
-}
 
-#[test]
-fn test_btreemap_as_tuple_list() {
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    struct S(#[serde(with = "serde_with::rust::btreemap_as_tuple_list")] BTreeMap<String, u8>);
+    struct BTree(#[serde(with = "serde_with::rust::map_as_tuple_list")] BTreeMap<String, u8>);
 
     is_equal(
-        S(BTreeMap::from_iter(vec![
+        BTree(BTreeMap::from_iter(vec![
             ("ABC".to_string(), 1),
             ("Hello".to_string(), 0),
             ("World".to_string(), 20),
@@ -479,7 +476,7 @@ fn test_btreemap_as_tuple_list() {
             ]"#]],
     );
     is_equal(
-        S(BTreeMap::from_iter(vec![("Hello".to_string(), 0)])),
+        BTree(BTreeMap::from_iter(vec![("Hello".to_string(), 0)])),
         expect![[r#"
             [
               [
@@ -488,10 +485,10 @@ fn test_btreemap_as_tuple_list() {
               ]
             ]"#]],
     );
-    is_equal(S(BTreeMap::default()), expect![[r#"[]"#]]);
+    is_equal(BTree(BTreeMap::default()), expect![[r#"[]"#]]);
 
     // Test parse error, only single element instead of tuple
-    check_error_deserialization::<S>(
+    check_error_deserialization::<BTree>(
         r#"[ [1] ]"#,
         expect![[r#"invalid type: integer `1`, expected a string at line 1 column 4"#]],
     );


### PR DESCRIPTION
The existing bound on `btreemap_as_tuple_list` and
`hashmap_as_tuple_list` are more restrictive than necessary. In fact,
both of them can be merged by using the `IntoIterator`,
`ExactSizeIterator`, and `FromIterator` traits.
This now provides support types besides `HashMap` and `BTreeMap`.

The old names are still available but are marked as deprecated.
The replacement is the new `map_as_tuple_list` module.