### PR TITLE
Add support for `indexmap`

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -28,6 +28,7 @@ base64 = ["base64_crate"]
 chrono = ["chrono_crate"]
 default = ["macros"]
 guide = ["doc-comment", "macros"]
+indexmap = ["indexmap_crate"]
 json = ["serde_json"]
 macros = ["serde_with_macros"]
 
@@ -41,6 +42,7 @@ rustversion = "1.0.0"
 serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.0", optional = true}
+indexmap_crate = {package = "indexmap", version = "1.8", optional = true}
 
 [dev-dependencies]
 expect-test = "1.0.0"

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "indexmap")]
+use indexmap_crate::{IndexMap, IndexSet};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 
@@ -34,6 +36,26 @@ where
     }
 }
 
+#[cfg(feature = "indexmap")]
+impl<T, S> PreventDuplicateInsertsSet<T> for IndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn insert(&mut self, value: T) -> bool {
+        self.insert(value)
+    }
+}
+
 impl<T> PreventDuplicateInsertsSet<T> for BTreeSet<T>
 where
     T: Ord,
@@ -50,6 +72,26 @@ where
 }
 
 impl<K, V, S> PreventDuplicateInsertsMap<K, V> for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn insert(&mut self, key: K, value: V) -> bool {
+        self.insert(key, value).is_none()
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<K, V, S> PreventDuplicateInsertsMap<K, V> for IndexMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "indexmap")]
+use indexmap_crate::IndexSet;
 use std::collections::{BTreeSet, HashSet};
 use std::hash::{BuildHasher, Hash};
 
@@ -9,6 +11,27 @@ pub trait DuplicateInsertsLastWinsSet<T> {
 }
 
 impl<T, S> DuplicateInsertsLastWinsSet<T> for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn replace(&mut self, value: T) {
+        // Hashset already fulfils the contract
+        self.replace(value);
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<T, S> DuplicateInsertsLastWinsSet<T> for IndexSet<T, S>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -7,8 +7,9 @@ Each entry will explain the feature in more detail.
 2. [`chrono`](#chrono)
 3. [`guide`](#guide)
 4. [`hex`](#hex)
-5. [`json`](#json)
-6. [`macros`](#macros)
+5. [`indexmap`](#indexmap)
+6. [`json`](#json)
+7. [`macros`](#macros)
 
 ## `base64`
 
@@ -33,6 +34,11 @@ The feature only changes the rustdoc output and enables no other effects.
 The `hex` feature enables serializing data in hex format.
 
 This pulls in `hex` as a dependency.
+
+## `indexmap`
+
+The `indexmap` feature enables implementations of `indexmap` specific checks.
+This includes support for checking duplicate keys
 
 ## `json`
 


### PR DESCRIPTION
Add optional support for `indexmap` to

- `sets_duplicate_value_is_error`
- `maps_duplicate_key_is_error`
- `sets_last_value_wins`

Signed-off-by: Joe Grund <jgrund@whamcloud.io>