### PR TITLE
Ignore compiler-messages test on beta

### DIFF
--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,7 +1,8 @@
 // This test fails for older compiler versions since the error messages are different.
 #[rustversion::attr(before(1.43), ignore)]
 #[cfg_attr(tarpaulin, ignore)]
-// The error messages are more detailed on nightly, thus breaking the test.
+// The error messages are different on beta and nightly, thus breaking the test.
+#[rustversion::attr(beta, ignore)]
 #[rustversion::attr(nightly, ignore)]
 #[test]
 fn compile_test() {


### PR DESCRIPTION
Rust beta has more detailed error messages than stable, making the test fail.

bors r+