### PR TITLE
Remove unmaintained actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,6 +12,11 @@ on:
     - trying
   schedule:
     - cron: '0 0 * * *'
+
+# Allow the action to post about found problems
+permissions:
+  issues: write
+
 jobs:
   security_audit:
     name: Rustsec Audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,31 +28,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: clippy
+      - name: "Install/Update the Rust version"
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy
+          rustup default ${{ matrix.rust }}
+          cargo --version
+          rustc --version
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/clippy-check@v1
-        name: clippy "No Default Features" (${{ matrix.os }} / ${{ matrix.rust }})
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --no-default-features --all-targets -- -D warnings
-          name: clippy "No Default Features" (${{ matrix.os }} / ${{ matrix.rust }})
-      - uses: actions-rs/clippy-check@v1
-        name: clippy "Default" (${{ matrix.os }} / ${{ matrix.rust }})
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets -- -D warnings
-          name: clippy "Default" (${{ matrix.os }} / ${{ matrix.rust }})
-      - uses: actions-rs/clippy-check@v1
-        name: clippy "All Features" (${{ matrix.os }} / ${{ matrix.rust }})
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features --all-targets -- -D warnings
-          name: clippy "All Features" (${{ matrix.os }} / ${{ matrix.rust }})
+      - name: clippy "No Default Features" (${{ matrix.os }} / ${{ matrix.rust }})
+        run: cargo clippy --workspace --no-default-features --all-targets
+      - name: clippy "Default" (${{ matrix.os }} / ${{ matrix.rust }})
+        run: cargo clippy --workspace --all-targets
+      - name: clippy "All Features" (${{ matrix.os }} / ${{ matrix.rust }})
+        run: cargo clippy --workspace --all-features --all-targets
 
   rustfmt:
     name: Rustfmt
@@ -63,17 +51,14 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        name: Rustfmt Check (${{ matrix.rust }})
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: "Install/Update the Rust version"
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt
+          rustup default ${{ matrix.rust }}
+          cargo --version
+          rustc --version
+      - name: Rustfmt Check (${{ matrix.rust }})
+        run: cargo fmt --all -- --check
 
   build_and_test:
     name: Build and Test
@@ -88,79 +73,44 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+      - name: "Install/Update the Rust version"
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+          rustup default ${{ matrix.rust }}
+          cargo --version
+          rustc --version
       - uses: Swatinem/rust-cache@v1
 
       # Build the project
-      - uses: actions-rs/cargo@v1
-        name: "Build (${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        if: matrix.rust != 'nightly'
-        with:
-          command: build
-          args: --all-features --all-targets --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Build (${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        if: matrix.rust == 'nightly'
-        with:
-          command: build
-          # https://github.com/rust-lang/cargo/issues/8088 for unstable-options
-          args: --all-features --all-targets --manifest-path=${{ matrix.crate }}/Cargo.toml -Zunstable-options -Zfeatures=dev_dep,host_dep
+      - name: "Build (${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo build --all-features --all-targets --manifest-path=${{ matrix.crate }}/Cargo.toml
 
       # The tests are split into build and run steps, to see the time impact of each
       # cargo test --all-targets does NOT run doctests
       # since doctests are important this should not be added
       # https://github.com/rust-lang/cargo/issues/6669
-      - uses: actions-rs/cargo@v1
-        name: "Test Build (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          # We need to specify the manifest path, such that cargo knows where to apply the `no-default-features`.
-          # This is no longer necessary for Rust 1.51 or resolver="2"
-          # https://doc.rust-lang.org/nightly/cargo/reference/features.html#resolver-version-2-command-line-flags
-          args: --no-default-features --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Test Run (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          args: --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Test Build (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          # We need to specify the manifest path, such that cargo knows where to apply the `no-default-features`.
-          # This is no longer necessary for Rust 1.51 or resolver="2"
-          # https://doc.rust-lang.org/nightly/cargo/reference/features.html#resolver-version-2-command-line-flags
-          args: --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Test Run (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          args: --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Test Build (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          # We need to specify the manifest path, such that cargo knows where to apply the `no-default-features`.
-          # This is no longer necessary for Rust 1.51 or resolver="2"
-          # https://doc.rust-lang.org/nightly/cargo/reference/features.html#resolver-version-2-command-line-flags
-          args: --all-features  --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: "Test Run (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        with:
-          command: test
-          args: --all-features --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+      #
+      # We need to specify the manifest path, such that cargo knows where to apply the `no-default-features`.
+      # This is no longer necessary for Rust 1.51 or resolver="2"
+      # https://doc.rust-lang.org/nightly/cargo/reference/features.html#resolver-version-2-command-line-flags
+      - name: "Test Build (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --no-default-features --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+      - name: "Test Run (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+      - name: "Test Build (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+      - name: "Test Run (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+      - name: "Test Build (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --all-features  --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+      - name: "Test Run (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo test --all-features --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
         if: matrix.rust == 'stable'  && matrix.os == 'ubuntu-latest'
-        with:
-          # tarpaulin already runs with --all-targets
-          args: "--workspace --all-features -- --test-threads=1"
-          version: "latest"
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out Xml --workspace --all-features -- --test-threads=1
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -5,6 +5,10 @@ on:
       - "macros-v*"
 name: Publish to crates.io
 
+# Limit to write releases
+permissions:
+  contents: write
+
 jobs:
   publish_serde_with:
     runs-on: ubuntu-latest
@@ -29,15 +33,14 @@ jobs:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./serde_with/CHANGELOG.md
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # This pulls from the "Get Changelog Entry" step above, referencing it's ID to get its outputs object.
           # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           tag_name: "v${{ steps.changelog_reader.outputs.version }}"
-          release_name: "serde_with v${{ steps.changelog_reader.outputs.version }}"
+          name: "serde_with v${{ steps.changelog_reader.outputs.version }}"
           body: ${{ steps.changelog_reader.outputs.changes }}
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
@@ -68,15 +71,14 @@ jobs:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./serde_with_macros/CHANGELOG.md
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # This pulls from the "Get Changelog Entry" step above, referencing it's ID to get its outputs object.
           # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           tag_name: "macros-v${{ steps.changelog_reader.outputs.version }}"
-          release_name: "serde_with_macros v${{ steps.changelog_reader.outputs.version }}"
+          name: "serde_with_macros v${{ steps.changelog_reader.outputs.version }}"
           body: ${{ steps.changelog_reader.outputs.changes }}
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}

--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -11,11 +11,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: "Install/Update the Rust version"
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          cargo --version
+          rustc --version
       - name: Get version from tag
         id: tag_name
         run: |
@@ -50,11 +51,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/macros-v')
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: "Install/Update the Rust version"
+        run: rustup toolchain install stable --profile minimal
+          rustup default stable
+          cargo --version
+          rustc --version
       - name: Get version from tag
         id: tag_name
         run: |


### PR DESCRIPTION
Most actions in the actions-rs organizations were last updated more than a year ago meaning they are effectively unmaintained.
Remove the actions and call rustup and cargo manually.

Switch to `softprops/action-gh-release` for creating releases, since the current one is no longer maintained.