### PR TITLE
Allow generics for `SerializeDisplay` and `DeserializeFromStr` derives

### DIFF
--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+* Account for generics when deriving implementations with `SerializeDisplay` and `DeserializeFromStr` #413
+
 ## [1.5.1] - 2021-10-18
 
 ### Added

--- a/serde_with_macros/src/utils.rs
+++ b/serde_with_macros/src/utils.rs
@@ -1,7 +1,9 @@
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::ToTokens;
 use std::iter::Iterator;
-use syn::{Error, Path};
+use syn::{parse_quote, Error, Generics, Path, TypeGenerics};
 
 /// Merge multiple [`syn::Error`] into one.
 pub(crate) trait IteratorExt {
@@ -43,5 +45,33 @@ impl DeriveOptions {
         self.alt_crate_path
             .clone()
             .unwrap_or_else(|| syn::parse_str("::serde_with").unwrap())
+    }
+}
+
+// Inspired by https://github.com/serde-rs/serde/blob/fb2fe409c8f7ad6c95e3096e5e9ede865c8cfb49/serde_derive/src/de.rs#L3120
+// Serde is also licences Apache 2 + MIT
+pub(crate) fn split_with_de_lifetime(
+    generics: &Generics,
+) -> (
+    DeImplGenerics<'_>,
+    TypeGenerics<'_>,
+    Option<&syn::WhereClause>,
+) {
+    let de_impl_generics = DeImplGenerics(generics);
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+    (de_impl_generics, ty_generics, where_clause)
+}
+
+pub(crate) struct DeImplGenerics<'a>(&'a Generics);
+
+impl<'a> ToTokens for DeImplGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let mut generics = self.0.clone();
+        generics.params = Some(parse_quote!('de))
+            .into_iter()
+            .chain(generics.params)
+            .collect();
+        let (impl_generics, _, _) = generics.split_for_impl();
+        impl_generics.to_tokens(tokens);
     }
 }

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -24,3 +24,37 @@ impl ::std::fmt::Display for A {
         ::std::unimplemented!()
     }
 }
+
+#[derive(DeserializeFromStr, SerializeDisplay)]
+#[serde_with(crate = "::s_with")]
+struct G<T>(T);
+
+impl<T> ::std::str::FromStr for G<T> {
+    type Err = ::std::string::String;
+    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
+        ::std::unimplemented!()
+    }
+}
+
+impl<T> ::std::fmt::Display for G<T> {
+    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::std::unimplemented!()
+    }
+}
+
+#[derive(DeserializeFromStr, SerializeDisplay)]
+#[serde_with(crate = "::s_with")]
+struct LT<'a>(&'a ());
+
+impl ::std::str::FromStr for LT<'_> {
+    type Err = ::std::string::String;
+    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
+        ::std::unimplemented!()
+    }
+}
+
+impl ::std::fmt::Display for LT<'_> {
+    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::std::unimplemented!()
+    }
+}


### PR DESCRIPTION
The derives did not take into account that types can have generics. Ensure that lifetime and type generics are added to the generated impls. Add new tests to `serde_with_test` to prevent regressions.