### PR TITLE
Bytes const size borrowed arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* The `Bytes` type now supports borrowed and Cow arrays of fixed size (requires Rust 1.51+)
+
+    ```rust
+    #[serde_as(as = "Bytes")]
+    #[serde(borrow)]
+    borrowed_array: &'a [u8; 15],
+    #[serde_as(as = "Bytes")]
+    #[serde(borrow)]
+    cow_array: Cow<'a, [u8; 15]>,
+    ```
+
+    Note: For borrowed arrays the used Deserializer needs to support Serde's 0-copy deserialization.
+
 ## [1.9.2] - 2021-06-07
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1333,11 +1333,13 @@ pub struct TimestampNanoSecondsWithFrac<
 /// The type provides de-/serialization for these types:
 ///
 /// * `[u8; N]`, Rust 1.51+, not possible using `serde_bytes`
+/// * `&[u8; N]`, Rust 1.51+, not possible using `serde_bytes`
 /// * `&[u8]`
 /// * `Box<[u8; N]>`, Rust 1.51+, not possible using `serde_bytes`
 /// * `Box<[u8]>`
 /// * `Vec<u8>`
 /// * `Cow<'_, [u8]>`
+/// * `Cow<'_, [u8; N]>`, Rust 1.51+, not possible using `serde_bytes`
 ///
 /// # Examples
 ///
@@ -1359,6 +1361,10 @@ pub struct TimestampNanoSecondsWithFrac<
 ///     #[serde_as(as = "Bytes")]
 ///     #[serde(borrow)]
 ///     cow: Cow<'a, [u8]>,
+/// #   #[cfg(FALSE)]
+///     #[serde_as(as = "Bytes")]
+///     #[serde(borrow)]
+///     cow_array: Cow<'a, [u8; 15]>,
 ///     #[serde_as(as = "Bytes")]
 ///     vec: Vec<u8>,
 /// }
@@ -1368,16 +1374,19 @@ pub struct TimestampNanoSecondsWithFrac<
 ///     array: b"0123456789ABCDE".clone(),
 ///     boxed: b"...".to_vec().into_boxed_slice(),
 ///     cow: Cow::Borrowed(b"FooBar"),
+/// #   #[cfg(FALSE)]
+///     cow_array: Cow::Borrowed(&[42u8; 15]),
 ///     vec: vec![0x41, 0x61, 0x21],
 /// };
 /// let expected = r#"(
 ///     array: "MDEyMzQ1Njc4OUFCQ0RF",
 ///     boxed: "Li4u",
 ///     cow: "Rm9vQmFy",
+///     cow_array: "KioqKioqKioqKioqKioq",
 ///     vec: "QWEh",
 /// )"#;
 /// # drop(expected);
-/// # // Create a fake expected value without the array to make the test compile without const generics
+/// # // Create a fake expected value that doesn't use const generics
 /// # let expected = r#"(
 /// #     boxed: "Li4u",
 /// #     cow: "Rm9vQmFy",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1400,6 +1400,50 @@ pub struct TimestampNanoSecondsWithFrac<
 /// # }
 /// ```
 ///
+/// Fully borrowed types can also be used but you'll need a Deserializer that
+/// supports Serde's 0-copy deserialization:
+///
+/// ```
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_with::{serde_as, Bytes};
+/// # use std::borrow::Cow;
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct TestBorrows<'a> {
+/// #   #[cfg(FALSE)]
+///     #[serde_as(as = "Bytes")]
+///     #[serde(borrow)]
+///     array_buf: &'a [u8; 15],
+///     #[serde_as(as = "Bytes")]
+///     #[serde(borrow)]
+///     buf: &'a [u8],
+/// }
+///
+/// let value = TestBorrows {
+/// #   #[cfg(FALSE)]
+///     array_buf: &[10u8; 15],
+///     buf: &[20u8, 21u8, 22u8],
+/// };
+/// let expected = r#"(
+///     array_buf: "CgoKCgoKCgoKCgoKCgoK",
+///     buf: "FBUW",
+/// )"#;
+/// # drop(expected);
+/// # // Create a fake expected value that doesn't use const generics
+/// # let expected = r#"(
+/// #     buf: "FBUW",
+/// # )"#;
+///
+/// # let pretty_config = ron::ser::PrettyConfig::new()
+/// #     .with_new_line("\n".into());
+/// assert_eq!(expected, ron::ser::to_string_pretty(&value, pretty_config).unwrap());
+/// // RON doesn't support borrowed deserialization of byte arrays
+/// # }
+/// ```
+///
 /// ## Alternative to [`BytesOrString`]
 ///
 /// The [`Bytes`] can replace [`BytesOrString`].

--- a/src/ser/const_arrays.rs
+++ b/src/ser/const_arrays.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use super::*;
 use std::collections::{BTreeMap, HashMap};
 
@@ -52,11 +53,29 @@ impl<'a, const N: usize> SerializeAs<[u8; N]> for Bytes {
     }
 }
 
+impl<'a, const N: usize> SerializeAs<&[u8; N]> for Bytes {
+    fn serialize_as<S>(bytes: &&[u8; N], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(*bytes)
+    }
+}
+
 impl<'a, const N: usize> SerializeAs<Box<[u8; N]>> for Bytes {
     fn serialize_as<S>(bytes: &Box<[u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         serializer.serialize_bytes(&**bytes)
+    }
+}
+
+impl<'a, const N: usize> SerializeAs<Cow<'a, [u8; N]>> for Bytes {
+    fn serialize_as<S>(bytes: &Cow<'a, [u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes.as_ref())
     }
 }


### PR DESCRIPTION
Currently `Bytes` (added in #277) supports some const size array types (e.g. `[u8; N]` and `Box<[u8; N]>`)
but not others (e.g. `&[u8; N]` and `Cow<'_, [u8; N]>`).

This pull request implements `Bytes` support for `&[u8; N]` and `Cow<'_, [u8; N]>`
This bring parity between dynamic and const sized types.

### Before:

| Sizing  | Owned          | Borrowed      | Cow                   | Box               |
| ------- | -------------- | ------------- | --------------------- | ----------------- |
| Const   | ✅ `[u8; N]`   | ❌ `&[u8; N]` | ❌ `Cow<'_, [u8; N]>` | ✅ `Box<[u8; N]>` |
| Dynamic | ✅ `Vec<u8>`\* | ✅ `&[u8]`    | ✅ `Cow<'_, [u8]>`    | ✅ `Box<[u8]>`    |

### After:

| Sizing  | Owned          | Borrowed      | Cow                   | Box               |
| ------- | -------------- | ------------- | --------------------- | ----------------- |
| Const   | ✅ `[u8; N]`   | ✅ `&[u8; N]` | ✅ `Cow<'_, [u8; N]>` | ✅ `Box<[u8; N]>` |
| Dynamic | ✅ `Vec<u8>`\* | ✅ `&[u8]`    | ✅ `Cow<'_, [u8]>`    | ✅ `Box<[u8]>`    |

I've also added a separate commit with an example of using fully borrowed types, but that example only does serialization
because RON doesn't support 0-copy deserialization for byte arrays (as it needs to decode them from base64).
Because of that I'm not sure if this example is useful so feel free to merge only the main commit.

<sub>\* Technically `[u8]` corresponds to `[u8; N]` but `[u8]` is an un`Sized` type and cannot be
directly used in structs.</sub>