### PR TITLE
Specify MSRV in Cargo.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,8 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         # It is good to test more than the MSRV and stable since sometimes
         # breakage occurs in intermediate versions.
-        rust: ["1.46", "1.50", "stable", "beta", "nightly"]
+        # IMPORTANT: Synchronize the MSRV with the Cargo.toml values.
+        rust: ["1.46", "1.50", "1.55", "stable", "beta", "nightly"]
         crate: ["serde_with", "serde_with_macros", "serde_with_test"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
 ]
 name = "serde_with"
 version = "1.10.0"
+rust-version = "1.46"
 
 categories = ["encoding"]
 description = "Custom de/serialization functions for Rust's serde"

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Jonas Bushart"]
 name = "serde_with_macros"
 version = "1.5.0"
+rust-version = "1.46"
 
 categories = ["encoding"]
 description = "proc-macro library for serde_with"

--- a/serde_with_test/Cargo.toml
+++ b/serde_with_test/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2018"
 name = "serde_with_test"
 publish = false
 version = "0.0.0"
+rust-version = "1.46"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This will be stabilized with Rust 1.56, see
* https://github.com/rust-lang/rust/issues/65262
* https://github.com/rust-lang/cargo/pull/9732

For older cargo versions, this will print a warning, but will not fail
the build/check/test.