### PR TITLE
Fix proc-macros were relying on the prelude to be available

### DIFF
--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Describe how the `serde_as` macro works on a high level.
+* The derive macros `SerializeDisplay` and `DeserializeFromStr` were relying on the prelude where they were used.
+    Properly name all types and traits required for the expanded code to work.
+    The tests were improved to be better able to catch such problems.
 
 ## [1.4.1] - 2021-02-16
 

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -823,7 +823,7 @@ fn deserialize_fromstr(input: DeriveInput, serde_with_crate_path: Path) -> Token
                     type Value = S;
 
                     fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        write!(formatter, "string")
+                        ::std::write!(formatter, "string")
                     }
 
                     fn visit_str<E>(self, value: &str) -> ::std::result::Result<Self::Value, E>
@@ -922,7 +922,7 @@ fn serialize_display(input: DeriveInput, serde_with_crate_path: Path) -> TokenSt
             where
                 S: #serde_with_crate_path::serde::Serializer,
             {
-                serializer.serialize_str(&self.to_string())
+                serializer.serialize_str(&::std::string::ToString::to_string(self))
             }
         }
     }

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -1,35 +1,24 @@
+//! Test that the derive macros properly name all the types and traits used
+
+// Ensure no prelude is available
+#![no_implicit_prelude]
 #![allow(dead_code)]
 
-use s_with::{DeserializeFromStr, SerializeDisplay};
-
-// We check that the macros result in valid code even in
-// absence of a FromStr import and with a clobbered Result type
-// Ensure that types from the environment do not infect the macro
-
-#[allow(unused_imports)]
-use crate::Option::*;
-mod std {}
-type Result = ();
-enum Option {
-    Some,
-    None(()),
-    Ok,
-    Err,
-}
+use ::s_with::{DeserializeFromStr, SerializeDisplay};
 
 #[derive(DeserializeFromStr, SerializeDisplay)]
-#[serde_with(crate = "s_with")]
+#[serde_with(crate = "::s_with")]
 struct A;
 
 impl ::std::str::FromStr for A {
-    type Err = String;
+    type Err = ::std::string::String;
     fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        unimplemented!()
+        ::std::unimplemented!()
     }
 }
 
 impl ::std::fmt::Display for A {
     fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        unimplemented!()
+        ::std::unimplemented!()
     }
 }

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -2,9 +2,11 @@
 
 // Ensure no prelude is available
 #![no_implicit_prelude]
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use ::s_with::{DeserializeFromStr, SerializeDisplay};
+// Needed for 1.45, unused in 1.50
+use ::std::panic;
 
 #[derive(DeserializeFromStr, SerializeDisplay)]
 #[serde_with(crate = "::s_with")]

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -1,32 +1,24 @@
+//! Test that flattened_maybe properly names all the types and traits used
+
+// Ensure no prelude is available
+#![no_implicit_prelude]
 #![allow(dead_code)]
 
-use s_with as serde_with;
-
-// Ensure that types from the environment do not infect the macro
-#[allow(unused_imports)]
-use crate::Option::*;
-mod std {}
-type Result = ();
-enum Option {
-    Some,
-    None(()),
-    Ok,
-    Err,
-}
+use ::s_with as serde_with;
 
 // The macro creates custom deserialization code.
 // You need to specify a function name and the field name of the flattened field.
-s_with::flattened_maybe!(deserialize_t, "t");
+::s_with::flattened_maybe!(deserialize_t, "t");
 // Setup the types
-#[derive(s::Deserialize, Debug)]
-#[serde(crate = "s")]
+#[derive(::s::Deserialize, Debug)]
+#[serde(crate = "::s")]
 struct S {
     #[serde(flatten, deserialize_with = "deserialize_t")]
     t: T,
 }
 
-#[derive(s::Deserialize, Debug)]
-#[serde(crate = "s")]
+#[derive(::s::Deserialize, Debug)]
+#[serde(crate = "::s")]
 struct T {
     i: i32,
 }
@@ -35,17 +27,17 @@ struct T {
 fn flattened_maybe() {
     // Supports both flattened
     let j = r#" {"i":1} "#;
-    assert!(s_json::from_str::<S>(j).is_ok());
+    ::std::assert!(::s_json::from_str::<S>(j).is_ok());
 
     // and non-flattened versions.
     let j = r#" {"t":{"i":1}} "#;
-    assert!(s_json::from_str::<S>(j).is_ok());
+    ::std::assert!(::s_json::from_str::<S>(j).is_ok());
 
     // Ensure that the value is given
     let j = r#" {} "#;
-    assert!(s_json::from_str::<S>(j).is_err());
+    ::std::assert!(::s_json::from_str::<S>(j).is_err());
 
     // and only occurs once, not multiple times.
     let j = r#" {"i":1,"t":{"i":1}} "#;
-    assert!(s_json::from_str::<S>(j).is_err());
+    ::std::assert!(::s_json::from_str::<S>(j).is_err());
 }

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -2,9 +2,11 @@
 
 // Ensure no prelude is available
 #![no_implicit_prelude]
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use ::s_with as serde_with;
+// Needed for 1.45, unused in 1.50
+use ::std::panic;
 
 // The macro creates custom deserialization code.
 // You need to specify a function name and the field name of the flattened field.

--- a/serde_with_test/tests/serde_as_crate_path.rs
+++ b/serde_with_test/tests/serde_as_crate_path.rs
@@ -1,26 +1,15 @@
 //! Test that the `serde_as(crate = "...")` argument allows compilation when the crate isn't
 //! available at path `::serde_with`
 
+#![no_implicit_prelude]
 #![allow(dead_code)]
 
-use s::{Deserialize, Serialize};
-use s_with::serde_as;
+use ::s::{Deserialize, Serialize};
+use ::s_with::serde_as;
 
-// Ensure that types from the environment do not infect the macro
-#[allow(unused_imports)]
-use crate::Option::*;
-mod std {}
-type Result = ();
-enum Option {
-    Some,
-    None(()),
-    Ok,
-    Err,
-}
-
-#[serde_as(crate = "s_with")]
+#[serde_as(crate = "::s_with")]
 #[derive(Deserialize, Serialize)]
-#[serde(crate = "s")]
+#[serde(crate = "::s")]
 struct Data {
     #[serde_as(as = "_")]
     a: u32,


### PR DESCRIPTION
Properly name all types and traits in the derive macros such that they do not conflict with the environment where they are used.

bors r+