### PR TITLE
Disable the OSSF Scorecard Action

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -1,11 +1,12 @@
 name: Scorecards supply-chain security
 on:
-  # Only the default branch is supported.
-  branch_protection_rule:
-  schedule:
-    - cron: '22 12 * * 4'
-  push:
-    branches: [ master ]
+  workflow_dispatch:
+#  # Only the default branch is supported.
+#  branch_protection_rule:
+#  schedule:
+#    - cron: '22 12 * * 4'
+#  push:
+#    branches: [ master ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Without a way to supress analysis results more permanently the security
tab becomes too noisy. Either the action needs to allow an allowlist or
the GitHub UI needs to be better in permanently supressing lines.
The biggest annoyance is that each change to a action tag will trigger
a new warning, even if the same line was ignored before.

https://github.com/ossf/scorecard-action/issues/143