### PR TITLE
`--test-threads 1` is broken on tarpaulin 0.18.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.rust == 'stable'  && matrix.os == 'ubuntu-latest'
         with:
           # tarpaulin already runs with --all-targets
-          args: "--workspace --all-features -- --test-threads 1"
+          args: "--workspace --all-features -- --test-threads=1"
           version: "latest"
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2.0.3


### PR DESCRIPTION
But using an `=` sign works.

https://github.com/xd009642/tarpaulin/issues/819

bors merge