### PR TITLE
unit tests for string_empty_as_none

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1056,20 +1056,6 @@ pub mod string_empty_as_none {
                 }
             }
 
-            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                deserializer.deserialize_any(OptionStringEmptyNone(PhantomData))
-            }
-
-            fn visit_none<E>(self) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Ok(None)
-            }
-
             // handles the `null` case
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1056,6 +1056,20 @@ pub mod string_empty_as_none {
                 }
             }
 
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_any(OptionStringEmptyNone(PhantomData))
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(None)
+            }
+
             // handles the `null` case
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -6,6 +6,7 @@ use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use pretty_assertions::assert_eq;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_test::{assert_tokens, Token};
 use serde_with::CommaSeparator;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet, LinkedList, VecDeque};
@@ -602,10 +603,20 @@ fn tuple_list_as_map_vecdeque() {
 fn test_string_empty_as_none() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
     struct S(#[serde(with = "serde_with::rust::string_empty_as_none", default)] Option<String>);
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct Q(
+        #[serde(
+            deserialize_with = "serde_with::rust::string_empty_as_none::deserialize",
+            default
+        )]
+        Option<String>,
+    );
 
     is_equal(S(Some("str".to_string())), expect![[r#""str""#]]);
     check_deserialization(S(None), r#""""#);
     check_deserialization(S(None), r#"null"#);
+
+    assert_tokens(&Q(None), &[Token::NewtypeStruct { name: "Q" }, Token::None]);
 }
 
 #[test]

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -602,6 +602,7 @@ fn tuple_list_as_map_vecdeque() {
 fn test_string_empty_as_none() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
     struct S(#[serde(with = "serde_with::rust::string_empty_as_none", default)] Option<String>);
+
     is_equal(S(Some("str".to_string())), expect![[r#""str""#]]);
     check_deserialization(S(None), r#""""#);
     check_deserialization(S(None), r#"null"#);

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -599,6 +599,16 @@ fn tuple_list_as_map_vecdeque() {
 }
 
 #[test]
+fn test_string_empty_as_none() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "serde_with::rust::string_empty_as_none", default)] Option<String>);
+
+    is_equal(S(Some("str".to_string())), expect![[r#""str""#]]);
+    check_deserialization(S(None), r#""""#);
+    check_deserialization(S(None), r#"null"#);
+}
+
+#[test]
 fn test_default_on_error() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
     struct S<T>(#[serde(with = "serde_with::rust::default_on_error")] T)

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -6,7 +6,6 @@ use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use pretty_assertions::assert_eq;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_test::{assert_tokens, Token};
 use serde_with::CommaSeparator;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet, LinkedList, VecDeque};
@@ -603,20 +602,9 @@ fn tuple_list_as_map_vecdeque() {
 fn test_string_empty_as_none() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
     struct S(#[serde(with = "serde_with::rust::string_empty_as_none", default)] Option<String>);
-    #[derive(Debug, PartialEq, Deserialize, Serialize)]
-    struct Q(
-        #[serde(
-            deserialize_with = "serde_with::rust::string_empty_as_none::deserialize",
-            default
-        )]
-        Option<String>,
-    );
-
     is_equal(S(Some("str".to_string())), expect![[r#""str""#]]);
     check_deserialization(S(None), r#""""#);
     check_deserialization(S(None), r#"null"#);
-
-    assert_tokens(&Q(None), &[Token::NewtypeStruct { name: "Q" }, Token::None]);
 }
 
 #[test]

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -601,7 +601,7 @@ fn tuple_list_as_map_vecdeque() {
 #[test]
 fn test_string_empty_as_none() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
-    struct S(#[serde(with = "serde_with::rust::string_empty_as_none", default)] Option<String>);
+    struct S(#[serde(with = "serde_with::rust::string_empty_as_none")] Option<String>);
 
     is_equal(S(Some("str".to_string())), expect![[r#""str""#]]);
     check_deserialization(S(None), r#""""#);


### PR DESCRIPTION
Deserialize `OptionStringEmptyNone` from Some and None too, not just from unit
`visit_some` and `visit_none` implemented for `OptionStringEmptyNone`'s Visitor
unit tests for `string_empty_as_none` added

