### PR TITLE
Remove docs.rs badge, since it no longer shows the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Custom de/serialization functions for Rust's [serde](https://serde.rs)
 
-[![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)
 [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
 [![Build Status](https://github.com/jonasbb/serde_with/workflows/Rust%20CI/badge.svg)](https://github.com/jonasbb/serde_with)
 [![codecov](https://codecov.io/gh/jonasbb/serde_with/branch/master/graph/badge.svg)](https://codecov.io/gh/jonasbb/serde_with)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 #![doc(html_root_url = "https://docs.rs/serde_with/1.10.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-//! [![docs.rs badge](https://docs.rs/serde_with/badge.svg)](https://docs.rs/serde_with/)
 //! [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
 //! [![Build Status](https://github.com/jonasbb/serde_with/workflows/Rust%20CI/badge.svg)](https://github.com/jonasbb/serde_with)
 //! [![codecov](https://codecov.io/gh/jonasbb/serde_with/branch/master/graph/badge.svg)](https://codecov.io/gh/jonasbb/serde_with)


### PR DESCRIPTION
The docs.rs is no longer useful, since it now just forwards to
shields.io and contains no useful information, i.e., the current version
on docs.rs.

https://github.com/rust-lang/docs.rs/pull/1362

bors merge