### PR TITLE
Add the missing `Timestamp*` and `Duration*` implementations for chrono types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Deprecated the module names `serde_with::rust::btreemap_as_tuple_list` and `serde_with::rust::hashmap_as_tuple_list`.
     You can use `serde_with::rust::map_as_tuple_list` as a replacement.
 
+### Fixed
+
+* Implement `Timestamp*Seconds` and `Duration*Seconds` also for chrono types.
+    This closes [#194]. This was incompletely implemented in #199.
+
+[#194]: https://github.com/jonasbb/serde_with/issues/194
+
 ## [1.7.0] - 2021-03-24
 
 ### Added

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -614,7 +614,7 @@ macro_rules! use_signed_duration {
             $ty:ty; $converter:ident =>
             $({
                 $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident)*
+                $($tbound:ident: $bound:ident $(,)?)*
             })*
         }
     ) => {

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -286,10 +286,10 @@ macro_rules! use_signed_duration {
     (
         $main_trait:ident $internal_trait:ident =>
         {
-            $ty:ty; $converter:ident =>
+            $ty:ty =>
             $({
                 $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident)*
+                $($tbound:ident: $bound:ident $(,)?)*
             })*
         }
     ) => {
@@ -323,7 +323,7 @@ use_signed_duration!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; to_std_duration =>
+        Duration =>
         {u64, STRICTNESS => STRICTNESS: Strictness}
         {f64, STRICTNESS => STRICTNESS: Strictness}
         {String, STRICTNESS => STRICTNESS: Strictness}
@@ -335,7 +335,7 @@ use_signed_duration!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; to_std_duration =>
+        Duration =>
         {f64, STRICTNESS => STRICTNESS: Strictness}
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
@@ -347,7 +347,7 @@ use_signed_duration!(
     TimestampMicroSeconds DurationMicroSeconds,
     TimestampNanoSeconds DurationNanoSeconds,
     => {
-        SystemTime; to_system_time =>
+        SystemTime =>
         {i64, STRICTNESS => STRICTNESS: Strictness}
         {f64, STRICTNESS => STRICTNESS: Strictness}
         {String, STRICTNESS => STRICTNESS: Strictness}
@@ -359,7 +359,7 @@ use_signed_duration!(
     TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        SystemTime; to_system_time =>
+        SystemTime =>
         {f64, STRICTNESS => STRICTNESS: Strictness}
         {String, STRICTNESS => STRICTNESS: Strictness}
     }


### PR DESCRIPTION
This implements the range of milli, micro, and nano variants for
TimestampSeconds and DurationSeconds types.
This was left missing from #194.

The new implementations are still missing tests.

Closes #194