### PR TITLE
`serde_conv`: Allow `clippy::ptr_arg`

### DIFF
--- a/src/serde_conv.rs
+++ b/src/serde_conv.rs
@@ -103,6 +103,7 @@ macro_rules! serde_conv {
         #[allow(non_camel_case_types)]
         $vis struct $m;
 
+        #[allow(clippy::ptr_arg)]
         impl $m {
             $vis fn serialize<S>(x: &$t, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
             where


### PR DESCRIPTION
With `String` as `t`, `&String` would trigger [`clippy::ptr_arg`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg).

What do you think?