### PR TITLE
Make `NoneAsEmptyString` use `Display` for serialization

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
     If an existing `default` attribute is detected, the attribute is not applied again.
     This behavior can be supressed by using `#[serde_as(no_default)]` or `#[serde_as(as = "Option<S>", no_default)]`.
+* `NoneAsEmptyString` and `string_empty_as_none` use a different serialization bound (#388).
+
+    Both types used `AsRef<str>` as the serialization bound.
+    This is limiting for non-string types like `Option<i32>`.
+    The deserialization often was already more flexible, due to the `FromStr` bound.
+
+    For most std types this should have little impact, as the types implementing `AsRef<str>` mostly implement `Display`, too, such as `String`, `Cow<str>`, or `Rc<str>`.
 
 ## [1.14.0] - 2022-05-29
 
@@ -112,7 +119,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Depend on a newer `serde_with_macros` version to pull in some fixes.
     * Account for generics when deriving implementations with `SerializeDisplay` and `DeserializeFromStr` #413
     * Provide better error messages when parsing types fails #423
-
 
 ## [1.12.0] - 2022-02-07
 

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -1079,13 +1079,13 @@ pub mod string_empty_as_none {
     /// Serialize a string from `Option<T>` using `AsRef<str>` or using the empty string if `None`.
     pub fn serialize<T, S>(option: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
-        T: AsRef<str>,
+        T: Display,
         S: Serializer,
     {
         if let Some(value) = option {
-            value.as_ref().serialize(serializer)
+            serializer.collect_str(value)
         } else {
-            "".serialize(serializer)
+            serializer.serialize_str("")
         }
     }
 }

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -456,11 +456,11 @@ where
     }
 }
 
-impl<AsRefStr> SerializeAs<Option<AsRefStr>> for NoneAsEmptyString
+impl<T> SerializeAs<Option<T>> for NoneAsEmptyString
 where
-    AsRefStr: AsRef<str>,
+    T: Display,
 {
-    fn serialize_as<S>(source: &Option<AsRefStr>, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize_as<S>(source: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {


### PR DESCRIPTION
Deserialization already uses `FromStr` which makes it often times more flexible than the previous `AsRef<str>` bound.
This allows to use more types, e.g., `Option<i32>`.
Most std types which implement `AsRef<str>` also implement `Display`, such that this should cause few regressions.

Closes #388

bors r+