### PR TITLE
Add support for `time` v0.3 types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         # It is good to test more than the MSRV and stable since sometimes
         # breakage occurs in intermediate versions.
         # IMPORTANT: Synchronize the MSRV with the Cargo.toml values.
-        rust: ["1.46", "1.50", "1.55", "stable", "beta", "nightly"]
+        rust: ["1.53", "1.55", "1.60", "stable", "beta", "nightly"]
         crate: ["serde_with", "serde_with_macros", "serde_with_test"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     "rfc_3339": ["1997-11-21T09:55:06-06:00"],
     ```
 
+### Changed
+
+* Bump MSRV to 1.53, since the new dependency `time` requires that version.
+
 ### Fixed
 
 * Make the documentation clearer by stating that the `#[serde_as]` and `#[skip_serializing_none]` attributes must always be places before `#[derive]`.

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add support for `time` crate v0.3 #450
+
+    `time::Duration` can now be serialized with the `DurationSeconds` and related converters.
+
+    ```rust
+    // Rust
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    value: Duration,
+
+    // JSON
+    "value": 86400,
+    ```
+
+    `time::OffsetDateTime` and `time::PrimitiveDateTime` can now be serialized with the `TimestampSeconds` and related converters.
+
+
+    ```rust
+    // Rust
+    #[serde_as(as = "serde_with::TimestampMicroSecondsWithFrac<String>")]
+    value: time::PrimitiveDateTime,
+
+    // JSON
+    "value": "1000000",
+    ```
+
+    `time::OffsetDateTime` can be serialized in string format in different well-known formats.
+    Two formats are supported, `time::format_description::well_known::Rfc2822` and `time::format_description::well_known::Rfc3339`.
+
+    ```rust
+    // Rust
+    #[serde_as(as = "time::format_description::well_known::Rfc2822")]
+    rfc_2822: OffsetDateTime,
+    #[serde_as(as = "Vec<time::format_description::well_known::Rfc3339>")]
+    rfc_3339: Vec<OffsetDateTime>,
+
+    // JSON
+    "rfc_2822": "Fri, 21 Nov 1997 09:55:06 -0600",
+    "rfc_3339": ["1997-11-21T09:55:06-06:00"],
+    ```
+
 ### Fixed
 
 * Make the documentation clearer by stating that the `#[serde_as]` and `#[skip_serializing_none]` attributes must always be places before `#[derive]`.
@@ -143,9 +185,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
     The `#[serde(borrow)]` annotation is automatically added by the `#[serde_as]` attribute.
 
-## Changed
+### Changed
 
-* Bump MSRV to 1.46, since the dev-dependency bitflags requires that version now.
+* Bump MSRV to 1.46, since the dev-dependency `bitflags` requires that version now.
 * `flattened_maybe!` no longer requires the `serde_with` crate to be available with a specific name.
     This allows renaming the crate or using `flattened_maybe!` through a re-export without any complications.
 

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -43,7 +43,7 @@ rustversion = "1.0.0"
 serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.2", optional = true}
-time_0_3 = {package = "time", version = "~0.3", optional = true}
+time_0_3 = {package = "time", version = "~0.3", optional = true, features = ["serde-well-known"]}
 
 [dev-dependencies]
 expect-test = "1.0.0"
@@ -89,6 +89,11 @@ required-features = ["json", "macros"]
 name = "serde_as"
 path = "tests/serde_as/lib.rs"
 required-features = ["macros"]
+
+[[test]]
+name = "time_0_3"
+path = "tests/time_0_3.rs"
+required-features = ["macros", "time_0_3"]
 
 [[test]]
 name = "derives"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Marcin Kaźmierczak",
 ]
 name = "serde_with"
-rust-version = "1.46"
+rust-version = "1.53"
 version = "1.13.0"
 
 categories = ["encoding"]

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -43,6 +43,7 @@ rustversion = "1.0.0"
 serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.2", optional = true}
