### PR TITLE
Ensure that `HashSet` can be used with custom hashers

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Fixed RUSTSEC-2020-0071 in the `time` v0.1 dependency, but changing the feature flags of the `chrono` dependency. This should not change anything. Crates requiring the `oldtime` feature of `chrono` can enable it separately.
+* Allow `HashSet`s with custom hashers to be deserialized when used in combination with `serde_as`.  #408
 
 ## [1.10.0] - 2021-09-04
 

--- a/serde_with/tests/serde_as/collections.rs
+++ b/serde_with/tests/serde_as/collections.rs
@@ -1,0 +1,44 @@
+use super::*;
+use fnv::{FnvHashMap, FnvHashSet};
+
+/// Test that HashSets are also supported with non-default hashers.
+#[test]
+fn test_fnv_hashset() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "FnvHashSet<DisplayFromStr>")] FnvHashSet<u32>);
+
+    // Normal
+    is_equal(
+        S([1, 2, 3, 4, 5].iter().cloned().collect()),
+        expect![[r#"
+            [
+              "5",
+              "4",
+              "1",
+              "3",
+              "2"
+            ]"#]],
+    );
+    is_equal(S(FnvHashSet::default()), expect![[r#"[]"#]]);
+}
+
+/// Test that HashSets are also supported with non-default hashers.
+#[test]
+fn test_fnv_hashmap() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "FnvHashMap<DisplayFromStr, DisplayFromStr>")] FnvHashMap<u8, u32>);
+
+    // Normal
+    is_equal(
+        S([(1, 1), (3, 3), (111, 111)].iter().cloned().collect()),
+        expect![[r#"
+            {
+              "1": "1",
+              "3": "3",
+              "111": "111"
+            }"#]],
+    );
+    is_equal(S(FnvHashMap::default()), expect![[r#"{}"#]]);
+}

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -1,3 +1,4 @@
+mod collections;
 mod default_on;
 mod enum_map;
 mod frominto;


### PR DESCRIPTION
https://users.rust-lang.org/t/recursive-serde-deserialize-with-definition/70865/3
A user reported that `FnvHashSet` could not be deserialized in
combination with `serde_as`.
This commit adds the necessary bound on the hasher and adds a test to
prevent regressions.