### PR TITLE
Bump MSRV to 1.46

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         # It is good to test more than the MSRV and stable since sometimes
         # breakage occurs in intermediate versions.
-        rust: ["1.40.0", "1.45.2", "1.50.0", "stable", "beta", "nightly"]
+        rust: ["1.46", "1.50", "stable", "beta", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed
+
+* Bump MSRV to 1.46, since the dev-dependency bitflags requires that version now.
+
 ## [1.9.4] - 2021-06-18
 
 ### Fixed

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -30,9 +30,7 @@
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Necessary for nightly clippy lints
-// False positive in current clippy nightlies clippy::nonstandard_macro_braces
-// https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::unknown_clippy_lints, clippy::nonstandard_macro_braces)]
+#![allow(clippy::unknown_clippy_lints)]
 
 //! proc-macro extensions for [`serde_with`].
 //!

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code, unused_imports)]
 
 use ::s_with::{DeserializeFromStr, SerializeDisplay};
-// Needed for 1.45, unused in 1.50
+// Needed for 1.46, unused in 1.50
 use ::std::panic;
 
 #[derive(DeserializeFromStr, SerializeDisplay)]

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code, unused_imports)]
 
 use ::s_with as serde_with;
-// Needed for 1.45, unused in 1.50
+// Needed for 1.46, unused in 1.50
 use ::std::panic;
 
 // The macro creates custom deserialization code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,6 @@
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
 #![doc(html_root_url = "https://docs.rs/serde_with/1.9.4")]
-// Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
-#![allow(renamed_and_removed_lints)]
-// Rust 1.45: introduction of `strip_prefix` used by clippy::manual_strip
-#![allow(clippy::unknown_clippy_lints)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! [![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)

--- a/src/with_prefix.rs
+++ b/src/with_prefix.rs
@@ -492,16 +492,15 @@ where
 {
     type Error = A::Error;
 
-    // Use `strip_prefix` with Rust 1.45
-    #[allow(clippy::manual_strip)]
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
         K: DeserializeSeed<'de>,
     {
         while let Some(s) = self.delegate.next_key::<String>()? {
-            if s.starts_with(self.prefix) {
-                let without_prefix = s[self.prefix.len()..].into_deserializer();
-                return seed.deserialize(without_prefix).map(Some);
+            if let Some(without_prefix) = s.strip_prefix(self.prefix) {
+                return seed
+                    .deserialize(without_prefix.into_deserializer())
+                    .map(Some);
             }
             self.delegate.next_value::<IgnoredAny>()?;
         }
@@ -584,8 +583,6 @@ where
 {
     type Error = A::Error;
 
-    // Use `strip_prefix` with Rust 1.45
-    #[allow(clippy::manual_strip)]
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
         K: DeserializeSeed<'de>,
@@ -595,9 +592,10 @@ where
             return seed.deserialize(without_prefix).map(Some);
         }
         while let Some(s) = self.delegate.next_key::<String>()? {
-            if s.starts_with(self.prefix) {
-                let without_prefix = s[self.prefix.len()..].into_deserializer();
-                return seed.deserialize(without_prefix).map(Some);
+            if let Some(without_prefix) = s.strip_prefix(self.prefix) {
+                return seed
+                    .deserialize(without_prefix.into_deserializer())
+                    .map(Some);
             }
             self.delegate.next_value::<IgnoredAny>()?;
         }

--- a/tests/serde_as/lib.rs
+++ b/tests/serde_as/lib.rs
@@ -1,8 +1,3 @@
-// Nightly clippy contains upper_case_acronyms, unknown in older versions
-// but clippy::unknown_clippy_lints is not accepted on nightly anymore (thus the other allows).
-#![allow(unknown_lints, renamed_and_removed_lints, clippy::unknown_clippy_lints)]
-#![allow(clippy::upper_case_acronyms)]
-
 mod default_on;
 mod frominto;
 mod map_tuple_list;

--- a/tests/serde_as/map_tuple_list.rs
+++ b/tests/serde_as/map_tuple_list.rs
@@ -152,12 +152,12 @@ fn test_tuple_list_as_map() {
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct SLL(
+    struct Sll(
         #[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")] LinkedList<(u32, IpAddr)>,
     );
 
     is_equal(
-        SLL(vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect()),
+        Sll(vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect()),
         expect![[r#"
             {
               "1": "1.2.3.4",

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::Debug;
 
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn is_equal<T>(value: T, expected: Expect)
 where
     T: Debug + DeserializeOwned + PartialEq + Serialize,
@@ -21,7 +21,7 @@ where
 }
 
 /// Like [`is_equal`] but not pretty-print
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn is_equal_compact<T>(value: T, expected: Expect)
 where
     T: Debug + DeserializeOwned + PartialEq + Serialize,
@@ -35,7 +35,7 @@ where
     );
 }
 
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn check_deserialization<T>(value: T, deserialize_from: &str)
 where
     T: Debug + DeserializeOwned + PartialEq,
@@ -47,7 +47,7 @@ where
     );
 }
 
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn check_serialization<T>(value: T, serialize_to: Expect)
 where
     T: Debug + Serialize,
@@ -55,7 +55,7 @@ where
     serialize_to.assert_eq(&serde_json::to_string_pretty(&value).unwrap());
 }
 
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn check_error_serialization<T>(value: T, error_msg: Expect)
 where
     T: Debug + Serialize,
@@ -67,7 +67,7 @@ where
     );
 }
 
-#[rustversion::attr(since(1.46), track_caller)]
+#[track_caller]
 pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: Expect)
 where
     T: Debug + DeserializeOwned,


### PR DESCRIPTION
The dev-dependency bitflags changed the MSRV, so bump it here too to make CI pass.