### PR TITLE
Fix syntax error in the release script

### DIFF
--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -60,7 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install/Update the Rust version"
-        run: rustup toolchain install stable --profile minimal
+        run: |
+          rustup toolchain install stable --profile minimal
           rustup default stable
           cargo --version
           rustc --version


### PR DESCRIPTION
The YAML string was accidentially not a newline preserving string.

bors merge