### PR TITLE
Implement new adapter PicKFirst, picking between multiple deserialization options

### DIFF
--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -898,7 +898,148 @@ where
         match h {
             Helper::One(one) => Ok(vec![one.into_inner()]),
             Helper::Many(many) => Ok(many.into_inner()),
-            _ => unreachable!(),
+            Helper::_JustAMarkerForTheLifetime(_) => unreachable!(),
+        }
+    }
+}
+
+impl<'de, T, TAs1> DeserializeAs<'de, T> for PickFirst<(TAs1,)>
+where
+    TAs1: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(DeserializeAsWrap::<T, TAs1>::deserialize(deserializer)?.into_inner())
+    }
+}
+
+impl<'de, T, TAs1, TAs2> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2)>
+where
+    TAs1: DeserializeAs<'de, T>,
+    TAs2: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(
+            untagged,
+            bound(deserialize = r#"
+            DeserializeAsWrap<T, TAs1>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs2>: Deserialize<'de>,
+        "#),
+            expecting = "// TODO"
+        )]
+        enum Helper<'a, T, TAs1, TAs2>
+        where
+            TAs1: DeserializeAs<'a, T>,
+            TAs2: DeserializeAs<'a, T>,
+        {
+            First(DeserializeAsWrap<T, TAs1>),
+            Second(DeserializeAsWrap<T, TAs2>),
+            #[serde(skip)]
+            _JustAMarkerForTheLifetime(PhantomData<&'a u32>),
+        }
+
+        let h: Helper<'de, T, TAs1, TAs2> = Deserialize::deserialize(deserializer)?;
+        match h {
+            Helper::First(first) => Ok(first.into_inner()),
+            Helper::Second(second) => Ok(second.into_inner()),
+            Helper::_JustAMarkerForTheLifetime(_) => unreachable!(),
+        }
+    }
+}
+
+impl<'de, T, TAs1, TAs2, TAs3> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2, TAs3)>
+where
+    TAs1: DeserializeAs<'de, T>,
+    TAs2: DeserializeAs<'de, T>,
+    TAs3: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(
+            untagged,
+            bound(deserialize = r#"
+            DeserializeAsWrap<T, TAs1>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs2>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs3>: Deserialize<'de>,
+        "#),
+            expecting = "// TODO"
+        )]
+        enum Helper<'a, T, TAs1, TAs2, TAs3>
+        where
+            TAs1: DeserializeAs<'a, T>,
+            TAs2: DeserializeAs<'a, T>,
+            TAs3: DeserializeAs<'a, T>,
+        {
+            First(DeserializeAsWrap<T, TAs1>),
+            Second(DeserializeAsWrap<T, TAs2>),
+            Third(DeserializeAsWrap<T, TAs3>),
+            #[serde(skip)]
+            _JustAMarkerForTheLifetime(PhantomData<&'a u32>),
+        }
+
+        let h: Helper<'de, T, TAs1, TAs2, TAs3> = Deserialize::deserialize(deserializer)?;
+        match h {
+            Helper::First(first) => Ok(first.into_inner()),
+            Helper::Second(second) => Ok(second.into_inner()),
+            Helper::Third(third) => Ok(third.into_inner()),
+            Helper::_JustAMarkerForTheLifetime(_) => unreachable!(),
+        }
+    }
+}
+
+impl<'de, T, TAs1, TAs2, TAs3, TAs4> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2, TAs3, TAs4)>
+where
+    TAs1: DeserializeAs<'de, T>,
+    TAs2: DeserializeAs<'de, T>,
+    TAs3: DeserializeAs<'de, T>,
+    TAs4: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(
+            untagged,
+            bound(deserialize = r#"
+            DeserializeAsWrap<T, TAs1>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs2>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs3>: Deserialize<'de>,
+            DeserializeAsWrap<T, TAs4>: Deserialize<'de>,
+        "#),
+            expecting = "// TODO"
+        )]
+        enum Helper<'a, T, TAs1, TAs2, TAs3, TAs4>
+        where
+            TAs1: DeserializeAs<'a, T>,
+            TAs2: DeserializeAs<'a, T>,
+            TAs3: DeserializeAs<'a, T>,
+            TAs4: DeserializeAs<'a, T>,
+        {
+            First(DeserializeAsWrap<T, TAs1>),
+            Second(DeserializeAsWrap<T, TAs2>),
+            Third(DeserializeAsWrap<T, TAs3>),
+            Forth(DeserializeAsWrap<T, TAs4>),
+            #[serde(skip)]
+            _JustAMarkerForTheLifetime(PhantomData<&'a u32>),
+        }
+
+        let h: Helper<'de, T, TAs1, TAs2, TAs3, TAs4> = Deserialize::deserialize(deserializer)?;
+        match h {
+            Helper::First(first) => Ok(first.into_inner()),
+            Helper::Second(second) => Ok(second.into_inner()),
+            Helper::Third(third) => Ok(third.into_inner()),
+            Helper::Forth(forth) => Ok(forth.into_inner()),
+            Helper::_JustAMarkerForTheLifetime(_) => unreachable!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1495,3 +1495,7 @@ pub struct Bytes;
 /// ```
 #[derive(Copy, Clone, Debug, Default)]
 pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomData<(T, FORMAT)>);
+
+/// TODO
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PickFirst<T>(PhantomData<T>);

--- a/src/ser/impls.rs
+++ b/src/ser/impls.rs
@@ -440,3 +440,51 @@ where
         SerializeAsWrap::<Vec<T>, Vec<U>>::new(source).serialize(serializer)
     }
 }
