### PR TITLE
Support `no_std` for `serde_with` Take 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,10 +69,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          # Extra toolchain to test no_std
+          target: thumbv7em-none-eabihf
 
       # Build the project
       - name: "Build (${{ matrix.os }} / ${{ matrix.rust }})"
         run: cargo build --all-features --all-targets
+
+      # Check no_std works
+      - name: "Check no_std (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo check --package serde_with --no-default-features --target thumbv7em-none-eabihf
+      - name: "Check no_std+alloc (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }} / Crate ${{ matrix.crate }})"
+        run: cargo check --package serde_with --no-default-features --features=alloc --target thumbv7em-none-eabihf
 
       # The tests are split into build and run steps, to see the time impact of each
       # cargo test --all-targets does NOT run doctests

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -8,7 +8,7 @@ name = "serde_with"
 rust-version = "1.53"
 version = "1.14.0"
 
-categories = ["encoding"]
+categories = ["encoding", "no-std"]
 description = "Custom de/serialization functions for Rust's serde"
 documentation = "https://docs.rs/serde_with/"
 edition = "2018"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -24,13 +24,16 @@ maintenance = {status = "actively-developed"}
 
 # When adding new features update the documentation in feature-flags.md
 [features]
+default = ["std", "macros"]
+
+alloc = ["serde/alloc"]
 base64 = ["base64_crate"]
 chrono = ["chrono_crate"]
-default = ["macros"]
 guide = ["doc-comment", "macros"]
 indexmap = ["indexmap_crate"]
 json = ["serde_json"]
 macros = ["serde_with_macros"]
+std = ["alloc", "serde/std"]
 
 # When adding new optional dependencies update the documentation in feature-flags.md
 [dependencies]
