### PR TITLE
Add tests for IndexMap and IndexSet

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -38,7 +38,7 @@ base64_crate = {package = "base64", version = "0.13.0", optional = true}
 chrono_crate = {package = "chrono", version = "0.4.1", features = ["clock", "serde", "std"], optional = true, default-features = false}
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.2", optional = true}
-indexmap_crate = {package = "indexmap", version = "1.8", optional = true}
+indexmap_crate = {package = "indexmap", version = "1.8", features = ["serde-1"], optional = true}
 rustversion = "1.0.0"
 serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
@@ -74,6 +74,11 @@ required-features = ["chrono", "macros"]
 name = "hex"
 path = "tests/hex.rs"
 required-features = ["hex", "macros"]
+
+[[test]]
+name = "indexmap"
+path = "tests/indexmap.rs"
+required-features = ["indexmap", "macros"]
 
 [[test]]
 name = "json"

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -3,6 +3,8 @@ use crate::formats::Strictness;
 use crate::rust::StringWithSeparator;
 use crate::utils::duration::DurationSigned;
 use crate::Separator;
+#[cfg(feature = "indexmap")]
+use indexmap_crate::{IndexMap, IndexSet};
 use serde::ser::Error;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
@@ -228,6 +230,8 @@ seq_impl!(LinkedList<T>);
 seq_impl!(Slice<T>);
 seq_impl!(Vec<T>);
 seq_impl!(VecDeque<T>);