+
+impl<T, TAs1> SerializeAs<T> for PickFirst<(TAs1,)>
+where
+    TAs1: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<T, TAs1>::new(source).serialize(serializer)
+    }
+}
+
+impl<T, TAs1, TAs2> SerializeAs<T> for PickFirst<(TAs1, TAs2)>
+where
+    TAs1: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<T, TAs1>::new(source).serialize(serializer)
+    }
+}
+
+impl<T, TAs1, TAs2, TAs3> SerializeAs<T> for PickFirst<(TAs1, TAs2, TAs3)>
+where
+    TAs1: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<T, TAs1>::new(source).serialize(serializer)
+    }
+}
+
+impl<T, TAs1, TAs2, TAs3, TAs4> SerializeAs<T> for PickFirst<(TAs1, TAs2, TAs3, TAs4)>
+where
+    TAs1: SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializeAsWrap::<T, TAs1>::new(source).serialize(serializer)
+    }
+}

--- a/tests/serde_as/lib.rs
+++ b/tests/serde_as/lib.rs
@@ -5,6 +5,7 @@
 
 mod default_on;
 mod map_tuple_list;
+mod pickfirst;
 mod serde_as_macro;
 mod time;
 #[path = "../utils.rs"]

--- a/tests/serde_as/pickfirst.rs
+++ b/tests/serde_as/pickfirst.rs
@@ -1,0 +1,125 @@
+use super::*;
+use serde_with::{CommaSeparator, PickFirst, SpaceSeparator, StringWithSeparator};
+
+#[test]
+fn test_pick_first_two() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "PickFirst<(_, DisplayFromStr)>")] u32);
+
+    is_equal(S(123), expect![[r#"123"#]]);
+    check_deserialization(S(123), r#""123""#);
+    check_error_deserialization::<S>(r#""Abc""#, expect![[r#"// TODO"#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S2(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] u32);
+
+    is_equal(S2(123), expect![[r#""123""#]]);
+    check_deserialization(S2(123), r#"123"#);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S3(
+        #[serde_as(as = "PickFirst<(_, StringWithSeparator::<SpaceSeparator, String>,)>")]
+        Vec<String>,
+    );
+    is_equal(
+        S3(vec!["A".to_string(), "B".to_string(), "C".to_string()]),
+        expect![[r#"
+            [
+              "A",
+              "B",
+              "C"
+            ]"#]],
+    );
+    check_deserialization(
+        S3(vec!["A".to_string(), "B".to_string(), "C".to_string()]),
+        r#""A B C""#,
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S4(
+        #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, _,)>")]
+        Vec<String>,
+    );
+    is_equal(
+        S4(vec!["A".to_string(), "B".to_string(), "C".to_string()]),
+        expect![[r#""A,B,C""#]],
+    );
+    check_deserialization(
+        S4(vec!["A".to_string(), "B".to_string(), "C".to_string()]),
+        r#"["A", "B", "C"]"#,
+    );
+}
+
+#[test]
+fn test_pick_first_three() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(
+        #[serde_as(
+            as = "PickFirst<(_, Vec<DisplayFromStr>, StringWithSeparator::<CommaSeparator, u32>)>"
+        )]
+        Vec<u32>,
+    );
+    is_equal(
+        S(vec![1, 2, 3]),
+        expect![[r#"
+        [
+          1,
+          2,
+          3
+        ]"#]],
+    );
+    check_deserialization(
+        S(vec![1, 2, 3]),
+        r#"
+        [
+          "1",
+          "2",
+          "3"
+        ]"#,
+    );
+    check_deserialization(S(vec![1, 2, 3]), r#""1,2,3""#);
+    check_error_deserialization::<S>(r#""Abc""#, expect![[r#"// TODO"#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S2(
+        #[serde_as(
+            as = "PickFirst<(StringWithSeparator::<CommaSeparator, u32>, _, Vec<DisplayFromStr>)>"
+        )]
+        Vec<u32>,
+    );
+    is_equal(S2(vec![1, 2, 3]), expect![[r#""1,2,3""#]]);
+    check_deserialization(
+        S2(vec![1, 2, 3]),
+        r#"
+        [
+          "1",
+          "2",
+          "3"
+        ]"#,
+    );
+    check_deserialization(
+        S2(vec![1, 2, 3]),
+        r#"
+        [
+          1,
+          2,
+          3
+        ]"#,
+    );
+}
+
+#[test]
+fn test_pick_first_four() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "PickFirst<(_, _, _, _)>")] u32);
+
+    is_equal(S(123), expect![[r#"123"#]]);
+    check_error_deserialization::<S>(r#""Abc""#, expect![[r#"// TODO"#]]);
+}


### PR DESCRIPTION
@pashadia I found some time to implement the `DeserializeOptions`  you proposed in #276.

I'm not quite happy with the name yet. I am thinking maybe something along those line:
* `Choose`
* `Choices`
* `PickFirst`

---

This was originally proposed in #276 under the name
`DeserializeOptions`.
The adapter takes 2-4 types and tries each in order. The first option
which deserializes is returned.

The type is still missing documentation.