@@ -39,7 +42,7 @@ chrono_crate = {package = "chrono", version = "0.4.1", features = ["clock", "ser
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.2", optional = true}
 indexmap_crate = {package = "indexmap", version = "1.8", features = ["serde-1"], optional = true}
-serde = {version = "1.0.122", features = ["derive"]}
+serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.1", optional = true}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.2", optional = true}
 time_0_3 = {package = "time", version = "~0.3", optional = true, features = ["serde-well-known"]}

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,11 +1,14 @@
 use super::*;
+#[cfg(feature = "alloc")]
+use crate::formats::Format;
 #[cfg(feature = "std")]
 use crate::utils::duration::DurationSigned;
 use crate::{
-    formats::{Flexible, Format, Strict},
+    formats::{Flexible, Strict},
     rust::StringWithSeparator,
     utils,
 };
+#[cfg(feature = "alloc")]
 use alloc::{
     borrow::{Cow, ToOwned},
     boxed::Box,
@@ -39,6 +42,7 @@ use std::{
 ///////////////////////////////////////////////////////////////////////////////
 // region: Simple Wrapper types (e.g., Box, Option)
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, Box<T>> for Box<U>
 where
     U: DeserializeAs<'de, T>,
@@ -102,6 +106,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, Rc<T>> for Rc<U>
 where
     U: DeserializeAs<'de, T>,
@@ -116,6 +121,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, RcWeak<T>> for RcWeak<U>
 where
     U: DeserializeAs<'de, T>,
@@ -129,6 +135,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, Arc<T>> for Arc<U>
 where
     U: DeserializeAs<'de, T>,
@@ -143,6 +150,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, ArcWeak<T>> for ArcWeak<U>
 where
     U: DeserializeAs<'de, T>,
@@ -277,6 +285,7 @@ where
 ///////////////////////////////////////////////////////////////////////////////
 // region: Collection Types (e.g., Maps, Sets, Vec)
 
+#[cfg(feature = "alloc")]
 macro_rules! seq_impl {
     (
         $ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)* $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)* )* >,
@@ -340,19 +349,23 @@ macro_rules! seq_impl {
     };
 }
 
+#[cfg(feature = "alloc")]
 type BoxedSlice<T> = Box<[T]>;
+#[cfg(feature = "alloc")]
 seq_impl!(
     BinaryHeap<T: Ord>,
     seq,
     BinaryHeap::with_capacity(utils::size_hint_cautious(seq.size_hint())),
     push
 );
+#[cfg(feature = "alloc")]
 seq_impl!(
     BoxedSlice<T>,
     seq,
     Vec::with_capacity(utils::size_hint_cautious(seq.size_hint())),
     push
 );
+#[cfg(feature = "alloc")]
 seq_impl!(BTreeSet<T: Ord>, seq, BTreeSet::new(), insert);
 #[cfg(feature = "std")]
 seq_impl!(
@@ -361,13 +374,16 @@ seq_impl!(
     HashSet::with_capacity_and_hasher(utils::size_hint_cautious(seq.size_hint()), S::default()),
     insert
 );
+#[cfg(feature = "alloc")]
 seq_impl!(LinkedList<T>, seq, LinkedList::new(), push_back);
+#[cfg(feature = "alloc")]
 seq_impl!(
     Vec<T>,
     seq,
     Vec::with_capacity(utils::size_hint_cautious(seq.size_hint())),
     push
 );
+#[cfg(feature = "alloc")]
 seq_impl!(
     VecDeque<T>,
     seq,
@@ -382,6 +398,7 @@ seq_impl!(
     insert
 );
 
+#[cfg(feature = "alloc")]
 macro_rules! map_impl {
     (
         $ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)*)* >,
@@ -444,6 +461,7 @@ macro_rules! map_impl {
     }
 }
 
+#[cfg(feature = "alloc")]
 map_impl!(
     BTreeMap<K: Ord, V>,
     map,
@@ -524,6 +542,7 @@ tuple_impl!(14 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 
 tuple_impl!(15 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 T7 As7 8 T8 As8 9 T9 As9 10 T10 As10 11 T11 As11 12 T12 As12 13 T13 As13 14 T14 As14);
 tuple_impl!(16 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 T7 As7 8 T8 As8 9 T9 As9 10 T10 As10 11 T11 As11 12 T12 As12 13 T13 As13 14 T14 As14 15 T15 As15);
 
+#[cfg(feature = "alloc")]
 macro_rules! map_as_tuple_seq {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V>) => {
         impl<'de, K, KAs, V, VAs> DeserializeAs<'de, $ty<K, V>> for Vec<(KAs, VAs)>
@@ -577,12 +596,14 @@ macro_rules! map_as_tuple_seq {
         }
     };
 }
+#[cfg(feature = "alloc")]
 map_as_tuple_seq!(BTreeMap<K: Ord, V>);
 #[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K: Eq + Hash, V>);
 #[cfg(feature = "indexmap")]
 map_as_tuple_seq!(IndexMap<K: Eq + Hash, V>);
 
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_impl_intern {
     ($tyorig:ident < (K $(: $($kbound:ident $(+)?)+)?, V $(: $($vbound:ident $(+)?)+)?)>, $ty:ident <KAs, VAs>) => {
         #[allow(clippy::implicit_hasher)]
@@ -639,6 +660,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
         }
     }
 }
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_impl {
     ($($tyorig:ident < (K $(: $($kbound:ident $(+)?)+)?, V $(: $($vbound:ident $(+)?)+)?)> $(,)?)+) => {$(
         tuple_seq_as_map_impl_intern!($tyorig < (K $(: $($kbound +)+)?, V $(: $($vbound +)+)?) >, BTreeMap<KAs, VAs>);
@@ -647,6 +669,7 @@ macro_rules! tuple_seq_as_map_impl {
     )+}
 }
 
+#[cfg(feature = "alloc")]
 tuple_seq_as_map_impl! {
     BinaryHeap<(K: Ord, V: Ord)>,
     BTreeSet<(K: Ord, V: Ord)>,
@@ -659,6 +682,7 @@ tuple_seq_as_map_impl!(HashSet<(K: Eq + Hash, V: Eq + Hash)>);
 #[cfg(feature = "indexmap")]
 tuple_seq_as_map_impl!(IndexSet<(K: Eq + Hash, V: Eq + Hash)>);
 
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_option_impl {
     ($($ty:ident $(,)?)+) => {$(
         #[allow(clippy::implicit_hasher)]
@@ -712,10 +736,12 @@ macro_rules! tuple_seq_as_map_option_impl {
         }
     )+}
 }
+#[cfg(feature = "alloc")]
 tuple_seq_as_map_option_impl!(BTreeMap);
 #[cfg(feature = "std")]
 tuple_seq_as_map_option_impl!(HashMap);
 
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_arr {
     ($tyorig:ty, $ty:ident <KAs, VAs>) => {
         #[allow(clippy::implicit_hasher)]
@@ -763,6 +789,7 @@ macro_rules! tuple_seq_as_map_arr {
         }
     }
 }
+#[cfg(feature = "alloc")]
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<KAs, VAs>);
 #[cfg(feature = "std")]
 tuple_seq_as_map_arr!([(K, V); N], HashMap<KAs, VAs>);
@@ -793,6 +820,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, Vec<T>> for VecSkipError<U>
 where
     U: DeserializeAs<'de, T>,
@@ -870,6 +898,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, TAs> DeserializeAs<'de, T> for DefaultOnError<TAs>
 where
     TAs: DeserializeAs<'de, T>,
@@ -904,6 +933,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
     fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -924,15 +954,38 @@ where
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        if s.is_empty() {
-            Ok(None.into_iter().collect())
-        } else {
-            s.split(SEPARATOR::separator())
-                .map(FromStr::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(Error::custom)
+        struct Helper<SEPARATOR, I, T>(PhantomData<(SEPARATOR, I, T)>);
+
+        impl<'de, SEPARATOR, I, T> Visitor<'de> for Helper<SEPARATOR, I, T>
+        where
+            SEPARATOR: Separator,
+            I: FromIterator<T>,
+            T: FromStr,
+            T::Err: Display,
+        {
+            type Value = I;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "a string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                if value.is_empty() {
+                    Ok(None.into_iter().collect())
+                } else {
+                    value
+                        .split(SEPARATOR::separator())
+                        .map(FromStr::from_str)
+                        .collect::<Result<_, _>>()
+                        .map_err(Error::custom)
+                }
+            }
         }
+
+        deserializer.deserialize_str(Helper::<SEPARATOR, I, T>(PhantomData))
     }
 }
 
@@ -1057,6 +1110,7 @@ impl<'de> DeserializeAs<'de, &'de [u8]> for Bytes {
 // * visit_byte_buf
 // * visit_str
 // * visit_string
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Vec<u8>> for Bytes {
     fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -1111,6 +1165,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Box<[u8]>> for Bytes {
     fn deserialize_as<D>(deserializer: D) -> Result<Box<[u8]>, D::Error>
     where
@@ -1132,6 +1187,7 @@ impl<'de> DeserializeAs<'de, Box<[u8]>> for Bytes {
 // * visit_byte_buf
 // * visit_string
 // * visit_seq
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
     fn deserialize_as<D>(deserializer: D) -> Result<Cow<'de, [u8]>, D::Error>
     where
@@ -1281,6 +1337,7 @@ impl<'de, const N: usize> DeserializeAs<'de, &'de [u8; N]> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
     fn deserialize_as<D>(deserializer: D) -> Result<Cow<'de, [u8; N]>, D::Error>
     where
@@ -1377,6 +1434,7 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, const N: usize> DeserializeAs<'de, Box<[u8; N]>> for Bytes {
     fn deserialize_as<D>(deserializer: D) -> Result<Box<[u8; N]>, D::Error>
     where
@@ -1386,6 +1444,7 @@ impl<'de, const N: usize> DeserializeAs<'de, Box<[u8; N]>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, U, FORMAT> DeserializeAs<'de, Vec<T>> for OneOrMany<U, FORMAT>
 where
     U: DeserializeAs<'de, T>,
@@ -1421,6 +1480,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, TAs1> DeserializeAs<'de, T> for PickFirst<(TAs1,)>
 where
     TAs1: DeserializeAs<'de, T>,
@@ -1433,6 +1493,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, TAs1, TAs2> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2)>
 where
     TAs1: DeserializeAs<'de, T>,
@@ -1471,6 +1532,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, TAs1, TAs2, TAs3> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2, TAs3)>
 where
     TAs1: DeserializeAs<'de, T>,
@@ -1514,6 +1576,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, T, TAs1, TAs2, TAs3, TAs4> DeserializeAs<'de, T> for PickFirst<(TAs1, TAs2, TAs3, TAs4)>
 where
     TAs1: DeserializeAs<'de, T>,
@@ -1591,6 +1654,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Cow<'de, str>> for BorrowCow {
     fn deserialize_as<D>(deserializer: D) -> Result<Cow<'de, str>, D::Error>
     where
@@ -1631,6 +1695,7 @@ impl<'de> DeserializeAs<'de, Cow<'de, str>> for BorrowCow {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for BorrowCow {
     fn deserialize_as<D>(deserializer: D) -> Result<Cow<'de, [u8]>, D::Error>
     where
@@ -1640,6 +1705,7 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for BorrowCow {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for BorrowCow {
     fn deserialize_as<D>(deserializer: D) -> Result<Cow<'de, [u8; N]>, D::Error>
     where

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,9 +1,10 @@
 use super::*;
+#[cfg(feature = "std")]
+use crate::utils::duration::DurationSigned;
 use crate::{
     formats::{Flexible, Format, Strict},
     rust::StringWithSeparator,
     utils,
-    utils::duration::DurationSigned,
 };
 use alloc::{
     borrow::{Cow, ToOwned},
@@ -14,18 +15,21 @@ use alloc::{
     sync::{Arc, Weak as ArcWeak},
     vec::Vec,
 };
+#[cfg(feature = "std")]
+use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "std")]
+use core::time::Duration;
 use core::{
     cell::{Cell, RefCell},
     convert::TryInto,
     fmt::{self, Display},
-    hash::{BuildHasher, Hash},
     iter::FromIterator,
     str::FromStr,
-    time::Duration,
 };
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::de::*;
+#[cfg(feature = "std")]
 use std::{
     collections::{HashMap, HashSet},
     sync::{Mutex, RwLock},
@@ -180,6 +184,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'de, T, U> DeserializeAs<'de, Mutex<T>> for Mutex<U>
 where
     U: DeserializeAs<'de, T>,
@@ -194,6 +199,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'de, T, U> DeserializeAs<'de, RwLock<T>> for RwLock<U>
 where
     U: DeserializeAs<'de, T>,
@@ -348,6 +354,7 @@ seq_impl!(
     push
 );
 seq_impl!(BTreeSet<T: Ord>, seq, BTreeSet::new(), insert);
+#[cfg(feature = "std")]
 seq_impl!(
     HashSet<T: Eq + Hash, S: BuildHasher + Default>,
     seq,
@@ -441,6 +448,7 @@ map_impl!(
     BTreeMap<K: Ord, V>,
     map,
     BTreeMap::new());
+#[cfg(feature = "std")]
 map_impl!(
     HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
     map,
@@ -570,6 +578,7 @@ macro_rules! map_as_tuple_seq {
     };
 }
 map_as_tuple_seq!(BTreeMap<K: Ord, V>);
+#[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K: Eq + Hash, V>);
 #[cfg(feature = "indexmap")]
 map_as_tuple_seq!(IndexMap<K: Eq + Hash, V>);
@@ -633,6 +642,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
 macro_rules! tuple_seq_as_map_impl {
     ($($tyorig:ident < (K $(: $($kbound:ident $(+)?)+)?, V $(: $($vbound:ident $(+)?)+)?)> $(,)?)+) => {$(
         tuple_seq_as_map_impl_intern!($tyorig < (K $(: $($kbound +)+)?, V $(: $($vbound +)+)?) >, BTreeMap<KAs, VAs>);
+        #[cfg(feature = "std")]
         tuple_seq_as_map_impl_intern!($tyorig < (K $(: $($kbound +)+)?, V $(: $($vbound +)+)?) >, HashMap<KAs, VAs>);
     )+}
 }
@@ -644,6 +654,7 @@ tuple_seq_as_map_impl! {
     Vec<(K, V)>,
     VecDeque<(K, V)>,
 }
+#[cfg(feature = "std")]
 tuple_seq_as_map_impl!(HashSet<(K: Eq + Hash, V: Eq + Hash)>);
 #[cfg(feature = "indexmap")]
 tuple_seq_as_map_impl!(IndexSet<(K: Eq + Hash, V: Eq + Hash)>);
@@ -702,6 +713,7 @@ macro_rules! tuple_seq_as_map_option_impl {
     )+}
 }
 tuple_seq_as_map_option_impl!(BTreeMap);
+#[cfg(feature = "std")]
 tuple_seq_as_map_option_impl!(HashMap);
 
 macro_rules! tuple_seq_as_map_arr {
@@ -752,6 +764,7 @@ macro_rules! tuple_seq_as_map_arr {
     }
 }
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<KAs, VAs>);
+#[cfg(feature = "std")]
 tuple_seq_as_map_arr!([(K, V); N], HashMap<KAs, VAs>);
 
 // endregion
@@ -923,6 +936,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 macro_rules! use_signed_duration {
     (
         $main_trait:ident $internal_trait:ident =>
@@ -956,6 +970,7 @@ macro_rules! use_signed_duration {
     };
 }
 
+#[cfg(feature = "std")]
 use_signed_duration!(
     DurationSeconds DurationSeconds,
     DurationMilliSeconds DurationMilliSeconds,
@@ -969,6 +984,7 @@ use_signed_duration!(
         {FORMAT, Flexible => FORMAT: Format}
     }
 );
+#[cfg(feature = "std")]
 use_signed_duration!(
     DurationSecondsWithFrac DurationSecondsWithFrac,
     DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
@@ -982,6 +998,7 @@ use_signed_duration!(
     }
 );
 
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSeconds DurationSeconds,
     TimestampMilliSeconds DurationMilliSeconds,
@@ -995,6 +1012,7 @@ use_signed_duration!(
         {FORMAT, Flexible => FORMAT: Format}
     }
 );
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,7 +1,9 @@
 use alloc::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
 pub trait PreventDuplicateInsertsSet<T> {
@@ -18,6 +20,7 @@ pub trait PreventDuplicateInsertsMap<K, V> {
     fn insert(&mut self, key: K, value: V) -> bool;
 }
 
+#[cfg(feature = "std")]
 impl<T, S> PreventDuplicateInsertsSet<T> for HashSet<T, S>
 where
     T: Eq + Hash,
@@ -72,6 +75,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, S> PreventDuplicateInsertsMap<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,7 +1,9 @@
 use alloc::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexMap;
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
 #[deprecated = "This is serde's default behavior."]
@@ -19,6 +21,7 @@ pub trait DuplicateInsertsFirstWinsMap<K, V> {
     fn insert(&mut self, key: K, value: V);
 }
 
+#[cfg(feature = "std")]
 #[allow(deprecated)]
 impl<T, S> DuplicateInsertsFirstWinsSet<T> for HashSet<T, S>
 where
@@ -57,6 +60,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, S> DuplicateInsertsFirstWinsMap<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,7 +1,9 @@
 use alloc::collections::BTreeSet;
+#[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "indexmap")]
 use indexmap_crate::IndexSet;
+#[cfg(feature = "std")]
 use std::collections::HashSet;
 
 pub trait DuplicateInsertsLastWinsSet<T> {
@@ -11,6 +13,7 @@ pub trait DuplicateInsertsLastWinsSet<T> {
     fn replace(&mut self, value: T);
 }
 
+#[cfg(feature = "std")]
 impl<T, S> DuplicateInsertsLastWinsSet<T> for HashSet<T, S>
 where
     T: Eq + Hash,

--- a/serde_with/src/formats.rs
+++ b/serde_with/src/formats.rs
@@ -1,5 +1,6 @@
 //! Specify the format and how lenient the deserialization is
 
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 /// Specify how to serialize/deserialize a type
@@ -44,6 +45,10 @@ impl_format!(
     i64
     /// Serialize into a u64
     u64
+    /// Serialize into an i128
+    i128
+    /// Serialize into a u128
+    u128
 
     /// Serialize into a f32
     f32
@@ -52,16 +57,12 @@ impl_format!(
 
     /// Serialize into a bool
     bool
-
+);
+#[cfg(feature = "alloc")]
+impl_format!(
     /// Serialize into a String
     String
 );
-serde::serde_if_integer128!(impl_format!(
-    /// Serialize into an i128
-    i128
-    /// Serialize into a u128
-    u128
-););
 
 create_format!(
     /// Use uppercase characters

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -3,14 +3,29 @@
 This crate has the following features which can be enabled.
 Each entry will explain the feature in more detail.
 
-1. [`base64`](#base64)
-2. [`chrono`](#chrono)
-3. [`guide`](#guide)
-4. [`hex`](#hex)
-5. [`indexmap`](#indexmap)
-6. [`json`](#json)
-7. [`macros`](#macros)
-8. [`time_0_3`](#time_0_3)
+`serde_with` is fully `no_std` compatible.
+Using it in a `no_std` environment requires using `default-features = false`, since `std` is enabled by default.
+
+1. [`alloc`](#alloc)
+2. [`std` (default)](#std-default)
+3. [`base64`](#base64)
+4. [`chrono`](#chrono)
+5. [`guide`](#guide)
+6. [`hex`](#hex)
+7. [`indexmap`](#indexmap)
+8. [`json`](#json)
+9. [`macros` (default)](#macros-default)
+10. [`time_0_3`](#time_0_3)
+
+## `alloc`
+
+Enable support for types from the `alloc` crate when running in a `no_std` environment.
+
+## `std` (default)
+
+Enables support for various types from the std library.
+This will enable `std` support in all dependencies too.
+The feature enabled by default and also enables `alloc`.
 
 ## `base64`
 
@@ -47,7 +62,7 @@ The `json` features enables JSON conversions from the `json` module.
 
 This pulls in `serde_json` as a dependency.
 
-## `macros`
+## `macros` (default)
 
 The `macros` features enables all helper macros and derives.
 It is enabled by default, since the macros provide a usability benefit, especially for `serde_as`.

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -274,9 +274,12 @@ pub mod base64;
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod chrono;
+#[cfg(feature = "alloc")]
 mod content;
 pub mod de;
+#[cfg(feature = "alloc")]
 mod duplicate_key_impls;
+#[cfg(feature = "alloc")]
 mod enum_map;
 #[cfg(feature = "std")]
 mod flatten_maybe;
@@ -339,10 +342,11 @@ generate_guide! {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use crate::{
-    de::DeserializeAs, enum_map::EnumMap, rust::StringWithSeparator, ser::SerializeAs,
-};
+pub use crate::enum_map::EnumMap;
+#[doc(inline)]
+pub use crate::{de::DeserializeAs, rust::StringWithSeparator, ser::SerializeAs};
 use core::marker::PhantomData;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Re-Export all proc_macros, as these should be seen as part of the serde_with crate
@@ -642,6 +646,7 @@ pub struct NoneAsEmptyString;
 /// assert_eq!(vec![1, 2, 0, 0, 0, 6], c.value);
 /// # }
 /// ```
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DefaultOnError<T = Same>(PhantomData<T>);
 
@@ -749,6 +754,7 @@ pub struct DefaultOnNull<T = Same>(PhantomData<T>);
 /// # }
 /// ```
 /// [`String`]: std::string::String
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BytesOrString;
 
@@ -1644,6 +1650,7 @@ pub struct Bytes;
 /// assert_eq!(data, serde_json::from_value(j).unwrap());
 /// # }
 /// ```
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomData<(T, FORMAT)>);
 
@@ -1705,6 +1712,7 @@ pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomDat
 /// assert_eq!(expected, serde_json::to_value(&data).unwrap());
 /// # }
 /// ```
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct PickFirst<T>(PhantomData<T>);
 
@@ -1948,6 +1956,7 @@ pub struct TryFromInto<T>(PhantomData<T>);
 /// assert!(matches!(deserialized.slice, Cow::Owned(_)));
 /// # }
 /// ```
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BorrowCow;
 
@@ -1985,7 +1994,7 @@ pub struct BorrowCow;
 /// assert_eq!(data, serde_json::from_str(source_json).unwrap());
 /// # }
 /// ```
-
+#[cfg(feature = "alloc")]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct VecSkipError<T>(PhantomData<T>);
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -278,6 +278,7 @@ mod content;
 pub mod de;
 mod duplicate_key_impls;
 mod enum_map;
+#[cfg(feature = "std")]
 mod flatten_maybe;
 pub mod formats;
 #[cfg(feature = "hex")]
@@ -288,11 +289,13 @@ pub mod hex;
 pub mod json;
 pub mod rust;
 pub mod ser;
+#[cfg(feature = "std")]
 mod serde_conv;
 #[cfg(feature = "time_0_3")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time_0_3")))]
 pub mod time_0_3;
 mod utils;
+#[cfg(feature = "std")]
 #[doc(hidden)]
 pub mod with_prefix;
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -261,9 +261,11 @@
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
 //! [as-annotation]: https://docs.rs/serde_with/1.14.0/serde_with/guide/serde_as/index.html
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[doc(hidden)]
 pub extern crate serde;
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "base64")]

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -3,6 +3,7 @@
 use crate::{utils, Separator};
 #[cfg(doc)]
 use alloc::collections::BTreeMap;
+#[cfg(feature = "alloc")]
 use alloc::{
     string::{String, ToString},
     vec::Vec,
@@ -196,6 +197,7 @@ pub mod display_fromstr {
 ///
 /// [`DisplayFromStr`]: crate::DisplayFromStr
 /// [`serde_as`]: crate::guide::serde_as
+#[cfg(feature = "alloc")]
 pub mod seq_display_fromstr {
     use super::*;
 
@@ -358,15 +360,38 @@ where
         V: FromStr,
         V::Err: Display,
     {
-        let s = String::deserialize(deserializer)?;
-        if s.is_empty() {
-            Ok(None.into_iter().collect())
-        } else {
-            s.split(Sep::separator())
-                .map(FromStr::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(Error::custom)
+        struct Helper<SEPARATOR, I, T>(PhantomData<(SEPARATOR, I, T)>);
+
+        impl<'de, SEPARATOR, I, T> Visitor<'de> for Helper<SEPARATOR, I, T>
+        where
+            SEPARATOR: Separator,
+            I: FromIterator<T>,
+            T: FromStr,
+            T::Err: Display,
+        {
+            type Value = I;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "a string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                if value.is_empty() {
+                    Ok(None.into_iter().collect())
+                } else {
+                    value
+                        .split(SEPARATOR::separator())
+                        .map(FromStr::from_str)
+                        .collect::<Result<_, _>>()
+                        .map_err(Error::custom)
+                }
+            }
         }
+
+        deserializer.deserialize_str(Helper::<Sep, T, V>(PhantomData))
     }
 }
 
@@ -561,6 +586,7 @@ pub mod unwrap_or_skip {
 /// let res: Result<Doc, _> = serde_json::from_str(s);
 /// assert!(res.is_err());
 /// ```
+#[cfg(feature = "alloc")]
 pub mod sets_duplicate_value_is_error {
     use super::*;
     use crate::duplicate_key_impls::PreventDuplicateInsertsSet;
@@ -663,6 +689,7 @@ pub mod sets_duplicate_value_is_error {
 /// let res: Result<Doc, _> = serde_json::from_str(s);
 /// assert!(res.is_err());
 /// ```
+#[cfg(feature = "alloc")]
 pub mod maps_duplicate_key_is_error {
     use super::*;
     use crate::duplicate_key_impls::PreventDuplicateInsertsMap;
@@ -733,6 +760,7 @@ pub mod maps_duplicate_key_is_error {
 /// This module implements the default behavior in serde.
 #[deprecated = "This module does nothing. Remove the attribute. Serde's default behavior is to use the first value when deserializing a set."]
 #[allow(deprecated)]
+#[cfg(feature = "alloc")]
 pub mod sets_first_value_wins {
     use super::*;
     use crate::duplicate_key_impls::DuplicateInsertsFirstWinsSet;
@@ -803,6 +831,7 @@ pub mod sets_first_value_wins {
 ///
 /// [`HashSet`]: std::collections::HashSet
 /// [`BTreeSet`]: std::collections::HashSet
+#[cfg(feature = "alloc")]
 pub mod sets_last_value_wins {
     use super::*;
     use crate::duplicate_key_impls::DuplicateInsertsLastWinsSet;
@@ -904,6 +933,7 @@ pub mod sets_last_value_wins {
 /// v.map.insert(2, 2);
 /// assert_eq!(v, serde_json::from_str(s).unwrap());
 /// ```
+#[cfg(feature = "alloc")]
 pub mod maps_first_key_wins {
     use super::*;
     use crate::duplicate_key_impls::DuplicateInsertsFirstWinsMap;
@@ -1054,6 +1084,7 @@ pub mod string_empty_as_none {
                 }
             }
 
+            #[cfg(feature = "alloc")]
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
             where
                 E: Error,
@@ -1620,6 +1651,7 @@ pub mod tuple_list_as_map {
 ///
 /// [`BytesOrString`]: crate::BytesOrString
 /// [`serde_as`]: crate::guide::serde_as
+#[cfg(feature = "alloc")]
 pub mod bytes_or_string {
     use super::*;
 
@@ -1644,6 +1676,7 @@ pub mod bytes_or_string {
             Ok(v.to_vec())
         }
 
+        #[cfg(feature = "alloc")]
         fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E> {
             Ok(v)
         }
@@ -1652,6 +1685,7 @@ pub mod bytes_or_string {
             Ok(v.as_bytes().to_vec())
         }
 
+        #[cfg(feature = "alloc")]
         fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
             Ok(v.into_bytes())
         }
@@ -1739,6 +1773,7 @@ pub mod bytes_or_string {
 /// let b: B = serde_json::from_str(r#"{  }"#).unwrap();
 /// assert_eq!(0, b.value);
 /// ```
+#[cfg(feature = "alloc")]
 pub mod default_on_error {
     use super::*;
 

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -20,6 +20,7 @@ use core::{
 #[cfg(feature = "indexmap")]
 use indexmap_crate::{IndexMap, IndexSet};
 use serde::ser::Error;
+#[cfg(feature = "std")]
 use std::{
     collections::{HashMap, HashSet},
     sync::{Mutex, RwLock},
@@ -162,6 +163,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, U> SerializeAs<Mutex<T>> for Mutex<U>
 where
     U: SerializeAs<T>,
@@ -177,6 +179,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, U> SerializeAs<RwLock<T>> for RwLock<U>
 where
     U: SerializeAs<T>,
@@ -253,6 +256,7 @@ type Slice<T> = [T];
 seq_impl!(BinaryHeap<T>);
 seq_impl!(BoxedSlice<T>);
 seq_impl!(BTreeSet<T>);
+#[cfg(feature = "std")]
 seq_impl!(HashSet<T, H: Sized>);
 seq_impl!(LinkedList<T>);
 seq_impl!(Slice<T>);
@@ -281,6 +285,7 @@ macro_rules! map_impl {
 }
 
 map_impl!(BTreeMap<K, V>);
+#[cfg(feature = "std")]
 map_impl!(HashMap<K, V, H: Sized>);
 #[cfg(feature = "indexmap")]
 map_impl!(IndexMap<K, V, H: Sized>);
@@ -346,6 +351,7 @@ macro_rules! map_as_tuple_seq {
 }
 map_as_tuple_seq!(BTreeMap<K, V>);
 // TODO HashMap with a custom hasher support would be better, but results in "unconstrained type parameter"
+#[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K, V>);
 #[cfg(feature = "indexmap")]
 map_as_tuple_seq!(IndexMap<K, V>);
@@ -375,6 +381,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
 macro_rules! tuple_seq_as_map_impl {
     ($($ty:ty $(,)?)+) => {$(
         tuple_seq_as_map_impl_intern!($ty, BTreeMap<K, V>);
+        #[cfg(feature = "std")]
         tuple_seq_as_map_impl_intern!($ty, HashMap<K, V>);
     )+}
 }
@@ -387,6 +394,7 @@ tuple_seq_as_map_impl! {
     Vec<(K, V)>,
     VecDeque<(K, V)>,
 }
+#[cfg(feature = "std")]
 tuple_seq_as_map_impl!(HashSet<(K, V)>);
 #[cfg(feature = "indexmap")]
 tuple_seq_as_map_impl!(IndexSet<(K, V)>);
@@ -414,6 +422,7 @@ macro_rules! tuple_seq_as_map_arr {
     };
 }
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<K, V>);
+#[cfg(feature = "std")]
 tuple_seq_as_map_arr!([(K, V); N], HashMap<K, V>);
 
 // endregion
@@ -572,6 +581,7 @@ use_signed_duration!(
     }
 );
 
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSeconds DurationSeconds,
     TimestampMilliSeconds DurationMilliSeconds,
@@ -584,6 +594,7 @@ use_signed_duration!(
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
+#[cfg(feature = "std")]
 use_signed_duration!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     formats::Strictness, rust::StringWithSeparator, utils::duration::DurationSigned, Separator,
 };
+#[cfg(feature = "alloc")]
 use alloc::{
     borrow::Cow,
     boxed::Box,
@@ -58,6 +59,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Box<T>> for Box<U>
 where
     U: SerializeAs<T>,
@@ -85,6 +87,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Rc<T>> for Rc<U>
 where
     U: SerializeAs<T>,
@@ -97,6 +100,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<RcWeak<T>> for RcWeak<U>
 where
     U: SerializeAs<T>,
@@ -110,6 +114,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Arc<T>> for Arc<U>
 where
     U: SerializeAs<T>,
@@ -122,6 +127,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<ArcWeak<T>> for ArcWeak<U>
 where
     U: SerializeAs<T>,
@@ -251,20 +257,28 @@ macro_rules! seq_impl {
     }
 }
 
+#[cfg(feature = "alloc")]
 type BoxedSlice<T> = Box<[T]>;
 type Slice<T> = [T];
+#[cfg(feature = "alloc")]
 seq_impl!(BinaryHeap<T>);
+#[cfg(feature = "alloc")]
 seq_impl!(BoxedSlice<T>);
+#[cfg(feature = "alloc")]
 seq_impl!(BTreeSet<T>);
 #[cfg(feature = "std")]
 seq_impl!(HashSet<T, H: Sized>);
+#[cfg(feature = "alloc")]
 seq_impl!(LinkedList<T>);
 seq_impl!(Slice<T>);
+#[cfg(feature = "alloc")]
 seq_impl!(Vec<T>);
+#[cfg(feature = "alloc")]
 seq_impl!(VecDeque<T>);
 #[cfg(feature = "indexmap")]
 seq_impl!(IndexSet<T, H: Sized>);
 
+#[cfg(feature = "alloc")]
 macro_rules! map_impl {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound:ident)* >) => {
         impl<K, KU, V, VU $(, $typaram)*> SerializeAs<$ty<K, V $(, $typaram)*>> for $ty<KU, VU $(, $typaram)*>
@@ -284,6 +298,7 @@ macro_rules! map_impl {
     }
 }
 
+#[cfg(feature = "alloc")]
 map_impl!(BTreeMap<K, V>);
 #[cfg(feature = "std")]
 map_impl!(HashMap<K, V, H: Sized>);
@@ -328,6 +343,7 @@ tuple_impl!(14 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 
 tuple_impl!(15 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 T7 As7 8 T8 As8 9 T9 As9 10 T10 As10 11 T11 As11 12 T12 As12 13 T13 As13 14 T14 As14);
 tuple_impl!(16 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 T7 As7 8 T8 As8 9 T9 As9 10 T10 As10 11 T11 As11 12 T12 As12 13 T13 As13 14 T14 As14 15 T15 As15);
 
+#[cfg(feature = "alloc")]
 macro_rules! map_as_tuple_seq {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V >) => {
         impl<K, KAs, V, VAs> SerializeAs<$ty<K, V>> for Vec<(KAs, VAs)>
@@ -349,6 +365,7 @@ macro_rules! map_as_tuple_seq {
         }
     };
 }
+#[cfg(feature = "alloc")]
 map_as_tuple_seq!(BTreeMap<K, V>);
 // TODO HashMap with a custom hasher support would be better, but results in "unconstrained type parameter"
 #[cfg(feature = "std")]
@@ -356,6 +373,7 @@ map_as_tuple_seq!(HashMap<K, V>);
 #[cfg(feature = "indexmap")]
 map_as_tuple_seq!(IndexMap<K, V>);
 
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_impl_intern {
     ($tyorig:ty, $ty:ident <K, V>) => {
         #[allow(clippy::implicit_hasher)]
@@ -380,6 +398,7 @@ macro_rules! tuple_seq_as_map_impl_intern {
 }
 macro_rules! tuple_seq_as_map_impl {
     ($($ty:ty $(,)?)+) => {$(
+        #[cfg(feature = "alloc")]
         tuple_seq_as_map_impl_intern!($ty, BTreeMap<K, V>);
         #[cfg(feature = "std")]
         tuple_seq_as_map_impl_intern!($ty, HashMap<K, V>);
@@ -387,10 +406,13 @@ macro_rules! tuple_seq_as_map_impl {
 }
 
 tuple_seq_as_map_impl! {
+    Option<(K, V)>,
+}
+#[cfg(feature = "alloc")]
+tuple_seq_as_map_impl! {
     BinaryHeap<(K, V)>,
     BTreeSet<(K, V)>,
     LinkedList<(K, V)>,
-    Option<(K, V)>,
     Vec<(K, V)>,
     VecDeque<(K, V)>,
 }
@@ -399,6 +421,7 @@ tuple_seq_as_map_impl!(HashSet<(K, V)>);
 #[cfg(feature = "indexmap")]
 tuple_seq_as_map_impl!(IndexSet<(K, V)>);
 
+#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_arr {
     ($tyorig:ty, $ty:ident <K, V>) => {
         #[allow(clippy::implicit_hasher)]
@@ -421,6 +444,7 @@ macro_rules! tuple_seq_as_map_arr {
         }
     };
 }
+#[cfg(feature = "alloc")]
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<K, V>);
 #[cfg(feature = "std")]
 tuple_seq_as_map_arr!([(K, V); N], HashMap<K, V>);
@@ -453,6 +477,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Vec<T>> for VecSkipError<U>
 where
     U: SerializeAs<T>,
@@ -477,6 +502,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, TAs> SerializeAs<T> for DefaultOnError<TAs>
 where
     TAs: SerializeAs<T>,
@@ -489,6 +515,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl SerializeAs<Vec<u8>> for BytesOrString {
     fn serialize_as<S>(source: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -566,6 +593,16 @@ use_signed_duration!(
         Duration =>
         {u64, STRICTNESS => STRICTNESS: Strictness}
         {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_signed_duration!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration =>
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -577,6 +614,16 @@ use_signed_duration!(
     => {
         Duration =>
         {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_signed_duration!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Duration =>
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -628,6 +675,7 @@ impl SerializeAs<&[u8]> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl SerializeAs<Vec<u8>> for Bytes {
     fn serialize_as<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -637,6 +685,7 @@ impl SerializeAs<Vec<u8>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl SerializeAs<Box<[u8]>> for Bytes {
     fn serialize_as<S>(bytes: &Box<[u8]>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -646,6 +695,7 @@ impl SerializeAs<Box<[u8]>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> SerializeAs<Cow<'a, [u8]>> for Bytes {
     fn serialize_as<S>(bytes: &Cow<'a, [u8]>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -673,6 +723,7 @@ impl<const N: usize> SerializeAs<&[u8; N]> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const N: usize> SerializeAs<Box<[u8; N]>> for Bytes {
     fn serialize_as<S>(bytes: &Box<[u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -682,6 +733,7 @@ impl<const N: usize> SerializeAs<Box<[u8; N]>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, const N: usize> SerializeAs<Cow<'a, [u8; N]>> for Bytes {
     fn serialize_as<S>(bytes: &Cow<'a, [u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -691,6 +743,7 @@ impl<'a, const N: usize> SerializeAs<Cow<'a, [u8; N]>> for Bytes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Vec<T>> for OneOrMany<U, formats::PreferOne>
 where
     U: SerializeAs<T>,
@@ -707,6 +760,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Vec<T>> for OneOrMany<U, formats::PreferMany>
 where
     U: SerializeAs<T>,
@@ -719,6 +773,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, TAs1> SerializeAs<T> for PickFirst<(TAs1,)>
 where
     TAs1: SerializeAs<T>,
@@ -731,6 +786,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, TAs1, TAs2> SerializeAs<T> for PickFirst<(TAs1, TAs2)>
 where
     TAs1: SerializeAs<T>,
@@ -743,6 +799,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, TAs1, TAs2, TAs3> SerializeAs<T> for PickFirst<(TAs1, TAs2, TAs3)>
 where
     TAs1: SerializeAs<T>,
@@ -755,6 +812,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, TAs1, TAs2, TAs3, TAs4> SerializeAs<T> for PickFirst<(TAs1, TAs2, TAs3, TAs4)>
 where
     TAs1: SerializeAs<T>,
@@ -798,6 +856,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> SerializeAs<Cow<'a, str>> for BorrowCow {
     fn serialize_as<S>(source: &Cow<'a, str>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -807,6 +866,7 @@ impl<'a> SerializeAs<Cow<'a, str>> for BorrowCow {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> SerializeAs<Cow<'a, [u8]>> for BorrowCow {
     fn serialize_as<S>(value: &Cow<'a, [u8]>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -816,6 +876,7 @@ impl<'a> SerializeAs<Cow<'a, [u8]>> for BorrowCow {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, const N: usize> SerializeAs<Cow<'a, [u8; N]>> for BorrowCow {
     fn serialize_as<S>(value: &Cow<'a, [u8; N]>, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -1,9 +1,10 @@
 pub(crate) mod duration;
 
-use core::{marker::PhantomData, mem::MaybeUninit};
+use core::{fmt, marker::PhantomData, mem::MaybeUninit};
 use serde::de::{Deserialize, Error, Expected, MapAccess, SeqAccess};
 
 /// Re-Implementation of `serde::private::de::size_hint::cautious`
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn size_hint_cautious(hint: Option<usize>) -> usize {
     core::cmp::min(hint.unwrap_or(0), 4096)
@@ -171,4 +172,33 @@ where
     // A normal transmute is not possible because of:
     // https://github.com/rust-lang/rust/issues/61956
     Ok(unsafe { core::mem::transmute_copy::<_, [T; N]>(&arr) })
+}
+
+pub(crate) struct DisplayWithSeparator<'a, I, SEPARATOR>(&'a I, PhantomData<SEPARATOR>);
+
+impl<'a, I, SEPARATOR> DisplayWithSeparator<'a, I, SEPARATOR> {
+    pub(crate) fn new(iter: &'a I) -> Self {
+        Self(iter, PhantomData)
+    }
+}
+
+impl<'a, I, SEPARATOR> fmt::Display for DisplayWithSeparator<'a, I, SEPARATOR>
+where
+    SEPARATOR: crate::Separator,
+    &'a I: IntoIterator,
+    <&'a I as IntoIterator>::Item: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut iter = self.0.into_iter();
+
+        if let Some(first) = iter.next() {
+            first.fmt(f)?;
+        }
+        for elem in iter {
+            f.write_str(SEPARATOR::separator())?;
+            elem.fmt(f)?;
+        }
+
+        Ok(())
+    }
 }

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -1,6 +1,5 @@
 pub(crate) mod duration;
 
-use alloc::string::String;
 use core::{marker::PhantomData, mem::MaybeUninit};
 use serde::de::{Deserialize, Error, Expected, MapAccess, SeqAccess};
 
@@ -95,16 +94,16 @@ pub(crate) fn duration_as_secs_f64(dur: &core::time::Duration) -> f64 {
 
 pub(crate) fn duration_signed_from_secs_f64(
     secs: f64,
-) -> Result<self::duration::DurationSigned, String> {
+) -> Result<self::duration::DurationSigned, &'static str> {
     const MAX_NANOS_F64: f64 = ((u64::max_value() as u128 + 1) * (NANOS_PER_SEC as u128)) as f64;
     // TODO why are the seconds converted to nanoseconds first?
     // Does it make sense to just truncate the value?
     let mut nanos = secs * (NANOS_PER_SEC as f64);
     if !nanos.is_finite() {
-        return Err("got non-finite value when converting float to duration".into());
+        return Err("got non-finite value when converting float to duration");
     }
     if nanos >= MAX_NANOS_F64 {
-        return Err("overflow when converting float to duration".into());
+        return Err("overflow when converting float to duration");
     }
     let mut sign = self::duration::Sign::Positive;
     if nanos < 0.0 {

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -10,7 +10,6 @@ use crate::{
 use alloc::{
     format,
     string::{String, ToString},
-    vec::Vec,
 };
 use core::{fmt, ops::Neg, time::Duration};
 use serde::{

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -16,6 +16,7 @@ use serde::{
     de::{self, Unexpected, Visitor},
     ser, Deserialize, Deserializer, Serialize, Serializer,
 };
+#[cfg(feature = "std")]
 use std::time::SystemTime;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -65,6 +66,7 @@ impl DurationSigned {
         Self { sign, duration }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn to_system_time<'de, D>(self) -> Result<SystemTime, D::Error>
     where
         D: Deserializer<'de>,
@@ -78,6 +80,7 @@ impl DurationSigned {
         })
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn to_std_duration<'de, D>(self) -> Result<Duration, D::Error>
     where
         D: Deserializer<'de>,
@@ -98,6 +101,7 @@ impl From<&Duration> for DurationSigned {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<&SystemTime> for DurationSigned {
     fn from(time: &SystemTime) -> Self {
         match time.duration_since(SystemTime::UNIX_EPOCH) {
@@ -376,6 +380,8 @@ impl<'de> DeserializeAs<'de, DurationSigned> for DurationSeconds<i64, Strict> {
     }
 }
 
+// round() only works on std
+#[cfg(feature = "std")]
 impl<'de> DeserializeAs<'de, DurationSigned> for DurationSeconds<f64, Strict> {
     fn deserialize_as<D>(deserializer: D) -> Result<DurationSigned, D::Error>
     where


### PR DESCRIPTION
* Introduce new `alloc` and `std` features
* Feature gate all imports and implementations

Further Todos:
* Documentation updates like the new features
* Check which features depend on `alloc` and `std` and enable these if necessary.

Part of #435