+#[cfg(feature = "indexmap")]
+seq_impl!(IndexSet<T, H: Sized>);
 
 macro_rules! map_impl {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound:ident)* >) => {
@@ -250,6 +254,8 @@ macro_rules! map_impl {
 
 map_impl!(BTreeMap<K, V>);
 map_impl!(HashMap<K, V, H: Sized>);
+#[cfg(feature = "indexmap")]
+map_impl!(IndexMap<K, V, H: Sized>);
 
 macro_rules! tuple_impl {
     ($len:literal $($n:tt $t:ident $tas:ident)+) => {
@@ -311,7 +317,10 @@ macro_rules! map_as_tuple_seq {
     };
 }
 map_as_tuple_seq!(BTreeMap<K, V>);
+// TODO HashMap with a custom hasher support would be better, but results in "unconstrained type parameter"
 map_as_tuple_seq!(HashMap<K, V>);
+#[cfg(feature = "indexmap")]
+map_as_tuple_seq!(IndexMap<K, V>);
 
 // endregion
 ///////////////////////////////////////////////////////////////////////////////
@@ -403,6 +412,8 @@ tuple_seq_as_map_impl! {
     Vec<(K, V)>,
     VecDeque<(K, V)>,
 }
+#[cfg(feature = "indexmap")]
+tuple_seq_as_map_impl!(IndexSet<(K, V)>);
 
 impl<T, TAs> SerializeAs<T> for DefaultOnError<TAs>
 where

--- a/serde_with/tests/indexmap.rs
+++ b/serde_with/tests/indexmap.rs
@@ -1,0 +1,272 @@
+mod utils;
+
+use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use expect_test::expect;
+use indexmap_crate::{IndexMap, IndexSet};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr, Same};
+use std::net::IpAddr;
+
+#[test]
+fn test_indexmap() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "IndexMap<DisplayFromStr, DisplayFromStr>")] IndexMap<u8, u32>);
+
+    // Normal
+    is_equal(
+        S([(1, 1), (3, 3), (111, 111)].iter().cloned().collect()),
+        expect![[r#"
+            {
+              "1": "1",
+              "3": "3",
+              "111": "111"
+            }"#]],
+    );
+    is_equal(S(IndexMap::default()), expect![[r#"{}"#]]);
+}
+
+#[test]
+fn test_indexset() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "IndexSet<DisplayFromStr>")] IndexSet<u32>);
+
+    // Normal
+    is_equal(
+        S([1, 2, 3, 4, 5].iter().cloned().collect()),
+        expect![[r#"
+            [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]"#]],
+    );
+    is_equal(S(IndexSet::default()), expect![[r#"[]"#]]);
+}
+
+#[test]
+fn test_map_as_tuple_list() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI(#[serde_as(as = "Vec<(DisplayFromStr, DisplayFromStr)>")] IndexMap<u32, IpAddr>);
+
+    let map: IndexMap<_, _> = vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect();
+    is_equal(
+        SI(map.clone()),
+        expect![[r#"
+            [
+              [
+                "1",
+                "1.2.3.4"
+              ],
+              [
+                "10",
+                "1.2.3.4"
+              ],
+              [
+                "200",
+                "255.255.255.255"
+              ]
+            ]"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI2(#[serde_as(as = "Vec<(Same, DisplayFromStr)>")] IndexMap<u32, IpAddr>);
+
+    is_equal(
+        SI2(map),
+        expect![[r#"
+            [
+              [
+                1,
+                "1.2.3.4"
+              ],
+              [
+                10,
+                "1.2.3.4"
+              ],
+              [
+                200,
+                "255.255.255.255"
+              ]
+            ]"#]],
+    );
+}
+
+#[test]
+fn test_tuple_list_as_map() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI(
+        #[serde_as(as = "std::collections::HashMap<DisplayFromStr, DisplayFromStr>")]
+        IndexSet<(u32, IpAddr)>,
+    );
+
+    is_equal(
+        SI(IndexSet::from([(1, ip), (10, ip), (200, ip2)])),
+        expect![[r#"
+            {
+              "1": "1.2.3.4",
+              "10": "1.2.3.4",
+              "200": "255.255.255.255"
+            }"#]],
+    );
+}
+
+#[test]
+fn duplicate_key_first_wins_indexmap() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::maps_first_key_wins")] IndexMap<usize, usize>);
+
+    // Different value and key always works
+    is_equal(
+        S(IndexMap::from([(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
+
+    // Same value for different keys is ok
+    is_equal(
+        S(IndexMap::from([(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
+
+    // Duplicate keys, the first one is used
+    check_deserialization(
+        S(IndexMap::from([(1, 1), (2, 2)])),
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+    );
+}
+
+#[test]
+fn prohibit_duplicate_key_indexmap() {
+    #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")] IndexMap<usize, usize>,
+    );
+
+    // Different value and key always works
+    is_equal(
+        S(IndexMap::from([(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
+
+    // Same value for different keys is ok
+    is_equal(
+        S(IndexMap::from([(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
+
+    // Duplicate keys are an error
+    check_error_deserialization::<S>(
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+        expect![[r#"invalid entry: found duplicate key at line 1 column 24"#]],
+    );
+}
+
+#[test]
+fn duplicate_value_last_wins_indexset() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_last_value_wins")] IndexSet<W>);
+
+    #[derive(Debug, Eq, Deserialize, Serialize)]
+    struct W(i32, bool);
+    impl PartialEq for W {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+    impl std::hash::Hash for W {
+        fn hash<H>(&self, state: &mut H)
+        where
+            H: std::hash::Hasher,
+        {
+            self.0.hash(state)
+        }
+    }
+
+    // Different values always work
+    is_equal(
+        S(IndexSet::from([W(1, true), W(2, false), W(3, true)])),
+        expect![[r#"
+            [
+              [
+                1,
+                true
+              ],
+              [
+                2,
+                false
+              ],
+              [
+                3,
+                true
+              ]
+            ]"#]],
+    );
+
+    let value: S = serde_json::from_str(
+        r#"[
+        [1, false],
+        [1, true],
+        [2, true],
+        [2, false]
+    ]"#,
+    )
+    .unwrap();
+    let entries: Vec<_> = value.0.into_iter().collect();
+    assert_eq!(1, entries[0].0);
+    assert!(entries[0].1);
+    assert_eq!(2, entries[1].0);
+    assert!(!entries[1].1);
+}
+
+#[test]
+fn prohibit_duplicate_value_indexset() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] IndexSet<usize>);
+
+    is_equal(
+        S(IndexSet::from([1, 2, 3, 4])),
+        expect![[r#"
+            [
+              1,
+              2,
+              3,
+              4
+            ]"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"[1, 2, 3, 4, 1]"#,
+        expect![[r#"invalid entry: found duplicate value at line 1 column 15"#]],
+    );
+}

--- a/serde_with/tests/indexmap.rs
+++ b/serde_with/tests/indexmap.rs
@@ -5,6 +5,7 @@ use expect_test::expect;
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Same};
+use std::iter::FromIterator;
 use std::net::IpAddr;
 
 #[test]
@@ -113,7 +114,7 @@ fn test_tuple_list_as_map() {
     );
 
     is_equal(
-        SI(IndexSet::from([(1, ip), (10, ip), (200, ip2)])),
+        SI(IndexSet::from_iter(vec![(1, ip), (10, ip), (200, ip2)])),
         expect![[r#"
             {
               "1": "1.2.3.4",
@@ -130,7 +131,7 @@ fn duplicate_key_first_wins_indexmap() {
 
     // Different value and key always works
     is_equal(
-        S(IndexMap::from([(1, 1), (2, 2), (3, 3)])),
+        S(IndexMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
         expect![[r#"
             {
               "1": 1,
@@ -141,7 +142,7 @@ fn duplicate_key_first_wins_indexmap() {
 
     // Same value for different keys is ok
     is_equal(
-        S(IndexMap::from([(1, 1), (2, 1), (3, 1)])),
+        S(IndexMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
         expect![[r#"
             {
               "1": 1,
@@ -152,7 +153,7 @@ fn duplicate_key_first_wins_indexmap() {
 
     // Duplicate keys, the first one is used
     check_deserialization(
-        S(IndexMap::from([(1, 1), (2, 2)])),
+        S(IndexMap::from_iter(vec![(1, 1), (2, 2)])),
         r#"{"1": 1, "2": 2, "1": 3}"#,
     );
 }
@@ -166,7 +167,7 @@ fn prohibit_duplicate_key_indexmap() {
 
     // Different value and key always works
     is_equal(
-        S(IndexMap::from([(1, 1), (2, 2), (3, 3)])),
+        S(IndexMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
         expect![[r#"
             {
               "1": 1,
@@ -177,7 +178,7 @@ fn prohibit_duplicate_key_indexmap() {
 
     // Same value for different keys is ok
     is_equal(
-        S(IndexMap::from([(1, 1), (2, 1), (3, 1)])),
+        S(IndexMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
         expect![[r#"
             {
               "1": 1,
@@ -216,7 +217,11 @@ fn duplicate_value_last_wins_indexset() {
 
     // Different values always work
     is_equal(
-        S(IndexSet::from([W(1, true), W(2, false), W(3, true)])),
+        S(IndexSet::from_iter(vec![
+            W(1, true),
+            W(2, false),
+            W(3, true),
+        ])),
         expect![[r#"
             [
               [
@@ -256,7 +261,7 @@ fn prohibit_duplicate_value_indexset() {
     struct S(#[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] IndexSet<usize>);
 
     is_equal(
-        S(IndexSet::from([1, 2, 3, 4])),
+        S(IndexSet::from_iter(vec![1, 2, 3, 4])),
         expect![[r#"
             [
               1,


### PR DESCRIPTION
During the tests a missing implementation of `DuplicateInsertsFirstWinsMap` was noticed, but is now included.
`indexmap` was also missing the `serde-1` feature flag.

bors merge