+time_0_3 = {package = "time", version = "~0.3", optional = true}
 
 [dev-dependencies]
 expect-test = "1.0.0"

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -10,6 +10,7 @@ Each entry will explain the feature in more detail.
 5. [`indexmap`](#indexmap)
 6. [`json`](#json)
 7. [`macros`](#macros)
+8. [`time_0_3`](#time_0_3)
 
 ## `base64`
 
@@ -52,3 +53,10 @@ The `macros` features enables all helper macros and derives.
 It is enabled by default, since the macros provide a usability benefit, especially for `serde_as`.
 
 This pulls in `serde_with_macros` as a dependency.
+
+## `time_0_3`
+
+The `time_0_3` enables integration of `time` v0.3 specific conversions.
+This includes support for the timestamp and duration types.
+
+This pulls in `time` v0.3 as a dependency.

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -23,6 +23,7 @@ This page lists the transformations implemented in this crate and supported by `
 19. [Timestamps as seconds since UNIX epoch](#timestamps-as-seconds-since-unix-epoch)
 20. [Value into JSON String](#value-into-json-string)
 21. [`Vec` of tuples to `Maps`](#vec-of-tuples-to-maps)
+22. [Well-known time formats for `OffsetDateTime`](#well-known-time-formats-for-offsetdatetime)
 
 ## Base64 encode bytes
 
@@ -211,6 +212,8 @@ value: Duration,
 ```
 
 The same conversions are also implemented for [`chrono::Duration`] with the `chrono` feature.
+
+The same conversions are also implemented for [`time::Duration`] with the `time_0_3` feature.
 
 ## Hex encode bytes
 
@@ -405,6 +408,8 @@ value: SystemTime,
 
 The same conversions are also implemented for [`chrono::DateTime<Utc>`], [`chrono::DateTime<Local>`], and [`chrono::NaiveDateTime`] with the `chrono` feature.
 
+The conversions are availble for [`time::OffsetDateTime`] and [`time::PrimitiveDateTime`] with the `time_0_3` feature enabled.
+
 ## Value into JSON String
 
 Some JSON APIs are weird and return a JSON encoded string in a JSON response
@@ -446,6 +451,25 @@ This includes `BinaryHeap<(K, V)>`, `BTreeSet<(K, V)>`, `HashSet<(K, V)>`, `Link
 
 The [inverse operation](#maps-to-vec-of-tuples) is also available.
 
+## Well-known time formats for `OffsetDateTime`
+
+[`time::OffsetDateTime`] can be serialized in string format in different well-known formats.
+Two formats are supported, [`time::format_description::well_known::Rfc2822`] and [`time::format_description::well_known::Rfc3339`].
+
+```ignore
+// Rust
+#[serde_as(as = "time::format_description::well_known::Rfc2822")]
+rfc_2822: OffsetDateTime,
+#[serde_as(as = "time::format_description::well_known::Rfc3339")]
+rfc_3339: OffsetDateTime,
+
+// JSON
+"rfc_2822": "Fri, 21 Nov 1997 09:55:06 -0600",
+"rfc_3339": "1997-11-21T09:55:06-06:00",
+```
+
+These conversions are availble with the `time_0_3` feature flag.
+
 [`Base64`]: crate::base64::Base64
 [`Bytes`]: crate::Bytes
 [`chrono::DateTime<Local>`]: chrono_crate::DateTime
@@ -464,6 +488,11 @@ The [inverse operation](#maps-to-vec-of-tuples) is also available.
 [`NoneAsEmptyString`]: crate::NoneAsEmptyString
 [`OneOrMany`]: crate::OneOrMany
 [`PickFirst`]: crate::PickFirst
+[`time::Duration`]: time_0_3::Duration
+[`time::format_description::well_known::Rfc2822`]: time_0_3::format_description::well_known::Rfc2822
+[`time::format_description::well_known::Rfc3339`]: time_0_3::format_description::well_known::Rfc3339
+[`time::OffsetDateTime`]: time_0_3::OffsetDateTime
+[`time::PrimitiveDateTime`]: time_0_3::PrimitiveDateTime
 [`TimestampSeconds`]: crate::TimestampSeconds
 [`TimestampSecondsWithFrac`]: crate::TimestampSecondsWithFrac
 [`TryFromInto`]: crate::TryFromInto

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -264,9 +264,6 @@ pub mod base64;
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod chrono;
-#[cfg(feature = "time_0_3")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time_0_3")))]
-pub mod time_0_3;
 mod content;
 pub mod de;
 mod duplicate_key_impls;
@@ -282,6 +279,9 @@ pub mod json;
 pub mod rust;
 pub mod ser;
 mod serde_conv;
+#[cfg(feature = "time_0_3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time_0_3")))]
+pub mod time_0_3;
 mod utils;
 #[doc(hidden)]
 pub mod with_prefix;
@@ -749,6 +749,7 @@ pub struct BytesOrString;
 /// For example, deserializing `DurationSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::Duration`] with the `chrono`-[feature flag].
+/// This type also supports [`time::Duration`][::time_0_3::Duration] with the `time_0_3`-[feature flag].
 ///
 /// | Duration Type         | Converter                 | Available `FORMAT`s    |
 /// | --------------------- | ------------------------- | ---------------------- |
@@ -756,6 +757,8 @@ pub struct BytesOrString;
 /// | `std::time::Duration` | `DurationSecondsWithFrac` | `f64`, `String`        |
 /// | `chrono::Duration`    | `DurationSeconds`         | `i64`, `f64`, `String` |
 /// | `chrono::Duration`    | `DurationSecondsWithFrac` | `f64`, `String`        |
+/// | `time::Duration`      | `DurationSeconds`         | `i64`, `f64`, `String` |
+/// | `time::Duration`      | `DurationSecondsWithFrac` | `f64`, `String`        |
 ///
 /// # Examples
 ///
@@ -889,6 +892,7 @@ pub struct DurationSeconds<
 /// For example, deserializing `DurationSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::Duration`] with the `chrono`-[feature flag].
+/// This type also supports [`time::Duration`][::time_0_3::Duration] with the `time_0_3`-[feature flag].
 ///
 /// | Duration Type         | Converter                 | Available `FORMAT`s    |
 /// | --------------------- | ------------------------- | ---------------------- |
@@ -896,6 +900,8 @@ pub struct DurationSeconds<
 /// | `std::time::Duration` | `DurationSecondsWithFrac` | `f64`, `String`        |
 /// | `chrono::Duration`    | `DurationSeconds`         | `i64`, `f64`, `String` |
 /// | `chrono::Duration`    | `DurationSecondsWithFrac` | `f64`, `String`        |
+/// | `time::Duration`      | `DurationSeconds`         | `i64`, `f64`, `String` |
+/// | `time::Duration`      | `DurationSecondsWithFrac` | `f64`, `String`        |
 ///
 /// # Examples
 ///
@@ -1069,6 +1075,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::DateTime`][DateTime] with the `chrono`-[feature flag].
+/// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// | Timestamp Type            | Converter                  | Available `FORMAT`s    |
 /// | ------------------------- | -------------------------- | ---------------------- |
@@ -1078,6 +1085,10 @@ pub struct DurationNanoSecondsWithFrac<
 /// | `chrono::DateTime<Utc>`   | `TimestampSecondsWithFrac` | `f64`, `String`        |
 /// | `chrono::DateTime<Local>` | `TimestampSeconds`         | `i64`, `f64`, `String` |
 /// | `chrono::DateTime<Local>` | `TimestampSecondsWithFrac` | `f64`, `String`        |
+/// | `time::OffsetDateTime`    | `TimestampSeconds`         | `i64`, `f64`, `String` |
+/// | `time::OffsetDateTime`    | `TimestampSecondsWithFrac` | `f64`, `String`        |
+/// | `time::PrimitiveDateTime` | `TimestampSeconds`         | `i64`, `f64`, `String` |
+/// | `time::PrimitiveDateTime` | `TimestampSecondsWithFrac` | `f64`, `String`        |
 ///
 /// # Examples
 ///
@@ -1212,6 +1223,7 @@ pub struct TimestampSeconds<
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::DateTime`][DateTime] and [`chrono::NaiveDateTime`][NaiveDateTime] with the `chrono`-[feature flag].
+/// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// | Timestamp Type            | Converter                  | Available `FORMAT`s    |
 /// | ------------------------- | -------------------------- | ---------------------- |
@@ -1223,6 +1235,10 @@ pub struct TimestampSeconds<
 /// | `chrono::DateTime<Local>` | `TimestampSecondsWithFrac` | `f64`, `String`        |
 /// | `chrono::NaiveDateTime`   | `TimestampSeconds`         | `i64`, `f64`, `String` |
 /// | `chrono::NaiveDateTime`   | `TimestampSecondsWithFrac` | `f64`, `String`        |
+/// | `time::OffsetDateTime`    | `TimestampSeconds`         | `i64`, `f64`, `String` |
+/// | `time::OffsetDateTime`    | `TimestampSecondsWithFrac` | `f64`, `String`        |
+/// | `time::PrimitiveDateTime` | `TimestampSeconds`         | `i64`, `f64`, `String` |
+/// | `time::PrimitiveDateTime` | `TimestampSecondsWithFrac` | `f64`, `String`        |
 ///
 /// # Examples
 ///

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -264,6 +264,9 @@ pub mod base64;
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod chrono;
+#[cfg(feature = "time_0_3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time_0_3")))]
+pub mod time_0_3;
 mod content;
 pub mod de;
 mod duplicate_key_impls;

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -1,0 +1,304 @@
+use crate::de::DeserializeAs;
+use crate::formats::{Flexible, Format, Strict, Strictness};
+use crate::ser::SerializeAs;
+use crate::utils::duration::{DurationSigned, Sign};
+use crate::{
+    DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
+    DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
+    DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,
+    TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
+    TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+};
+use serde::{de, Deserializer, Serializer};
+use std::convert::TryInto;
+use std::time::Duration as StdDuration;
+use time_0_3::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time};
+
+/// Create a [`PrimitiveDateTime`] for the Unix Epoch
+fn unix_epoch_primitive() -> PrimitiveDateTime {
+    PrimitiveDateTime::new(
+        Date::from_ordinal_date(1970, 1).unwrap(),
+        Time::from_hms_nano(0, 0, 0, 0).unwrap(),
+    )
+}
+
+/// Convert a [`chrono::Duration`] into a [`DurationSigned`]
+fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
+    let std_dur = StdDuration::new(
+        dur.whole_seconds().abs() as _,
+        dur.subsec_nanoseconds().abs() as _,
+    );
+
+    DurationSigned::with_duration(
+        if dur.is_positive() {
+            Sign::Positive
+        } else {
+            Sign::Negative
+        },
+        std_dur,
+    )
+}
+
+/// Convert a [`DurationSigned`] into a [`time_0_3::Duration`]
+fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut dur: Duration = match sdur.duration.try_into() {
+        Ok(dur) => dur,
+        Err(msg) => {
+            return Err(de::Error::custom(format!(
+                "Duration is outside of the representable range: {}",
+                msg
+            )))
+        }
+    };
+    if sdur.sign.is_negative() {
+        dur = -dur;
+    }
+    Ok(dur)
+}
+
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident =>
+        {
+            $ty:ty; $converter:ident =>
+            $({
+                $format:ty, $strictness:ty =>
+                $($tbound:ident: $bound:ident $(,)?)*
+            })*
+        }
+    ) => {
+        $(
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*
+    };
+    (
+        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
+    ) => {
+        $( use_duration_signed_ser!($main_trait $internal_trait => $rest); )+
+    };
+}
+
+fn offset_datetime_to_duration(source: &OffsetDateTime) -> DurationSigned {
+    duration_into_duration_signed(&(*source - OffsetDateTime::UNIX_EPOCH))
+}
+
+fn primitive_datetime_to_duration(source: &PrimitiveDateTime) -> DurationSigned {
+    duration_into_duration_signed(&(*source - unix_epoch_primitive()))
+}
+
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration; duration_into_duration_signed =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        OffsetDateTime; offset_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        PrimitiveDateTime; primitive_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Duration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        OffsetDateTime; offset_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        PrimitiveDateTime; primitive_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident =>
+        {
+            $ty:ty; $converter:ident =>
+            $({
+                $format:ty, $strictness:ty =>
+                $($tbound:ident: $bound:ident)*
+            })*
+        }
+    ) =>{
+        $(
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*
+    };
+    (
+        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
+    ) => {
+        $( use_duration_signed_de!($main_trait $internal_trait => $rest); )+
+    };
+}
+
+fn duration_to_offset_datetime<'de, D>(dur: DurationSigned) -> Result<OffsetDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(OffsetDateTime::UNIX_EPOCH + duration_from_duration_signed::<D>(dur)?)
+}
+
+fn duration_to_primitive_datetime<'de, D>(
+    dur: DurationSigned,
+) -> Result<PrimitiveDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(unix_epoch_primitive() + duration_from_duration_signed::<D>(dur)?)
+}
+
+// No subsecond precision
+use_duration_signed_de!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration; duration_from_duration_signed =>
+        {i64, Strict =>}
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        OffsetDateTime; duration_to_offset_datetime =>
+        {i64, Strict =>}
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        PrimitiveDateTime; duration_to_primitive_datetime =>
+        {i64, Strict =>}
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_de!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Duration; duration_from_duration_signed =>
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        OffsetDateTime; duration_to_offset_datetime =>
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        PrimitiveDateTime; duration_to_primitive_datetime =>
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -1,3 +1,9 @@
+//! De/Serialization of [time v0.3][time] types
+//!
+//! This modules is only available if using the `time_0_3` feature of the crate.
+//!
+//! [time]: https://docs.rs/time/0.3/
+
 use crate::de::DeserializeAs;
 use crate::formats::{Flexible, Format, Strict, Strictness};
 use crate::ser::SerializeAs;

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -34,8 +34,8 @@ fn unix_epoch_primitive() -> PrimitiveDateTime {
 /// Convert a [`time::Duration`][time_0_3::Duration] into a [`DurationSigned`]
 fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
     let std_dur = StdDuration::new(
-        dur.whole_seconds().abs() as _,
-        dur.subsec_nanoseconds().abs() as _,
+        dur.whole_seconds().unsigned_abs(),
+        dur.subsec_nanoseconds().unsigned_abs(),
     );
 
     DurationSigned::with_duration(

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -54,7 +54,7 @@ impl DurationSigned {
         }
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(any(feature = "chrono", feature = "time_0_3"))]
     pub(crate) fn with_duration(sign: Sign, duration: Duration) -> Self {
         Self { sign, duration }
     }

--- a/serde_with/tests/time_0_3.rs
+++ b/serde_with/tests/time_0_3.rs
@@ -1,0 +1,221 @@
+mod utils;
+
+use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use expect_test::expect;
+use serde::{Deserialize, Serialize};
+use serde_with::{
+    serde_as, DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
+    DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
+    DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,
+    TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
+    TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+};
+use time_0_3::{Duration, OffsetDateTime, PrimitiveDateTime, UtcOffset};
+
+/// Create a [`PrimitiveDateTime`] for the Unix Epoch
+fn unix_epoch_primitive() -> PrimitiveDateTime {
+    PrimitiveDateTime::new(
+        time_0_3::Date::from_ordinal_date(1970, 1).unwrap(),
+        time_0_3::Time::from_hms_nano(0, 0, 0, 0).unwrap(),
+    )
+}
+
+macro_rules! smoketest {
+    ($($valuety:ty, $adapter:literal, $value:expr, $expect:tt;)*) => {
+        $({
+            #[serde_as]
+            #[derive(Debug, Serialize, Deserialize, PartialEq)]
+            struct S(#[serde_as(as = $adapter)] $valuety);
+            #[allow(unused_braces)]
+            is_equal(S($value), $expect);
+        })*
+    };
+}
+
+#[test]
+fn test_duration_smoketest() {
+    let zero = Duration::seconds(0);
+    let one_second = Duration::seconds(1);
+
+    smoketest! {
+        Duration, "DurationSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        Duration, "DurationSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        Duration, "DurationMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        Duration, "DurationMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        Duration, "DurationMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        Duration, "DurationMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        Duration, "DurationNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        Duration, "DurationNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        Duration, "DurationSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        Duration, "DurationSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        Duration, "DurationMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        Duration, "DurationMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        Duration, "DurationMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        Duration, "DurationMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        Duration, "DurationNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        Duration, "DurationNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        Duration, "DurationSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        Duration, "DurationSecondsWithFrac", zero + Duration::nanoseconds(500_000_000), {expect![[r#"0.5"#]]};
+        Duration, "DurationSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
+        Duration, "DurationSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
+        Duration, "DurationSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_datetime_utc_smoketest() {
+    let zero = OffsetDateTime::UNIX_EPOCH;
+    let one_second = zero + Duration::seconds(1);
+
+    smoketest! {
+        OffsetDateTime, "TimestampSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        OffsetDateTime, "TimestampSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        OffsetDateTime, "TimestampMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        OffsetDateTime, "TimestampMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        OffsetDateTime, "TimestampMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        OffsetDateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        OffsetDateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        OffsetDateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        OffsetDateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        OffsetDateTime, "TimestampSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        OffsetDateTime, "TimestampMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        OffsetDateTime, "TimestampMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        OffsetDateTime, "TimestampMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        OffsetDateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        OffsetDateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        OffsetDateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        OffsetDateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        OffsetDateTime, "TimestampSecondsWithFrac", zero + Duration::nanoseconds(500_000_000), {expect![[r#"0.5"#]]};
+        OffsetDateTime, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
+        OffsetDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
+        OffsetDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_naive_datetime_smoketest() {
+    let zero = unix_epoch_primitive();
+    let one_second = zero + Duration::seconds(1);
+
+    smoketest! {
+        PrimitiveDateTime, "TimestampSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        PrimitiveDateTime, "TimestampSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        PrimitiveDateTime, "TimestampMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        PrimitiveDateTime, "TimestampMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        PrimitiveDateTime, "TimestampMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        PrimitiveDateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        PrimitiveDateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        PrimitiveDateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        PrimitiveDateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        PrimitiveDateTime, "TimestampSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        PrimitiveDateTime, "TimestampMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        PrimitiveDateTime, "TimestampMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        PrimitiveDateTime, "TimestampMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        PrimitiveDateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        PrimitiveDateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        PrimitiveDateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        PrimitiveDateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        PrimitiveDateTime, "TimestampSecondsWithFrac", zero + Duration::nanoseconds(500_000_000), {expect![[r#"0.5"#]]};
+        PrimitiveDateTime, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
+        PrimitiveDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
+        PrimitiveDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_offset_datetime_rfc2822() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde_as(as = "time_0_3::format_description::well_known::Rfc2822")] OffsetDateTime);
+
+    is_equal(
+        S(OffsetDateTime::UNIX_EPOCH),
+        expect![[r#""Thu, 01 Jan 1970 00:00:00 +0000""#]],
+    );
+
+    check_error_deserialization::<S>(
+        r#""Foobar""#,
+        expect![[r#"the 'weekday' component could not be parsed at line 1 column 8"#]],
+    );
+    check_error_deserialization::<S>(
+        r#""Fri, 2000""#,
+        expect![[r#"a character literal was not valid at line 1 column 11"#]],
+    );
+}
+
+#[test]
+fn test_offset_datetime_rfc3339() {
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde_as(as = "time_0_3::format_description::well_known::Rfc3339")] OffsetDateTime);
+
+    is_equal(
+        S(OffsetDateTime::UNIX_EPOCH),
+        expect![[r#""1970-01-01T00:00:00Z""#]],
+    );
+    check_deserialization::<S>(
+        S(
+            OffsetDateTime::from_unix_timestamp_nanos(482_196_050_520_000_000)
+                .unwrap()
+                .to_offset(UtcOffset::from_hms(0, 0, 0).unwrap()),
+        ),
+        r#""1985-04-12T23:20:50.52Z""#,
+    );
+    check_deserialization::<S>(
+        S(OffsetDateTime::from_unix_timestamp(851_042_397)
+            .unwrap()
+            .to_offset(UtcOffset::from_hms(-8, 0, 0).unwrap())),
+        r#""1996-12-19T16:39:57-08:00""#,
+    );
+    check_deserialization::<S>(
+        S(
+            OffsetDateTime::from_unix_timestamp_nanos(662_687_999_999_999_999)
+                .unwrap()
+                .to_offset(UtcOffset::from_hms(0, 0, 0).unwrap()),
+        ),
+        r#""1990-12-31T23:59:60Z""#,
+    );
+    check_deserialization::<S>(
+        S(
+            OffsetDateTime::from_unix_timestamp_nanos(662_687_999_999_999_999)
+                .unwrap()
+                .to_offset(UtcOffset::from_hms(-8, 0, 0).unwrap()),
+        ),
+        r#""1990-12-31T15:59:60-08:00""#,
+    );
+    check_deserialization::<S>(
+        S(
+            OffsetDateTime::from_unix_timestamp_nanos(-1_041_337_172_130_000_000)
+                .unwrap()
+                .to_offset(UtcOffset::from_hms(0, 20, 0).unwrap()),
+        ),
+        r#""1937-01-01T12:00:27.87+00:20""#,
+    );
+
+    check_error_deserialization::<S>(
+        r#""Foobar""#,
+        expect![[r#"the 'year' component could not be parsed at line 1 column 8"#]],
+    );
+    check_error_deserialization::<S>(
+        r#""2000-AA""#,
+        expect![[r#"the 'month' component could not be parsed at line 1 column 9"#]],
+    );
+}

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jonas Bushart"]
 name = "serde_with_macros"
-rust-version = "1.46"
+rust-version = "1.53"
 version = "1.5.2"
 
 categories = ["encoding"]

--- a/serde_with_test/Cargo.toml
+++ b/serde_with_test/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2018"
 name = "serde_with_test"
 publish = false
 version = "0.0.0"
-rust-version = "1.46"
+rust-version = "1.53"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -5,8 +5,6 @@
 #![allow(dead_code, unused_imports)]
 
 use ::s_with::{DeserializeFromStr, SerializeDisplay};
-// Needed for 1.46, unused in 1.50
-use ::std::panic;
 
 #[derive(DeserializeFromStr, SerializeDisplay)]
 #[serde_with(crate = "::s_with")]

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -4,9 +4,6 @@
 #![no_implicit_prelude]
 #![allow(dead_code, unused_imports)]
 
-// Needed for 1.46, unused in 1.50
-use ::std::panic;
-
 // The macro creates custom deserialization code.
 // You need to specify a function name and the field name of the flattened field.
 ::s_with::flattened_maybe!(deserialize_t, "t");


### PR DESCRIPTION
Add support for the `time` crate v0.3.

* Convert `time::Duration` with `Duration*Second`.
* Convert `time::OffsetDateTime` and `time::PrimitiveDateTime` with `Timestamp*Seconds`.
* Turn `Rfc2822` and `Rfc3339` into conversion type, such that they can be used inside collections.
* Add tests for the new functionality

Todo:
* [x] Update Changelog