### PR TITLE
Rework pre installed tools in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends lld python3-pip \
     && rustup update \
-    && rustup toolchain install nightly --profile minimal --component rustfmt \
+    && rustup toolchain install nightly --profile minimal --component clippy,rustfmt \
     && pip3 install --user --no-cache-dir pre-commit
 COPY config /root/.cargo/config
-RUN cargo install bacon cargo-readme cargo-tarpaulin \
+RUN cargo install --locked bacon cargo-readme \
     && rm -rf ~/.cargo/registry


### PR DESCRIPTION
clippy in the nightly version comes in handy to run more lints and be
able to debug the recurring nightly problems.
cargo-tarpaulin is quite heavy to build and not that often needed, so
it can be omitted and installed on demand.
Install crates with `--locked` to avoid potential breakage.

bors merge