### PR TITLE
Fixes

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.0", optional = true}
 
 [dev-dependencies]
-expect-test = "1.0.0"
+expect-test = "<1.2.1"
 fnv = "1.0.6"
 glob = "0.3.0"
 mime = "0.3.16"

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -223,6 +223,10 @@ macro_rules! seq_impl {
         $with_capacity:expr,
         $append:ident
     ) => {
+        // Fix for clippy regression in macros on stable
+        // The bug no longer exists on nightly
+        // https://github.com/rust-lang/rust-clippy/issues/7768
+        #[allow(clippy::semicolon_if_nothing_returned)]
         impl<'de, T, U> DeserializeAs<'de, $ty<T>> for $ty<U>
         where
             U: DeserializeAs<'de, T>,
@@ -316,6 +320,10 @@ macro_rules! map_impl2 {
         $access:ident,
         $with_capacity:expr
     ) => {
+        // Fix for clippy regression in macros on stable
+        // The bug no longer exists on nightly
+        // https://github.com/rust-lang/rust-clippy/issues/7768
+        #[allow(clippy::semicolon_if_nothing_returned)]
         impl<'de, K, V, KU, VU $(, $typaram)*> DeserializeAs<'de, $ty<K, V $(, $typaram)*>> for $ty<KU, VU $(, $typaram)*>
         where
             KU: DeserializeAs<'de, K>,


### PR DESCRIPTION
* Supress clippy warnings which are only on stable, but not nightly
* Fix MSRV compilation by pinning older `expect-test`.