### PR TITLE
NoneAsEmptyString: Deserialize using FromStr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* `NoneAsEmptyString`: Deserialize using `FromStr` instead of using `for<'a> From<&'a str>` (#316)
+
 ## [1.9.0] - 2021-05-09
 
 ### Added

--- a/tests/serde_as/lib.rs
+++ b/tests/serde_as/lib.rs
@@ -384,27 +384,6 @@ fn test_none_as_empty_string() {
 
     is_equal(S(None), expect![[r#""""#]]);
     is_equal(S(Some("Hello".to_string())), expect![[r#""Hello""#]]);
-
-    #[serde_as]
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct SRc(#[serde_as(as = "NoneAsEmptyString")] Option<Rc<str>>);
-
-    is_equal(SRc(None), expect![[r#""""#]]);
-    is_equal(SRc(Some("Hello".into())), expect![[r#""Hello""#]]);
-
-    #[serde_as]
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct SArc(#[serde_as(as = "NoneAsEmptyString")] Option<Arc<str>>);
-
-    is_equal(SArc(None), expect![[r#""""#]]);
-    is_equal(SArc(Some("Hello".into())), expect![[r#""Hello""#]]);
-
-    #[serde_as]
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct SBox(#[serde_as(as = "NoneAsEmptyString")] Option<Box<str>>);
-
-    is_equal(SBox(None), expect![[r#""""#]]);
-    is_equal(SBox(Some("Hello".into())), expect![[r#""Hello""#]]);
 }
 
 #[test]


### PR DESCRIPTION
The docs for `NoneAsEmptyString` are wrong. For deserialization `for<'a> From<&'a str>` is used instead of `FromStr`.

In my case, only `FromStr` is available, so I have to use `rust::string_empty_as_none` instead. Those docs advertise identical functionality using `NoneAsEmptyString`, so that advertisement either needs to be removed or `NoneAsEmptyStrings` functionality adjusted.

Which would you prefer?

PS: Thanks for this awesome project! :)