### PR TITLE
Cleanup code for pre-1.53 versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,28 +87,24 @@ jobs:
 
       # Build the project
       - name: "Build (${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo build --all-features --all-targets --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo build --all-features --all-targets
 
       # The tests are split into build and run steps, to see the time impact of each
       # cargo test --all-targets does NOT run doctests
       # since doctests are important this should not be added
       # https://github.com/rust-lang/cargo/issues/6669
-      #
-      # We need to specify the manifest path, such that cargo knows where to apply the `no-default-features`.
-      # This is no longer necessary for Rust 1.51 or resolver="2"
-      # https://doc.rust-lang.org/nightly/cargo/reference/features.html#resolver-version-2-command-line-flags
       - name: "Test Build (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --no-default-features --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --no-default-features --no-run
       - name: "Test Run (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --no-default-features --no-fail-fast
       - name: "Test Build (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --no-run
       - name: "Test Run (Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --no-fail-fast
       - name: "Test Build (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --all-features  --no-run --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --all-features  --no-run
       - name: "Test Run (All Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
-        run: cargo test --all-features --no-default-features --no-fail-fast --manifest-path=${{ matrix.crate }}/Cargo.toml
+        run: cargo test --all-features --no-default-features --no-fail-fast
 
       - name: Run cargo-tarpaulin
         if: matrix.rust == 'stable'  && matrix.os == 'ubuntu-latest'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "serde_with_macros",
     "serde_with_test",
 ]
