### PR TITLE
Support `no_std` environments with `serde_with`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,5 +2,6 @@
 
 # format_code_in_doc_comments = true
 # format_strings = true
-imports_granularity = "Module"
+imports_granularity = "Crate"
+group_imports = "One"
 use_field_init_shorthand = true

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -24,13 +24,15 @@ maintenance = {status = "actively-developed"}
 
 # When adding new features update the documentation in feature-flags.md
 [features]
+alloc = []
 base64 = ["base64_crate"]
 chrono = ["chrono_crate"]
-default = ["macros"]
+default = ["macros", "std"]
 guide = ["doc-comment", "macros"]
 indexmap = ["indexmap_crate"]
 json = ["serde_json"]
 macros = ["serde_with_macros"]
+std = ["alloc"]
 
 # When adding new optional dependencies update the documentation in feature-flags.md
 [dependencies]

--- a/serde_with/src/base64.rs
+++ b/serde_with/src/base64.rs
@@ -5,6 +5,7 @@
 //! Please check the documentation on the [`Base64`] type for details.
 
 use crate::{formats, DeserializeAs, SerializeAs};
+use alloc::{format, string::String, vec::Vec};
 use core::{
     convert::{TryFrom, TryInto},
     default::Default,

--- a/serde_with/src/base64.rs
+++ b/serde_with/src/base64.rs
@@ -5,12 +5,12 @@
 //! Please check the documentation on the [`Base64`] type for details.
 
 use crate::{formats, DeserializeAs, SerializeAs};
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-use std::{
+use core::{
     convert::{TryFrom, TryInto},
     default::Default,
     marker::PhantomData,
 };
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Serialize bytes with base64
 ///

--- a/serde_with/src/base64.rs
+++ b/serde_with/src/base64.rs
@@ -5,11 +5,12 @@
 //! Please check the documentation on the [`Base64`] type for details.
 
 use crate::{formats, DeserializeAs, SerializeAs};
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::convert::{TryFrom, TryInto};
-use std::default::Default;
-use std::marker::PhantomData;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    convert::{TryFrom, TryInto},
+    default::Default,
+    marker::PhantomData,
+};
 
 /// Serialize bytes with base64
 ///

--- a/serde_with/src/chrono.rs
+++ b/serde_with/src/chrono.rs
@@ -4,11 +4,11 @@
 //!
 //! [chrono]: https://docs.rs/chrono/
 
-use crate::de::DeserializeAs;
-use crate::formats::{Flexible, Format, Strict, Strictness};
-use crate::ser::SerializeAs;
-use crate::utils::duration::{DurationSigned, Sign};
 use crate::{
+    de::DeserializeAs,
+    formats::{Flexible, Format, Strict, Strictness},
+    ser::SerializeAs,
+    utils::duration::{DurationSigned, Sign},
     DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
     DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,

--- a/serde_with/src/chrono.rs
+++ b/serde_with/src/chrono.rs
@@ -15,7 +15,9 @@ use crate::{
     TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
     TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
 };
+use alloc::{format, string::String, vec::Vec};
 use chrono_crate::{DateTime, Duration, Local, NaiveDateTime, TimeZone, Utc};
+use core::fmt;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Create a [`DateTime`] for the Unix Epoch using the [`Utc`] timezone
@@ -57,6 +59,7 @@ fn unix_epoch_naive() -> NaiveDateTime {
 /// assert!(serde_json::from_str::<S>(r#"{ "date": "1478563200.123" }"#).is_ok());
 /// ```
 pub mod datetime_utc_ts_seconds_from_any {
+    use super::*;
     use chrono_crate::{DateTime, NaiveDateTime, Utc};
     use serde::de::{Deserializer, Error, Unexpected, Visitor};
 
@@ -69,7 +72,7 @@ pub mod datetime_utc_ts_seconds_from_any {
         impl<'de> Visitor<'de> for Helper {
             type Value = DateTime<Utc>;
 
-            fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter
                     .write_str("an integer, float, or string with optional subsecond precision.")
             }

--- a/serde_with/src/content/ser.rs
+++ b/serde_with/src/content/ser.rs
@@ -11,8 +11,8 @@
 //! The types support 128-bit integers, which is supported for all targets in Rust 1.40+.
 //! The [`ContentSerializer`] can also be configured to human readable or compact representation.
 
+use core::marker::PhantomData;
 use serde::ser::{self, Serialize, Serializer};
-use std::marker::PhantomData;
 
 #[derive(Debug)]
 pub(crate) enum Content {

--- a/serde_with/src/content/ser.rs
+++ b/serde_with/src/content/ser.rs
@@ -11,6 +11,7 @@
 //! The types support 128-bit integers, which is supported for all targets in Rust 1.40+.
 //! The [`ContentSerializer`] can also be configured to human readable or compact representation.
 
+use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 use core::marker::PhantomData;
 use serde::ser::{self, Serialize, Serializer};
 

--- a/serde_with/src/de/const_arrays.rs
+++ b/serde_with/src/de/const_arrays.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::utils::{MapIter, SeqIter};
-use alloc::{borrow::Cow, collections::BTreeMap};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 use core::{convert::TryInto, fmt, mem::MaybeUninit};
 use serde::de::*;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
 // TODO this should probably be moved into the utils module when const generics are available for MSRV
@@ -22,7 +23,7 @@ where
         arr[..num].iter_mut().for_each(|elem| {
             // TODO This would be better with assume_init_drop nightly function
             // https://github.com/rust-lang/rust/issues/63567
-            unsafe { std::ptr::drop_in_place(elem.as_mut_ptr()) };
+            unsafe { core::ptr::drop_in_place(elem.as_mut_ptr()) };
         });
     }
 
@@ -57,7 +58,7 @@ where
     // initialized type.
     // A normal transmute is not possible because of:
     // https://github.com/rust-lang/rust/issues/61956
-    Ok(unsafe { std::mem::transmute_copy::<_, [T; N]>(&arr) })
+    Ok(unsafe { core::mem::transmute_copy::<_, [T; N]>(&arr) })
 }
 
 impl<'de, T, As, const N: usize> DeserializeAs<'de, [T; N]> for [As; N]
@@ -145,6 +146,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
     }
 }
 tuple_seq_as_map_impl_intern!([(K, V); N], BTreeMap<KAs, VAs>);
+#[cfg(feature = "std")]
 tuple_seq_as_map_impl_intern!([(K, V); N], HashMap<KAs, VAs>);
 
 impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Bytes {

--- a/serde_with/src/de/const_arrays.rs
+++ b/serde_with/src/de/const_arrays.rs
@@ -1,11 +1,9 @@
 use super::*;
 use crate::utils::{MapIter, SeqIter};
+use alloc::{borrow::Cow, collections::BTreeMap};
+use core::{convert::TryInto, fmt, mem::MaybeUninit};
 use serde::de::*;
-use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
-use std::convert::TryInto;
-use std::fmt;
-use std::mem::MaybeUninit;
+use std::collections::HashMap;
 
 // TODO this should probably be moved into the utils module when const generics are available for MSRV
 

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -5,21 +5,28 @@ use crate::{
     utils,
     utils::duration::DurationSigned,
 };
-#[cfg(feature = "indexmap")]
-use indexmap_crate::{IndexMap, IndexSet};
-use serde::de::*;
-use std::{
+use alloc::{
     borrow::Cow,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::{Rc, Weak as RcWeak},
+    sync::{Arc, Weak as ArcWeak},
+};
+use core::{
     cell::{Cell, RefCell},
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
     convert::TryInto,
     fmt::{self, Display},
     hash::{BuildHasher, Hash},
     iter::FromIterator,
-    rc::{Rc, Weak as RcWeak},
     str::FromStr,
-    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
-    time::{Duration, SystemTime},
+    time::Duration,
+};
+#[cfg(feature = "indexmap")]
+use indexmap_crate::{IndexMap, IndexSet};
+use serde::de::*;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Mutex, RwLock},
+    time::SystemTime,
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,22 +1,26 @@
 use super::*;
-use crate::formats::{Flexible, Format, Strict};
-use crate::rust::StringWithSeparator;
-use crate::utils;
-use crate::utils::duration::DurationSigned;
+use crate::{
+    formats::{Flexible, Format, Strict},
+    rust::StringWithSeparator,
+    utils,
+    utils::duration::DurationSigned,
+};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::de::*;
-use std::borrow::Cow;
-use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
-use std::convert::TryInto;
-use std::fmt::{self, Display};
-use std::hash::{BuildHasher, Hash};
-use std::iter::FromIterator;
-use std::rc::{Rc, Weak as RcWeak};
-use std::str::FromStr;
-use std::sync::{Arc, Mutex, RwLock, Weak as ArcWeak};
-use std::time::{Duration, SystemTime};
+use std::{
+    borrow::Cow,
+    cell::{Cell, RefCell},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
+    convert::TryInto,
+    fmt::{self, Display},
+    hash::{BuildHasher, Hash},
+    iter::FromIterator,
+    rc::{Rc, Weak as RcWeak},
+    str::FromStr,
+    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
+    time::{Duration, SystemTime},
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 // region: Simple Wrapper types (e.g., Box, Option)

--- a/serde_with/src/de/legacy_arrays.rs
+++ b/serde_with/src/de/legacy_arrays.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::fmt;
+use core::fmt;
 use serde::de::*;
 
 macro_rules! array_impl {

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::{BuildHasher, Hash};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    hash::{BuildHasher, Hash},
+};
 
 pub trait PreventDuplicateInsertsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,7 +1,9 @@
 use alloc::collections::{BTreeMap, BTreeSet};
+#[cfg(any(feature = "indexmap", feature = "std"))]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
 pub trait PreventDuplicateInsertsSet<T> {
@@ -18,6 +20,7 @@ pub trait PreventDuplicateInsertsMap<K, V> {
     fn insert(&mut self, key: K, value: V) -> bool;
 }
 
+#[cfg(feature = "std")]
 impl<T, S> PreventDuplicateInsertsSet<T> for HashSet<T, S>
 where
     T: Eq + Hash,
@@ -72,6 +75,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, S> PreventDuplicateInsertsMap<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,9 +1,8 @@
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::{HashMap, HashSet};
 
 pub trait PreventDuplicateInsertsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexMap;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::{BuildHasher, Hash};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    hash::{BuildHasher, Hash},
+};
 
 #[deprecated = "This is serde's default behavior."]
 pub trait DuplicateInsertsFirstWinsSet<T> {

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,9 +1,8 @@
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexMap;
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::{HashMap, HashSet};
 
 #[deprecated = "This is serde's default behavior."]
 pub trait DuplicateInsertsFirstWinsSet<T> {
@@ -124,7 +123,7 @@ where
 
     #[inline]
     fn insert(&mut self, key: K, value: V) {
-        use std::collections::btree_map::Entry;
+        use alloc::collections::btree_map::Entry;
 
         match self.entry(key) {
             // we want to keep the first value, so do nothing

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,7 +1,9 @@
 use alloc::collections::{BTreeMap, BTreeSet};
+#[cfg(any(feature = "indexmap", feature = "std"))]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexMap;
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
 #[deprecated = "This is serde's default behavior."]
@@ -19,6 +21,7 @@ pub trait DuplicateInsertsFirstWinsMap<K, V> {
     fn insert(&mut self, key: K, value: V);
 }
 
+#[cfg(feature = "std")]
 #[allow(deprecated)]
 impl<T, S> DuplicateInsertsFirstWinsSet<T> for HashSet<T, S>
 where
@@ -57,6 +60,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, S> DuplicateInsertsFirstWinsMap<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexSet;
-use std::collections::{BTreeSet, HashSet};
-use std::hash::{BuildHasher, Hash};
+use std::{
+    collections::{BTreeSet, HashSet},
+    hash::{BuildHasher, Hash},
+};
 
 pub trait DuplicateInsertsLastWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,7 +1,9 @@
 use alloc::collections::BTreeSet;
+#[cfg(any(feature = "indexmap", feature = "std"))]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexSet;
+#[cfg(feature = "std")]
 use std::collections::HashSet;
 
 pub trait DuplicateInsertsLastWinsSet<T> {
@@ -11,6 +13,7 @@ pub trait DuplicateInsertsLastWinsSet<T> {
     fn replace(&mut self, value: T);
 }
 
+#[cfg(feature = "std")]
 impl<T, S> DuplicateInsertsLastWinsSet<T> for HashSet<T, S>
 where
     T: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,9 +1,8 @@
+use alloc::collections::BTreeSet;
+use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexSet;
-use std::{
-    collections::{BTreeSet, HashSet},
-    hash::{BuildHasher, Hash},
-};
+use std::collections::HashSet;
 
 pub trait DuplicateInsertsLastWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -1,12 +1,14 @@
-use crate::content::ser::{Content, ContentSerializer};
-use crate::{DeserializeAs, SerializeAs};
-use serde::de::{DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor};
-use serde::ser::{
-    Impossible, SerializeMap, SerializeSeq, SerializeStructVariant, SerializeTupleVariant,
+use crate::{
+    content::ser::{Content, ContentSerializer},
+    DeserializeAs, SerializeAs,
 };
-use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use std::marker::PhantomData;
+use serde::{
+    de::{DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor},
+    ser,
+    ser::{Impossible, SerializeMap, SerializeSeq, SerializeStructVariant, SerializeTupleVariant},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::{fmt, marker::PhantomData};
 
 /// Represent a list of enum values as a map.
 ///

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -2,6 +2,7 @@ use crate::{
     content::ser::{Content, ContentSerializer},
     DeserializeAs, SerializeAs,
 };
+use alloc::{string::ToString, vec::Vec};
 use core::{fmt, marker::PhantomData};
 use serde::{
     de::{DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor},

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -2,13 +2,13 @@ use crate::{
     content::ser::{Content, ContentSerializer},
     DeserializeAs, SerializeAs,
 };
+use core::{fmt, marker::PhantomData};
 use serde::{
     de::{DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor},
     ser,
     ser::{Impossible, SerializeMap, SerializeSeq, SerializeStructVariant, SerializeTupleVariant},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{fmt, marker::PhantomData};
 
 /// Represent a list of enum values as a map.
 ///

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -51,12 +51,12 @@
 #[macro_export]
 macro_rules! flattened_maybe {
     ($fn:ident, $field:literal) => {
-        fn $fn<'de, T, D>(deserializer: D) -> ::std::result::Result<T, D::Error>
+        fn $fn<'de, T, D>(deserializer: D) -> ::core::result::Result<T, D::Error>
         where
             T: $crate::serde::Deserialize<'de>,
             D: $crate::serde::Deserializer<'de>,
         {
-            use ::std::{
+            use ::core::{
                 option::Option::{self, None, Some},
                 result::Result::{self, Err, Ok},
             };

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -56,8 +56,10 @@ macro_rules! flattened_maybe {
             T: $crate::serde::Deserialize<'de>,
             D: $crate::serde::Deserializer<'de>,
         {
-            use ::std::option::Option::{self, None, Some};
-            use ::std::result::Result::{self, Err, Ok};
+            use ::std::{
+                option::Option::{self, None, Some},
+                result::Result::{self, Err, Ok},
+            };
             use $crate::serde;
 
             #[derive($crate::serde::Deserialize)]

--- a/serde_with/src/formats.rs
+++ b/serde_with/src/formats.rs
@@ -1,5 +1,7 @@
 //! Specify the format and how lenient the deserialization is
 
+use alloc::string::String;
+
 /// Specify how to serialize/deserialize a type
 ///
 /// The format specifier allows to configure how a value is serialized/deserialized.

--- a/serde_with/src/hex.rs
+++ b/serde_with/src/hex.rs
@@ -4,14 +4,17 @@
 //!
 //! Please check the documentation on the [`Hex`] type for details.
 
-use crate::de::DeserializeAs;
-use crate::formats::{Format, Lowercase, Uppercase};
-use crate::ser::SerializeAs;
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serializer};
-use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
+use crate::{
+    de::DeserializeAs,
+    formats::{Format, Lowercase, Uppercase},
+    ser::SerializeAs,
+};
+use serde::{de::Error, Deserialize, Deserializer, Serializer};
+use std::{
+    borrow::Cow,
+    convert::{TryFrom, TryInto},
+    marker::PhantomData,
+};
 
 /// Serialize bytes as a hex string
 ///

--- a/serde_with/src/hex.rs
+++ b/serde_with/src/hex.rs
@@ -9,7 +9,7 @@ use crate::{
     formats::{Format, Lowercase, Uppercase},
     ser::SerializeAs,
 };
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, format, vec::Vec};
 use core::{
     convert::{TryFrom, TryInto},
     marker::PhantomData,

--- a/serde_with/src/hex.rs
+++ b/serde_with/src/hex.rs
@@ -9,12 +9,12 @@ use crate::{
     formats::{Format, Lowercase, Uppercase},
     ser::SerializeAs,
 };
-use serde::{de::Error, Deserialize, Deserializer, Serializer};
-use std::{
-    borrow::Cow,
+use alloc::borrow::Cow;
+use core::{
     convert::{TryFrom, TryInto},
     marker::PhantomData,
 };
+use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
 /// Serialize bytes as a hex string
 ///

--- a/serde_with/src/json.rs
+++ b/serde_with/src/json.rs
@@ -36,11 +36,11 @@ use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
 /// );
 /// ```
 pub mod nested {
+    use core::{fmt, marker::PhantomData};
     use serde::{
         de::{DeserializeOwned, Deserializer, Error, Visitor},
         ser::{self, Serialize, Serializer},
     };
-    use std::{fmt, marker::PhantomData};
 
     /// Deserialize value from a string which is valid JSON
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/serde_with/src/json.rs
+++ b/serde_with/src/json.rs
@@ -2,10 +2,8 @@
 //!
 //! This modules is only available when using the `json` feature of the crate.
 
-use crate::de::DeserializeAs;
-use crate::ser::SerializeAs;
-use serde::de::DeserializeOwned;
-use serde::{Deserializer, Serialize, Serializer};
+use crate::{de::DeserializeAs, ser::SerializeAs};
+use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
 
 /// Serialize value as string containing JSON
 ///
@@ -38,10 +36,11 @@ use serde::{Deserializer, Serialize, Serializer};
 /// );
 /// ```
 pub mod nested {
-    use serde::de::{DeserializeOwned, Deserializer, Error, Visitor};
-    use serde::ser::{self, Serialize, Serializer};
-    use std::fmt;
-    use std::marker::PhantomData;
+    use serde::{
+        de::{DeserializeOwned, Deserializer, Error, Visitor},
+        ser::{self, Serialize, Serializer},
+    };
+    use std::{fmt, marker::PhantomData};
 
     /// Deserialize value from a string which is valid JSON
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -31,6 +31,7 @@
 // clippy on stable does not know yet about the lint name
 // https://github.com/rust-lang/rust-clippy/issues/8560
 #![allow(unknown_lints, clippy::only_used_in_recursion)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! [![crates.io badge](https://img.shields.io/crates/v/serde_with.svg)](https://crates.io/crates/serde_with/)
 //! [![Build Status](https://github.com/jonasbb/serde_with/workflows/Rust%20CI/badge.svg)](https://github.com/jonasbb/serde_with)

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1095,7 +1095,7 @@ pub struct DurationNanoSecondsWithFrac<
 ///     st_f64: SystemTime,
 ///     #[serde_as(as = "TimestampSeconds<String>")]
 ///     st_string: SystemTime,
-/// };
+/// }
 ///
 /// // Serialization
 /// // See how the values get rounded, since subsecond precision is not allowed.

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -253,6 +253,7 @@
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
 //! [as-annotation]: https://docs.rs/serde_with/1.13.0/serde_with/guide/serde_as/index.html
 
+extern crate alloc;
 #[doc(hidden)]
 pub extern crate serde;
 
@@ -324,13 +325,13 @@ generate_guide! {
 pub use crate::{
     de::DeserializeAs, enum_map::EnumMap, rust::StringWithSeparator, ser::SerializeAs,
 };
+use core::marker::PhantomData;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Re-Export all proc_macros, as these should be seen as part of the serde_with crate
 #[cfg(feature = "macros")]
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 #[doc(inline)]
 pub use serde_with_macros::*;
-use std::marker::PhantomData;
 
 /// Separator for string-based collection de/serialization
 pub trait Separator {

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -1,18 +1,20 @@
 //! De/Serialization for Rust's builtin and std types
 
 use crate::{utils, Separator};
-use serde::de::{
-    Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor,
+use serde::{
+    de::{Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor},
+    ser::{Serialize, Serializer},
 };
-use serde::ser::{Serialize, Serializer};
-use std::cmp::Eq;
 #[cfg(doc)]
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::{self, Display};
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{
+    cmp::Eq,
+    fmt::{self, Display},
+    hash::Hash,
+    iter::FromIterator,
+    marker::PhantomData,
+    str::FromStr,
+};
 
 /// De/Serialize using [`Display`] and [`FromStr`] implementation
 ///

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -3,6 +3,10 @@
 use crate::{utils, Separator};
 #[cfg(doc)]
 use alloc::collections::BTreeMap;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     cmp::Eq,
     fmt::{self, Display},

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -19,6 +19,7 @@ use serde::{
     de::{Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor},
     ser::{Serialize, Serializer},
 };
+#[cfg(feature = "std")]
 #[cfg(doc)]
 use std::collections::HashMap;
 

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -1,13 +1,9 @@
 //! De/Serialization for Rust's builtin and std types
 
 use crate::{utils, Separator};
-use serde::{
-    de::{Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor},
-    ser::{Serialize, Serializer},
-};
 #[cfg(doc)]
-use std::collections::{BTreeMap, HashMap};
-use std::{
+use alloc::collections::BTreeMap;
+use core::{
     cmp::Eq,
     fmt::{self, Display},
     hash::Hash,
@@ -15,6 +11,12 @@ use std::{
     marker::PhantomData,
     str::FromStr,
 };
+use serde::{
+    de::{Deserialize, DeserializeOwned, Deserializer, Error, MapAccess, SeqAccess, Visitor},
+    ser::{Serialize, Serializer},
+};
+#[cfg(doc)]
+use std::collections::HashMap;
 
 /// De/Serialize using [`Display`] and [`FromStr`] implementation
 ///

--- a/serde_with/src/ser/const_arrays.rs
+++ b/serde_with/src/ser/const_arrays.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
 use super::*;
-use std::collections::{BTreeMap, HashMap};
+use alloc::{borrow::Cow, collections::BTreeMap};
+use std::collections::HashMap;
 
 impl<T, As, const N: usize> SerializeAs<[T; N]> for [As; N]
 where

--- a/serde_with/src/ser/const_arrays.rs
+++ b/serde_with/src/ser/const_arrays.rs
@@ -1,5 +1,6 @@
 use super::*;
-use alloc::{borrow::Cow, collections::BTreeMap};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap};
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
 impl<T, As, const N: usize> SerializeAs<[T; N]> for [As; N]
@@ -42,6 +43,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
     };
 }
 tuple_seq_as_map_impl_intern!([(K, V); N], BTreeMap<K, V>);
+#[cfg(feature = "std")]
 tuple_seq_as_map_impl_intern!([(K, V); N], HashMap<K, V>);
 
 impl<'a, const N: usize> SerializeAs<[u8; N]> for Bytes {

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -2,18 +2,25 @@ use super::*;
 use crate::{
     formats::Strictness, rust::StringWithSeparator, utils::duration::DurationSigned, Separator,
 };
+use alloc::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::{Rc, Weak as RcWeak},
+    sync::{Arc, Weak as ArcWeak},
+};
+use core::{
+    cell::{Cell, RefCell},
+    convert::TryInto,
+    fmt::Display,
+    time::Duration,
+};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::ser::Error;
 use std::{
-    borrow::Cow,
-    cell::{Cell, RefCell},
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    convert::TryInto,
-    fmt::Display,
-    rc::{Rc, Weak as RcWeak},
-    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
-    time::{Duration, SystemTime},
+    collections::{HashMap, HashSet},
+    sync::{Mutex, RwLock},
+    time::SystemTime,
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -4,9 +4,12 @@ use crate::{
 };
 use alloc::{
     borrow::Cow,
+    boxed::Box,
     collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
     rc::{Rc, Weak as RcWeak},
+    string::{String, ToString},
     sync::{Arc, Weak as ArcWeak},
+    vec::Vec,
 };
 use core::{
     cell::{Cell, RefCell},
@@ -17,6 +20,7 @@ use core::{
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::ser::Error;
+#[cfg(feature = "std")]
 use std::{
     collections::{HashMap, HashSet},
     sync::{Mutex, RwLock},
@@ -159,6 +163,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, U> SerializeAs<Mutex<T>> for Mutex<U>
 where
     U: SerializeAs<T>,
@@ -174,6 +179,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, U> SerializeAs<RwLock<T>> for RwLock<U>
 where
     U: SerializeAs<T>,
@@ -233,6 +239,7 @@ type Slice<T> = [T];
 seq_impl!(BinaryHeap<T>);
 seq_impl!(BoxedSlice<T>);
 seq_impl!(BTreeSet<T>);
+#[cfg(feature = "std")]
 seq_impl!(HashSet<T, H: Sized>);
 seq_impl!(LinkedList<T>);
 seq_impl!(Slice<T>);
@@ -261,6 +268,7 @@ macro_rules! map_impl {
 }
 
 map_impl!(BTreeMap<K, V>);
+#[cfg(feature = "std")]
 map_impl!(HashMap<K, V, H: Sized>);
 #[cfg(feature = "indexmap")]
 map_impl!(IndexMap<K, V, H: Sized>);
@@ -326,6 +334,7 @@ macro_rules! map_as_tuple_seq {
 }
 map_as_tuple_seq!(BTreeMap<K, V>);
 // TODO HashMap with a custom hasher support would be better, but results in "unconstrained type parameter"
+#[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K, V>);
 #[cfg(feature = "indexmap")]
 map_as_tuple_seq!(IndexMap<K, V>);
@@ -407,6 +416,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
 macro_rules! tuple_seq_as_map_impl {
     ($($ty:ty $(,)?)+) => {$(
         tuple_seq_as_map_impl_intern!($ty, BTreeMap<K, V>);
+        #[cfg(feature = "std")]
         tuple_seq_as_map_impl_intern!($ty, HashMap<K, V>);
     )+}
 }
@@ -414,12 +424,13 @@ macro_rules! tuple_seq_as_map_impl {
 tuple_seq_as_map_impl! {
     BinaryHeap<(K, V)>,
     BTreeSet<(K, V)>,
-    HashSet<(K, V)>,
     LinkedList<(K, V)>,
     Option<(K, V)>,
     Vec<(K, V)>,
     VecDeque<(K, V)>,
 }
+#[cfg(feature = "std")]
+tuple_seq_as_map_impl!(HashSet<(K, V)>);
 #[cfg(feature = "indexmap")]
 tuple_seq_as_map_impl!(IndexSet<(K, V)>);
 
@@ -527,6 +538,7 @@ use_signed_duration!(
     }
 );
 
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSeconds DurationSeconds,
     TimestampMilliSeconds DurationMilliSeconds,
@@ -539,6 +551,7 @@ use_signed_duration!(
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1,19 +1,20 @@
 use super::*;
-use crate::formats::Strictness;
-use crate::rust::StringWithSeparator;
-use crate::utils::duration::DurationSigned;
-use crate::Separator;
+use crate::{
+    formats::Strictness, rust::StringWithSeparator, utils::duration::DurationSigned, Separator,
+};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::ser::Error;
-use std::borrow::Cow;
-use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
-use std::convert::TryInto;
-use std::fmt::Display;
-use std::rc::{Rc, Weak as RcWeak};
-use std::sync::{Arc, Mutex, RwLock, Weak as ArcWeak};
-use std::time::{Duration, SystemTime};
+use std::{
+    borrow::Cow,
+    cell::{Cell, RefCell},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
+    convert::TryInto,
+    fmt::Display,
+    rc::{Rc, Weak as RcWeak},
+    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
+    time::{Duration, SystemTime},
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 // region: Simple Wrapper types (e.g., Box, Option)

--- a/serde_with/src/ser/legacy_arrays.rs
+++ b/serde_with/src/ser/legacy_arrays.rs
@@ -1,5 +1,6 @@
 use super::*;
 use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
 macro_rules! array_impl {

--- a/serde_with/src/ser/legacy_arrays.rs
+++ b/serde_with/src/ser/legacy_arrays.rs
@@ -1,5 +1,6 @@
 use super::*;
-use std::collections::{BTreeMap, HashMap};
+use alloc::collections::BTreeMap;
+use std::collections::HashMap;
 
 macro_rules! array_impl {
     ($($len:literal)+) => {$(

--- a/serde_with/src/serde_conv.rs
+++ b/serde_with/src/serde_conv.rs
@@ -109,7 +109,7 @@ macro_rules! serde_conv {
 
         #[allow(clippy::ptr_arg)]
         impl $m {
-            $vis fn serialize<S>(x: &$t, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            $vis fn serialize<S>(x: &$t, serializer: S) -> ::core::result::Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
             {
@@ -117,7 +117,7 @@ macro_rules! serde_conv {
                 $crate::serde::Serialize::serialize(&y, serializer)
             }
 
-            $vis fn deserialize<'de, D>(deserializer: D) -> ::std::result::Result<$t, D::Error>
+            $vis fn deserialize<'de, D>(deserializer: D) -> ::core::result::Result<$t, D::Error>
             where
                 D: $crate::serde::Deserializer<'de>,
             {
@@ -127,7 +127,7 @@ macro_rules! serde_conv {
         }
 
         impl $crate::SerializeAs<$t> for $m {
-            fn serialize_as<S>(x: &$t, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            fn serialize_as<S>(x: &$t, serializer: S) -> ::core::result::Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
             {
@@ -136,7 +136,7 @@ macro_rules! serde_conv {
         }
 
         impl<'de> $crate::DeserializeAs<'de, $t> for $m {
-            fn deserialize_as<D>(deserializer: D) -> ::std::result::Result<$t, D::Error>
+            fn deserialize_as<D>(deserializer: D) -> ::core::result::Result<$t, D::Error>
             where
                 D: $crate::serde::Deserializer<'de>,
             {

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -1,12 +1,12 @@
 pub(crate) mod duration;
 
+use core::marker::PhantomData;
 use serde::de::{Deserialize, MapAccess, SeqAccess};
-use std::marker::PhantomData;
 
 /// Re-Implementation of `serde::private::de::size_hint::cautious`
 #[inline]
 pub(crate) fn size_hint_cautious(hint: Option<usize>) -> usize {
-    std::cmp::min(hint.unwrap_or(0), 4096)
+    core::cmp::min(hint.unwrap_or(0), 4096)
 }
 
 pub(crate) const NANOS_PER_SEC: u32 = 1_000_000_000;

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -1,5 +1,6 @@
 pub(crate) mod duration;
 
+use alloc::string::String;
 use core::marker::PhantomData;
 use serde::de::{Deserialize, MapAccess, SeqAccess};
 
@@ -88,7 +89,7 @@ where
     }
 }
 
-pub(crate) fn duration_as_secs_f64(dur: &std::time::Duration) -> f64 {
+pub(crate) fn duration_as_secs_f64(dur: &core::time::Duration) -> f64 {
     (dur.as_secs() as f64) + (dur.subsec_nanos() as f64) / (NANOS_PER_SEC as f64)
 }
 

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -6,11 +6,17 @@ use crate::{
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
     DurationSeconds, DurationSecondsWithFrac, SerializeAs,
 };
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{fmt, ops::Neg, time::Duration};
 use serde::{
     de::{self, Unexpected, Visitor},
     ser, Deserialize, Deserializer, Serialize, Serializer,
 };
+#[cfg(feature = "std")]
 use std::time::SystemTime;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -60,6 +66,7 @@ impl DurationSigned {
         Self { sign, duration }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn to_system_time<'de, D>(self) -> Result<SystemTime, D::Error>
     where
         D: Deserializer<'de>,
@@ -93,6 +100,7 @@ impl From<&Duration> for DurationSigned {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<&SystemTime> for DurationSigned {
     fn from(time: &SystemTime) -> Self {
         match time.duration_since(SystemTime::UNIX_EPOCH) {
@@ -108,7 +116,7 @@ impl From<&SystemTime> for DurationSigned {
     }
 }
 
-impl std::ops::Mul<u32> for DurationSigned {
+impl core::ops::Mul<u32> for DurationSigned {
     type Output = DurationSigned;
 
     fn mul(mut self, rhs: u32) -> Self::Output {
@@ -117,7 +125,7 @@ impl std::ops::Mul<u32> for DurationSigned {
     }
 }
 
-impl std::ops::Div<u32> for DurationSigned {
+impl core::ops::Div<u32> for DurationSigned {
     type Output = DurationSigned;
 
     fn div(mut self, rhs: u32) -> Self::Output {
@@ -303,7 +311,7 @@ struct DurationVisitorFlexible;
 impl<'de> Visitor<'de> for DurationVisitorFlexible {
     type Value = DurationSigned;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("an integer, a float, or a string containing a number")
     }
 

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -1,16 +1,20 @@
 //! Internal Helper types
 
-use crate::formats::{Flexible, Format, Strict, Strictness};
 use crate::{
+    formats::{Flexible, Format, Strict, Strictness},
     utils, DeserializeAs, DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
     DurationSeconds, DurationSecondsWithFrac, SerializeAs,
 };
-use serde::de::{self, Unexpected, Visitor};
-use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use std::ops::Neg;
-use std::time::{Duration, SystemTime};
+use serde::{
+    de::{self, Unexpected, Visitor},
+    ser, Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::{
+    fmt,
+    ops::Neg,
+    time::{Duration, SystemTime},
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Sign {

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -6,15 +6,12 @@ use crate::{
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
     DurationSeconds, DurationSecondsWithFrac, SerializeAs,
 };
+use core::{fmt, ops::Neg, time::Duration};
 use serde::{
     de::{self, Unexpected, Visitor},
     ser, Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{
-    fmt,
-    ops::Neg,
-    time::{Duration, SystemTime},
-};
+use std::time::SystemTime;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Sign {

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::fmt;
 use serde::{
     de::{self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor},

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -1,8 +1,8 @@
-use serde::de::{
-    self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor,
+use serde::{
+    de::{self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor},
+    forward_to_deserialize_any,
+    ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer},
 };
-use serde::forward_to_deserialize_any;
-use serde::ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
 use std::fmt;
 
 /// Serialize with an added prefix on every field name and deserialize by

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -115,7 +115,7 @@ macro_rules! with_prefix {
             use $crate::with_prefix::WithPrefix;
 
             #[allow(dead_code)]
-            pub fn serialize<T, S>(object: &T, serializer: S) -> Result<S::Ok, S::Error>
+            pub fn serialize<T, S>(object: &T, serializer: S) -> ::core::result::Result<S::Ok, S::Error>
             where
                 T: Serialize,
                 S: Serializer,
@@ -127,7 +127,7 @@ macro_rules! with_prefix {
             }
 
             #[allow(dead_code)]
-            pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+            pub fn deserialize<'de, T, D>(deserializer: D) -> ::core::result::Result<T, D::Error>
             where
                 T: Deserialize<'de>,
                 D: Deserializer<'de>,

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -1,9 +1,9 @@
+use core::fmt;
 use serde::{
     de::{self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor},
     forward_to_deserialize_any,
     ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer},
 };
-use std::fmt;
 
 /// Serialize with an added prefix on every field name and deserialize by
 /// trimming away the prefix.

--- a/serde_with/tests/base64.rs
+++ b/serde_with/tests/base64.rs
@@ -6,9 +6,11 @@ mod utils;
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::base64::{Base64, Bcrypt, BinHex, Crypt, ImapMutf7, Standard, UrlSafe};
-use serde_with::formats::{Padded, Unpadded};
-use serde_with::serde_as;
+use serde_with::{
+    base64::{Base64, Bcrypt, BinHex, Crypt, ImapMutf7, Standard, UrlSafe},
+    formats::{Padded, Unpadded},
+    serde_as,
+};
 
 #[test]
 fn base64_vec() {

--- a/serde_with/tests/chrono.rs
+++ b/serde_with/tests/chrono.rs
@@ -1,9 +1,13 @@
+extern crate alloc;
+
 mod utils;
 
 use crate::utils::{
     check_deserialization, check_error_deserialization, check_serialization, is_equal,
 };
+use alloc::collections::BTreeMap;
 use chrono_crate::{DateTime, Duration, Local, NaiveDateTime, Utc};
+use core::{iter::FromIterator, str::FromStr};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{
@@ -13,7 +17,6 @@ use serde_with::{
     TimestampMicroSecondsWithFrac, TimestampMilliSeconds, TimestampMilliSecondsWithFrac,
     TimestampNanoSeconds, TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
 };
-use std::{collections::BTreeMap, iter::FromIterator, str::FromStr};
 
 fn new_datetime(secs: i64, nsecs: u32) -> DateTime<Utc> {
     DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nsecs), Utc)

--- a/serde_with/tests/chrono.rs
+++ b/serde_with/tests/chrono.rs
@@ -6,18 +6,14 @@ use crate::utils::{
 use chrono_crate::{DateTime, Duration, Local, NaiveDateTime, Utc};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::formats::Flexible;
 use serde_with::{
-    serde_as, DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
-    DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
-    DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,
-    TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
-    TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+    formats::Flexible, serde_as, DurationMicroSeconds, DurationMicroSecondsWithFrac,
+    DurationMilliSeconds, DurationMilliSecondsWithFrac, DurationNanoSeconds,
+    DurationNanoSecondsWithFrac, DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds,
+    TimestampMicroSecondsWithFrac, TimestampMilliSeconds, TimestampMilliSecondsWithFrac,
+    TimestampNanoSeconds, TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
 };
-
-use std::collections::BTreeMap;
-use std::iter::FromIterator;
-use std::str::FromStr;
+use std::{collections::BTreeMap, iter::FromIterator, str::FromStr};
 
 fn new_datetime(secs: i64, nsecs: u32) -> DateTime<Utc> {
     DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nsecs), Utc)

--- a/serde_with/tests/derives/deserialize_fromstr.rs
+++ b/serde_with/tests/derives/deserialize_fromstr.rs
@@ -1,8 +1,10 @@
 use super::*;
 use pretty_assertions::assert_eq;
 use serde_with::DeserializeFromStr;
-use std::num::ParseIntError;
-use std::str::{FromStr, ParseBoolError};
+use std::{
+    num::ParseIntError,
+    str::{FromStr, ParseBoolError},
+};
 
 #[derive(Debug, PartialEq, DeserializeFromStr)]
 struct A {
@@ -39,8 +41,7 @@ fn test_deserialize_fromstr() {
 
 #[test]
 fn test_deserialize_from_bytes() {
-    use serde::de::value::Error;
-    use serde::de::{Deserialize, Deserializer, Visitor};
+    use serde::de::{value::Error, Deserialize, Deserializer, Visitor};
 
     // Unfortunately serde_json is too clever (i.e. handles bytes gracefully)
     // so instead create a custom deserializer which can only deserialize bytes.

--- a/serde_with/tests/derives/deserialize_fromstr.rs
+++ b/serde_with/tests/derives/deserialize_fromstr.rs
@@ -1,10 +1,10 @@
 use super::*;
-use pretty_assertions::assert_eq;
-use serde_with::DeserializeFromStr;
-use std::{
+use core::{
     num::ParseIntError,
     str::{FromStr, ParseBoolError},
 };
+use pretty_assertions::assert_eq;
+use serde_with::DeserializeFromStr;
 
 #[derive(Debug, PartialEq, DeserializeFromStr)]
 struct A {

--- a/serde_with/tests/derives/serialize_display.rs
+++ b/serde_with/tests/derives/serialize_display.rs
@@ -1,6 +1,6 @@
 use super::*;
+use core::fmt;
 use serde_with::SerializeDisplay;
-use std::fmt;
 
 #[derive(Debug, SerializeDisplay)]
 struct A {

--- a/serde_with/tests/hex.rs
+++ b/serde_with/tests/hex.rs
@@ -3,9 +3,11 @@ mod utils;
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::formats::{Lowercase, Uppercase};
-use serde_with::hex::Hex;
-use serde_with::serde_as;
+use serde_with::{
+    formats::{Lowercase, Uppercase},
+    hex::Hex,
+    serde_as,
+};
 
 #[test]
 fn hex_vec() {

--- a/serde_with/tests/indexmap.rs
+++ b/serde_with/tests/indexmap.rs
@@ -5,8 +5,7 @@ use expect_test::expect;
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Same};
-use std::iter::FromIterator;
-use std::net::IpAddr;
+use std::{iter::FromIterator, net::IpAddr};
 
 #[test]
 fn test_indexmap() {

--- a/serde_with/tests/indexmap.rs
+++ b/serde_with/tests/indexmap.rs
@@ -1,11 +1,12 @@
 mod utils;
 
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use core::iter::FromIterator;
 use expect_test::expect;
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Same};
-use std::{iter::FromIterator, net::IpAddr};
+use std::net::IpAddr;
 
 #[test]
 fn test_indexmap() {

--- a/serde_with/tests/indexmap.rs
+++ b/serde_with/tests/indexmap.rs
@@ -109,7 +109,7 @@ fn test_tuple_list_as_map() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct SI(
-        #[serde_as(as = "std::collections::HashMap<DisplayFromStr, DisplayFromStr>")]
+        #[serde_as(as = "std::collections::BTreeMap<DisplayFromStr, DisplayFromStr>")]
         IndexSet<(u32, IpAddr)>,
     );
 

--- a/serde_with/tests/json.rs
+++ b/serde_with/tests/json.rs
@@ -3,8 +3,7 @@ mod utils;
 use crate::utils::is_equal;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::json::JsonString;
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::{json::JsonString, serde_as, DisplayFromStr};
 
 #[test]
 fn test_nested_json() {

--- a/serde_with/tests/rust.rs
+++ b/serde_with/tests/rust.rs
@@ -38,6 +38,7 @@ fn string_collection() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn prohibit_duplicate_value_hashset() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -80,6 +81,7 @@ fn prohibit_duplicate_value_btreeset() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn prohibit_duplicate_key_hashmap() {
     #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -152,6 +154,7 @@ fn prohibit_duplicate_key_btreemap() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn duplicate_key_first_wins_hashmap() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -282,6 +285,7 @@ fn duplicate_value_first_wins_hashset() {
     assert!(entries[1].1);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn duplicate_value_last_wins_hashset() {
     #[derive(Debug, PartialEq, Deserialize, Serialize)]

--- a/serde_with/tests/rust.rs
+++ b/serde_with/tests/rust.rs
@@ -4,12 +4,13 @@ use crate::utils::{check_deserialization, check_error_deserialization, is_equal}
 use expect_test::expect;
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use pretty_assertions::assert_eq;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::CommaSeparator;
-use std::cmp;
-use std::collections::{BTreeMap, BTreeSet, LinkedList, VecDeque};
-use std::iter::FromIterator as _;
+use std::{
+    cmp,
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
+    iter::FromIterator as _,
+};
 
 #[test]
 fn string_collection() {

--- a/serde_with/tests/rust.rs
+++ b/serde_with/tests/rust.rs
@@ -1,16 +1,15 @@
+extern crate alloc;
+
 mod utils;
 
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use alloc::collections::{BTreeMap, BTreeSet, LinkedList, VecDeque};
+use core::{cmp, iter::FromIterator as _};
 use expect_test::expect;
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::CommaSeparator;
-use std::{
-    cmp,
-    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
-    iter::FromIterator as _,
-};
 
 #[test]
 fn string_collection() {

--- a/serde_with/tests/serde_as/collections.rs
+++ b/serde_with/tests/serde_as/collections.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "std")]
 use super::*;
+#[cfg(feature = "std")]
 use fnv::{FnvHashMap, FnvHashSet};
 
 /// Test that HashSets are also supported with non-default hashers.
+#[cfg(feature = "std")]
 #[test]
 fn test_fnv_hashset() {
     #[serde_as]
@@ -24,6 +27,7 @@ fn test_fnv_hashset() {
 }
 
 /// Test that HashSets are also supported with non-default hashers.
+#[cfg(feature = "std")]
 #[test]
 fn test_fnv_hashmap() {
     #[serde_as]

--- a/serde_with/tests/serde_as/enum_map.rs
+++ b/serde_with/tests/serde_as/enum_map.rs
@@ -1,7 +1,8 @@
 use super::*;
+use core::str::FromStr;
 use serde_test::Configure;
 use serde_with::EnumMap;
-use std::{net::IpAddr, str::FromStr};
+use std::net::IpAddr;
 
 fn bytes_debug_readable(bytes: &[u8]) -> String {
     let mut result = String::with_capacity(bytes.len() * 2);

--- a/serde_with/tests/serde_as/enum_map.rs
+++ b/serde_with/tests/serde_as/enum_map.rs
@@ -1,8 +1,7 @@
 use super::*;
 use serde_test::Configure;
 use serde_with::EnumMap;
-use std::net::IpAddr;
-use std::str::FromStr;
+use std::{net::IpAddr, str::FromStr};
 
 fn bytes_debug_readable(bytes: &[u8]) -> String {
     let mut result = String::with_capacity(bytes.len() * 2);

--- a/serde_with/tests/serde_as/frominto.rs
+++ b/serde_with/tests/serde_as/frominto.rs
@@ -1,6 +1,6 @@
 use super::*;
+use core::convert::TryFrom;
 use serde_with::{FromInto, TryFromInto};
-use std::convert::TryFrom;
 
 #[derive(Clone, Debug, PartialEq)]
 enum IntoSerializable {

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -13,15 +13,16 @@ mod utils;
 use crate::utils::*;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
-use serde_with::formats::Flexible;
 use serde_with::{
-    serde_as, BytesOrString, CommaSeparator, DisplayFromStr, NoneAsEmptyString, OneOrMany, Same,
-    StringWithSeparator,
+    formats::Flexible, serde_as, BytesOrString, CommaSeparator, DisplayFromStr, NoneAsEmptyString,
+    OneOrMany, Same, StringWithSeparator,
 };
-use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, BTreeSet, HashMap, LinkedList, VecDeque};
-use std::rc::{Rc, Weak as RcWeak};
-use std::sync::{Arc, Mutex, RwLock, Weak as ArcWeak};
+use std::{
+    cell::{Cell, RefCell},
+    collections::{BTreeMap, BTreeSet, HashMap, LinkedList, VecDeque},
+    rc::{Rc, Weak as RcWeak},
+    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
+};
 
 #[test]
 fn test_basic_wrappers() {
@@ -427,8 +428,7 @@ fn test_bytes_or_string() {
 
 #[test]
 fn string_with_separator() {
-    use serde_with::rust::StringWithSeparator;
-    use serde_with::{CommaSeparator, SpaceSeparator};
+    use serde_with::{rust::StringWithSeparator, CommaSeparator, SpaceSeparator};
 
     #[serde_as]
     #[derive(Deserialize, Serialize)]

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -25,6 +25,7 @@ use serde_with::{
     formats::Flexible, serde_as, BytesOrString, CommaSeparator, DisplayFromStr, NoneAsEmptyString,
     OneOrMany, Same, StringWithSeparator,
 };
+#[cfg(feature = "std")]
 use std::{
     collections::HashMap,
     sync::{Mutex, RwLock},
@@ -81,7 +82,11 @@ fn test_basic_wrappers() {
     struct SRefCell(#[serde_as(as = "RefCell<DisplayFromStr>")] RefCell<u32>);
 
     is_equal(SRefCell(RefCell::new(123)), expect![[r#""123""#]]);
+}
 
+#[cfg(feature = "std")]
+#[test]
+fn test_basic_wrappers_std() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize)]
     struct SMutex(#[serde_as(as = "Mutex<DisplayFromStr>")] Mutex<u32>);

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 mod collections;
 mod default_on;
 mod enum_map;
@@ -11,6 +13,12 @@ mod time;
 mod utils;
 
 use crate::utils::*;
+use alloc::{
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
+    rc::{Rc, Weak as RcWeak},
+    sync::{Arc, Weak as ArcWeak},
+};
+use core::cell::{Cell, RefCell};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{
@@ -18,10 +26,8 @@ use serde_with::{
     OneOrMany, Same, StringWithSeparator,
 };
 use std::{
-    cell::{Cell, RefCell},
-    collections::{BTreeMap, BTreeSet, HashMap, LinkedList, VecDeque},
-    rc::{Rc, Weak as RcWeak},
-    sync::{Arc, Mutex, RwLock, Weak as ArcWeak},
+    collections::HashMap,
+    sync::{Mutex, RwLock},
 };
 
 #[test]
@@ -687,9 +693,9 @@ fn test_bytes() {
     // https://github.com/serde-rs/bytes/blob/cbae606b9dc225fc094b031cc84eac9493da2058/tests/test_derive.rs
     // Original code by @dtolnay
 
+    use alloc::borrow::Cow;
     use serde_test::{assert_de_tokens, assert_tokens, Token};
     use serde_with::Bytes;
-    use std::borrow::Cow;
 
     #[serde_as]
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -915,9 +921,9 @@ fn test_one_or_many_prefer_many() {
 /// Test that Cow borrows from the input
 #[test]
 fn test_borrow_cow_str() {
+    use alloc::borrow::Cow;
     use serde_test::{assert_ser_tokens, Token};
     use serde_with::BorrowCow;
-    use std::borrow::Cow;
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::net::IpAddr;
 
 #[test]
-fn test_map_as_tuple_list() {
+fn test_map_as_tuple_list_btreemap() {
     let ip = "1.2.3.4".parse().unwrap();
     let ip2 = "255.255.255.255".parse().unwrap();
 
@@ -52,6 +52,13 @@ fn test_map_as_tuple_list() {
               ]
             ]"#]],
     );
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_map_as_tuple_list_hashmap() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -103,8 +110,10 @@ fn test_map_as_tuple_list() {
     );
 }
 
+#[cfg(feature = "std")]
+// test_tuple_list_as_btreemap is the more extensive version
 #[test]
-fn test_tuple_list_as_map() {
+fn test_tuple_list_as_hashmap() {
     let ip = "1.2.3.4".parse().unwrap();
     let ip2 = "255.255.255.255".parse().unwrap();
 
@@ -121,6 +130,12 @@ fn test_tuple_list_as_map() {
               "200": "255.255.255.255"
             }"#]],
     );
+}
+
+#[test]
+fn test_tuple_list_as_btreemap() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -153,7 +168,7 @@ fn test_tuple_list_as_map() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Sll(
-        #[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")] LinkedList<(u32, IpAddr)>,
+        #[serde_as(as = "BTreeMap<DisplayFromStr, DisplayFromStr>")] LinkedList<(u32, IpAddr)>,
     );
 
     is_equal(
@@ -168,7 +183,7 @@ fn test_tuple_list_as_map() {
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct SO(#[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")] Option<(u32, IpAddr)>);
+    struct SO(#[serde_as(as = "BTreeMap<DisplayFromStr, DisplayFromStr>")] Option<(u32, IpAddr)>);
 
     is_equal(
         SO(Some((1, ip))),
@@ -182,10 +197,103 @@ fn test_tuple_list_as_map() {
 
 #[rustversion::since(1.51)]
 #[test]
-fn test_tuple_array_as_map() {
+fn test_tuple_array_as_btreemap() {
     #[serde_as]
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     struct S1(#[serde_as(as = "BTreeMap<_, _>")] [(u8, u8); 1]);
+    is_equal(
+        S1([(1, 2)]),
+        expect![[r#"
+            {
+              "1": 2
+            }"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct S2(#[serde_as(as = "BTreeMap<_, _>")] [(u8, u8); 33]);
+    is_equal(
+        S2([
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (5, 5),
+            (6, 6),
+            (7, 7),
+            (8, 8),
+            (9, 9),
+            (10, 10),
+            (11, 11),
+            (12, 12),
+            (13, 13),
+            (14, 14),
+            (15, 15),
+            (16, 16),
+            (17, 17),
+            (18, 18),
+            (19, 19),
+            (20, 20),
+            (21, 21),
+            (22, 22),
+            (23, 23),
+            (24, 24),
+            (25, 25),
+            (26, 26),
+            (27, 27),
+            (28, 28),
+            (29, 29),
+            (30, 30),
+            (31, 31),
+            (32, 32),
+        ]),
+        expect![[r#"
+            {
+              "0": 0,
+              "1": 1,
+              "2": 2,
+              "3": 3,
+              "4": 4,
+              "5": 5,
+              "6": 6,
+              "7": 7,
+              "8": 8,
+              "9": 9,
+              "10": 10,
+              "11": 11,
+              "12": 12,
+              "13": 13,
+              "14": 14,
+              "15": 15,
+              "16": 16,
+              "17": 17,
+              "18": 18,
+              "19": 19,
+              "20": 20,
+              "21": 21,
+              "22": 22,
+              "23": 23,
+              "24": 24,
+              "25": 25,
+              "26": 26,
+              "27": 27,
+              "28": 28,
+              "29": 29,
+              "30": 30,
+              "31": 31,
+              "32": 32
+            }"#]],
+    );
+}
+
+#[cfg(feature = "std")]
+#[rustversion::since(1.51)]
+#[test]
+fn test_tuple_array_as_hashmap() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct S1(#[serde_as(as = "HashMap<_, _>")] [(u8, u8); 1]);
     is_equal(
         S1([(1, 2)]),
         expect![[r#"

--- a/serde_with/tests/serde_as/time.rs
+++ b/serde_with/tests/serde_as/time.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::time::Duration;
 use serde_with::{
     DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
@@ -6,11 +7,10 @@ use serde_with::{
     TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
     TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
 };
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 #[test]
 fn test_duration_seconds() {
-    use std::time::Duration;
     let zero = Duration::new(0, 0);
     let one_second = Duration::new(1, 0);
     let half_second = Duration::new(0, 500_000_000);
@@ -134,7 +134,6 @@ fn test_duration_seconds() {
 
 #[test]
 fn test_duration_seconds_with_frac() {
-    use std::time::Duration;
     let zero = Duration::new(0, 0);
     let one_second = Duration::new(1, 0);
     let half_second = Duration::new(0, 500_000_000);

--- a/serde_with/tests/serde_as/time.rs
+++ b/serde_with/tests/serde_as/time.rs
@@ -3,10 +3,15 @@ use core::time::Duration;
 use serde_with::{
     DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
     DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
-    DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,
-    TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
-    TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+    DurationSeconds, DurationSecondsWithFrac,
 };
+#[cfg(feature = "std")]
+use serde_with::{
+    TimestampMicroSeconds, TimestampMicroSecondsWithFrac, TimestampMilliSeconds,
+    TimestampMilliSecondsWithFrac, TimestampNanoSeconds, TimestampNanoSecondsWithFrac,
+    TimestampSeconds, TimestampSecondsWithFrac,
+};
+#[cfg(feature = "std")]
 use std::time::SystemTime;
 
 #[test]
@@ -210,6 +215,7 @@ fn test_duration_seconds_with_frac() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_timestamp_seconds_systemtime() {
     let zero = SystemTime::UNIX_EPOCH;
@@ -354,6 +360,7 @@ fn test_timestamp_seconds_systemtime() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_timestamp_seconds_with_frac_systemtime() {
     let zero = SystemTime::UNIX_EPOCH;
@@ -491,6 +498,7 @@ fn test_duration_smoketest() {
     };
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_timestamp_systemtime_smoketest() {
     let one_second = SystemTime::UNIX_EPOCH

--- a/serde_with/tests/utils.rs
+++ b/serde_with/tests/utils.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
+use core::fmt::Debug;
 use expect_test::Expect;
 use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
 
 #[track_caller]
 pub fn is_equal<T>(value: T, expected: Expect)

--- a/serde_with/tests/utils.rs
+++ b/serde_with/tests/utils.rs
@@ -2,8 +2,7 @@
 
 use expect_test::Expect;
 use pretty_assertions::assert_eq;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 #[track_caller]

--- a/serde_with/tests/with_prefix.rs
+++ b/serde_with/tests/with_prefix.rs
@@ -4,8 +4,10 @@ use crate::utils::is_equal;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::with_prefix;
-use std::collections::{BTreeMap, HashMap};
-use std::iter::FromIterator;
+use std::{
+    collections::{BTreeMap, HashMap},
+    iter::FromIterator,
+};
 
 #[test]
 fn test_flatten_with_prefix() {

--- a/serde_with/tests/with_prefix.rs
+++ b/serde_with/tests/with_prefix.rs
@@ -1,13 +1,14 @@
+extern crate alloc;
+
 mod utils;
 
 use crate::utils::is_equal;
+use alloc::collections::BTreeMap;
+use core::iter::FromIterator;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::with_prefix;
-use std::{
-    collections::{BTreeMap, HashMap},
-    iter::FromIterator,
-};
+use std::collections::HashMap;
 
 #[test]
 fn test_flatten_with_prefix() {

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -45,16 +45,14 @@ extern crate proc_macro;
 mod utils;
 
 use crate::utils::{split_with_de_lifetime, DeriveOptions, IteratorExt as _};
-use darling::util::Override;
-use darling::{Error as DarlingError, FromField, FromMeta};
+use darling::{util::Override, Error as DarlingError, FromField, FromMeta};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::punctuated::Pair;
-use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, parse_quote, AttributeArgs, DeriveInput, Error, Field, Fields,
-    GenericArgument, ItemEnum, ItemStruct, Meta, NestedMeta, Path, PathArguments, ReturnType, Type,
+    parse_macro_input, parse_quote, punctuated::Pair, spanned::Spanned, AttributeArgs, DeriveInput,
+    Error, Field, Fields, GenericArgument, ItemEnum, ItemStruct, Meta, NestedMeta, Path,
+    PathArguments, ReturnType, Type,
 };
 
 /// Apply function on every field of structs or enums

--- a/serde_with_macros/src/utils.rs
+++ b/serde_with_macros/src/utils.rs
@@ -1,8 +1,8 @@
+use core::iter::Iterator;
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
-use std::iter::Iterator;
 use syn::{parse_quote, Error, Generics, Path, TypeGenerics};
 
 /// Merge multiple [`syn::Error`] into one.

--- a/serde_with_test/tests/with_prefix.rs
+++ b/serde_with_test/tests/with_prefix.rs
@@ -1,0 +1,9 @@
+//! Test that the with_prefix macros properly name all the types and traits used
+
+// Ensure no prelude is available
+#![no_implicit_prelude]
+#![allow(dead_code, unused_imports)]
+
+use ::s_with::with_prefix;
+
+with_prefix!(prefix_foobar "foobar_");


### PR DESCRIPTION
This is the initial work to support `no_std` for `serde_with` (#435).

This updates all imports to import from `core` or `alloc` where possible. Additionally, implementations are gated behind the `std` feature.

TODOs:
* [ ] Update macros to import from `core`/`alloc`.
* [ ] Update `serde_with_macros` to generate code referencing `core`/`alloc`.
* [ ] Figure out if `core` or `core`+`alloc` is the better baseline?
* [ ] Update imports to use `no-default-features` and enable `alloc`/`std` as necessary.
* [ ] Figure out how to do testing. This is necessary to ensure the rewritten macros work properly.