### PR TITLE
Revert "Pin expect-test to an older version to  fix MSRV 1.46 tests"

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.0", optional = true}
 
 [dev-dependencies]
-expect-test = "<1.2.1"
+expect-test = "1.0.0"
 fnv = "1.0.6"
 glob = "0.3.0"
 mime = "0.3.16"


### PR DESCRIPTION
The new 1.2.3 version works with the current MSRV

bors r+