+resolver = "2"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -39,7 +39,6 @@ chrono_crate = {package = "chrono", version = "0.4.1", features = ["clock", "ser
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.2", optional = true}
 indexmap_crate = {package = "indexmap", version = "1.8", features = ["serde-1"], optional = true}
-rustversion = "1.0.0"
 serde = {version = "1.0.122", features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.2", optional = true}
@@ -54,10 +53,11 @@ pretty_assertions = "1.0.0"
 regex = {version = "1.3.9", default-features = false, features = ["std"]}
 rmp-serde = "0.15.5"
 ron = "0.7"
-serde-xml-rs = "0.5.0"
+rustversion = "1.0.0"
 serde_json = {version = "1.0.25", features = ["preserve_order"]}
 serde_test = "1.0.124"
 serde_yaml = "0.8.21"
+serde-xml-rs = "0.5.0"
 version-sync = "0.9.1"
 
 [[test]]

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -7,25 +7,8 @@
 //!
 //! [user guide]: crate::guide
 
+mod const_arrays;
 mod impls;
-
-// The redirection via macro_rules is necessary to circumvent https://github.com/rust-lang/rust/issues/54727
-// which prevents proc macros on non-inline modules
-#[rustversion::before(1.51)]
-macro_rules! mod_arrays {
-    () => {
-        #[path = "legacy_arrays.rs"]
-        mod arrays;
-    };
-}
-#[rustversion::since(1.51)]
-macro_rules! mod_arrays {
-    () => {
-        #[path = "const_arrays.rs"]
-        mod arrays;
-    };
-}
-mod_arrays!();
 
 use super::*;
 

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -3,7 +3,7 @@
 This page lists the transformations implemented in this crate and supported by `serde_as`.
 
 1. [Base64 encode bytes](#base64-encode-bytes)
-2. [Big Array support (Rust 1.51+)](#big-array-support-rust-151)
+2. [Big Array support](#big-array-support)
 3. [Borrow from the input for `Cow` type](#borrow-from-the-input-for-cow-type)
 4. [`Bytes` with more efficiency](#bytes-with-more-efficiency)
 5. [Convert to an intermediate type using `Into`](#convert-to-an-intermediate-type-using-into)
@@ -44,7 +44,7 @@ bcrypt_unpadded: Vec<u8>,
 "bcrypt_unpadded": "QETqZE6eT07wZEO",
 ```
 
-## Big Array support (Rust 1.51+)
+## Big Array support
 
 Support for arrays of arbitrary size.
 
@@ -59,7 +59,7 @@ value: [[u8; 64]; 33],
 
 ## Borrow from the input for `Cow` type
 
-The types `Cow<'_, str>`, `Cow<'_, [u8]>`, or `Cow<'_, [u8; N]>` (Rust 1.51+) can borrow from the input, avoiding extra copies.
+The types `Cow<'_, str>`, `Cow<'_, [u8]>`, or `Cow<'_, [u8; N]>` can borrow from the input, avoiding extra copies.
 
 ```ignore
 // Rust

--- a/serde_with/src/hex.rs
+++ b/serde_with/src/hex.rs
@@ -70,11 +70,6 @@ use std::marker::PhantomData;
 ///     serde_json::from_value(json!("00aAbc99FF")).unwrap()
 /// );
 ///
-/// /////////////////////////////////////
-/// // Arrays are supported in Rust 1.48+
-///
-/// # #[rustversion::since(1.48)]
-/// # fn test_array() {
 /// #[serde_as]
 /// # #[derive(Debug, PartialEq, Eq)]
 /// #[derive(Deserialize, Serialize)]
@@ -104,10 +99,6 @@ use std::marker::PhantomData;
 /// let error_result: Result<ByteArray, _> =
 ///     serde_json::from_value(json!("000000000000000000000000000000")); // Too long
 /// error_result.unwrap_err();
-/// # };
-/// # #[rustversion::before(1.48)]
-/// # fn test_array() {}
-/// # test_array();
 /// # }
 /// ```
 #[derive(Copy, Clone, Debug, Default)]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1411,14 +1411,14 @@ pub struct TimestampNanoSecondsWithFrac<
 ///
 /// The type provides de/serialization for these types:
 ///
-/// * `[u8; N]`, Rust 1.51+, not possible using `serde_bytes`
-/// * `&[u8; N]`, Rust 1.51+, not possible using `serde_bytes`
+/// * `[u8; N]`, not possible using `serde_bytes`
+/// * `&[u8; N]`, not possible using `serde_bytes`
 /// * `&[u8]`
-/// * `Box<[u8; N]>`, Rust 1.51+, not possible using `serde_bytes`
+/// * `Box<[u8; N]>`, not possible using `serde_bytes`
 /// * `Box<[u8]>`
 /// * `Vec<u8>`
 /// * `Cow<'_, [u8]>`
-/// * `Cow<'_, [u8; N]>`, Rust 1.51+, not possible using `serde_bytes`
+/// * `Cow<'_, [u8; N]>`, not possible using `serde_bytes`
 ///
 /// [`serde_bytes`]: https://crates.io/crates/serde_bytes
 ///

--- a/serde_with/src/ser/const_arrays.rs
+++ b/serde_with/src/ser/const_arrays.rs
@@ -1,5 +1,5 @@
-use std::borrow::Cow;
 use super::*;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
 impl<T, As, const N: usize> SerializeAs<[T; N]> for [As; N]

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -7,26 +7,9 @@
 //!
 //! [user guide]: crate::guide
 
+mod const_arrays;
 #[macro_use]
 mod impls;
-
-// The redirection via macro_rules is necessary to circumvent https://github.com/rust-lang/rust/issues/54727
-// which prevents proc macros on non-inline modules
-#[rustversion::before(1.51)]
-macro_rules! mod_arrays {
-    () => {
-        #[path = "legacy_arrays.rs"]
-        mod arrays;
-    };
-}
-#[rustversion::since(1.51)]
-macro_rules! mod_arrays {
-    () => {
-        #[path = "const_arrays.rs"]
-        mod arrays;
-    };
-}
-mod_arrays!();
 
 use super::*;
 

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -632,7 +632,6 @@ fn test_serialize_reference() {
     );
 }
 
-#[rustversion::since(1.51)]
 #[test]
 fn test_big_arrays() {
     // Single Big Array
@@ -679,8 +678,6 @@ fn test_big_arrays() {
     );
 }
 
-// The test requires const-generics to work
-#[rustversion::since(1.51)]
 #[test]
 fn test_bytes() {
     // The test case is copied from

--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -180,7 +180,6 @@ fn test_tuple_list_as_map() {
     is_equal(SO(None), expect![[r#"{}"#]]);
 }
 
-#[rustversion::since(1.51)]
 #[test]
 fn test_tuple_array_as_map() {
     #[serde_as]


### PR DESCRIPTION
The MSRV got updated and this commit removes old code. Pre const-generic code could all be removed. Some further older entries could also be removed.

This makes `rustversion` a dev-dependency, since runtime changes are not necessary anymore.

Closes #451

bors merge