### PR TITLE
Make use of nightly features to improve the documentation on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,11 @@ required-features = ["macros"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = [
+    # Enable doc_cfg showing the required features.
+    "--cfg=docsrs",
+    # Generate links to definition in rustdoc source code pages
+    # https://github.com/rust-lang/rust/pull/84176
+    "-Zunstable-options", "--generate-link-to-definition"
+]
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Some common use cases are:
 
 * De/Serializing a type using the `Display` and `FromStr` traits, e.g., for `u8`, `url::Url`, or `mime::Mime`.
      Check [`DisplayFromStr`][] or [`serde_with::rust::display_fromstr`][display_fromstr] for details.
+* Support for arrays larger than 32 elements or using const generics.
+    With `serde_as` large arrays are supported, even if they are nested in other types.
+    `[bool; 64]`, `Option<[u8; M]>`, and `Box<[[u8; 64]; N]>` are all supported, as [this examples shows](#large-and-const-generic-arrays).
 * Skip serializing all empty `Option` types with [`#[skip_serializing_none]`][skip_serializing_none].
 * Apply a prefix to each field name of a struct, without changing the de/serialize implementations of the struct using [`with_prefix!`][].
 * Deserialize a comma separated list like `#hash,#tags,#are,#great` into a `Vec<String>`.
@@ -57,6 +60,32 @@ Foo {bar: 12}
 
 // into this JSON
 {"bar": "12"}
+```
+
+### Large and const-generic arrays
+
+serde does not support arrays with more than 32 elements or using const-generics.
+The `serde_as` attribute allows to circumvent this restriction, even for nested types and nested arrays.
+
+```rust
+#[serde_as]
+#[derive(Deserialize, Serialize)]
+struct Arrays<const N: usize, const M: usize> {
+    #[serde_as(as = "[_; N]")]
+    constgeneric: [bool; N],
+    #[serde_as(as = "Box<[[_; 64]; N]>")]
+    nested: Box<[[u8; 64]; N]>,
+    #[serde_as(as = "Option<[_; M]>")]
+    optional: Option<[u8; M]>,
+}
+
+// This allows us to serialize a struct like this
+let arrays = Arrays {
+    constgeneric: [true; 100],
+    nested: Box::new([[111; 64]; 100]),
+    optional: Some([222; 128])
+};
+assert!(serde_json::to_string(&arrays).is_ok());
 ```
 
 ### `skip_serializing_none`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@
 //! The `serde_as` attribute allows to circumvent this restriction, even for nested types and nested arrays.
 //!
 //! ```rust
+//! # #[cfg(FALSE)] {
 //! # #[cfg(feature = "macros")]
 //! # use serde::{Deserialize, Serialize};
 //! # #[cfg(feature = "macros")]
@@ -139,6 +140,7 @@
 //!     optional: Some([222; 128])
 //! };
 //! assert!(serde_json::to_string(&arrays).is_ok());
+//! # }
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 #![allow(renamed_and_removed_lints)]
 // Rust 1.45: introduction of `strip_prefix` used by clippy::manual_strip
 #![allow(clippy::unknown_clippy_lints)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! [![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)
 //! [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
@@ -214,14 +215,17 @@
 pub extern crate serde;
 
 #[cfg(feature = "chrono")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod chrono;
 pub mod de;
 mod duplicate_key_impls;
 mod flatten_maybe;
 pub mod formats;
 #[cfg(feature = "hex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hex")))]
 pub mod hex;
 #[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
 pub mod rust;
 pub mod ser;
@@ -273,6 +277,7 @@ pub use crate::{de::DeserializeAs, rust::StringWithSeparator, ser::SerializeAs};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Re-Export all proc_macros, as these should be seen as part of the serde_with crate
 #[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 #[doc(inline)]
 pub use serde_with_macros::*;
 use std::marker::PhantomData;


### PR DESCRIPTION
* Add doc_cfg annotations
* Generate links to definitions on the src pages.

Also document in the README/main doc page how to use `serde_as` for large arrays/const generic arrays.

bors +