### PR TITLE
Turn deny lints into warn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ This repository provides a devcontainer setup, which can be used with VS Code or
     * A changelog entry can also be added.
 3. Contributions must pass `cargo clippy` and `cargo fmt`.
     This is also checked by CI and needs to pass before the PR can be merged.
+    The CI does not allow any warnings in the compiled code.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1,8 +1,10 @@
-#![deny(
+#![warn(
+    clippy::semicolon_if_nothing_returned,
     missing_copy_implementations,
     // missing_crate_level_docs, not available in MSRV
     missing_debug_implementations,
     missing_docs,
+    rust_2018_idioms,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -10,7 +12,6 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![warn(rust_2018_idioms)]
 #![doc(test(attr(forbid(unsafe_code))))]
 #![doc(test(attr(deny(
     missing_copy_implementations,

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1,9 +1,11 @@
 #![forbid(unsafe_code)]
-#![deny(
+#![warn(
+    clippy::semicolon_if_nothing_returned,
     missing_copy_implementations,
     // missing_crate_level_docs, not available in MSRV
     missing_debug_implementations,
     missing_docs,
+    rust_2018_idioms,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -11,7 +13,6 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![warn(rust_2018_idioms)]
 #![doc(test(attr(forbid(unsafe_code))))]
 #![doc(test(attr(deny(
     missing_copy_implementations,


### PR DESCRIPTION
This makes local development easier, since warnings do not fail
compilation.
On CI all warnings are denied anyway, so it will not pass.

Closes #386 

bors merge