### PR TITLE
Bump codecov action to 1.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
           args: "--workspace --all-features -- --test-threads 1"
           version: "latest"
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.4.0
+        uses: codecov/codecov-action@v1.4.1
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
 
   # Added to summarize the matrix (otherwise we would need to list every single


### PR DESCRIPTION
Version 1.4.0 is broken and cannot be used anymore, since it breaks the build due to a checksum mismatch error.

https://github.com/codecov/codecov-action/issues/289