### PR TITLE
Provide better error messages for type parse failures

### DIFF
--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 maintenance = {status = "actively-developed"}
 
 [dependencies]
-darling = "0.13.0"
+darling = "0.13.4"
 proc-macro2 = "1.0.1"
 quote = "1.0.0"
 


### PR DESCRIPTION
This relies on a newer `darling` version.

Closes #423

bors merge