### PR TITLE
Do not derive any traits on conversion types

### DIFF
--- a/serde_with/src/base64.rs
+++ b/serde_with/src/base64.rs
@@ -9,7 +9,6 @@ use alloc::vec::Vec;
 use base64::Config;
 use core::{
     convert::{TryFrom, TryInto},
-    default::Default,
     fmt,
     marker::PhantomData,
 };
@@ -71,7 +70,6 @@ use serde::{de::Error, Deserializer, Serialize, Serializer};
 
 // The padding might be better as `const PADDING: bool = true`
 // https://blog.rust-lang.org/inside-rust/2021/09/06/Splitting-const-generics.html#featureconst_generics_default/
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Base64<CHARSET: CharacterSet = Standard, PADDING: formats::Format = formats::Padded>(
     PhantomData<(CHARSET, PADDING)>,
 );
@@ -159,7 +157,6 @@ pub trait CharacterSet {
 /// The standard character set (uses `+` and `/`).
 ///
 /// See [RFC 3548](https://tools.ietf.org/html/rfc3548#section-3).
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Standard;
 impl CharacterSet for Standard {
     fn charset() -> base64::CharacterSet {
@@ -170,7 +167,6 @@ impl CharacterSet for Standard {
 /// The URL safe character set (uses `-` and `_`).
 ///
 /// See [RFC 3548](https://tools.ietf.org/html/rfc3548#section-3).
-#[derive(Copy, Clone, Debug, Default)]
 pub struct UrlSafe;
 impl CharacterSet for UrlSafe {
     fn charset() -> base64::CharacterSet {
@@ -181,7 +177,6 @@ impl CharacterSet for UrlSafe {
 /// The `crypt(3)` character set (uses `./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz`).
 ///
 /// Not standardized, but folk wisdom on the net asserts that this alphabet is what crypt uses.
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Crypt;
 impl CharacterSet for Crypt {
     fn charset() -> base64::CharacterSet {
@@ -190,7 +185,6 @@ impl CharacterSet for Crypt {
 }
 
 /// The bcrypt character set (uses `./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`).
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Bcrypt;
 impl CharacterSet for Bcrypt {
     fn charset() -> base64::CharacterSet {
@@ -201,7 +195,6 @@ impl CharacterSet for Bcrypt {
 /// The character set used in IMAP-modified UTF-7 (uses `+` and `,`).
 ///
 /// See [RFC 3501](https://tools.ietf.org/html/rfc3501#section-5.1.3).
-#[derive(Copy, Clone, Debug, Default)]
 pub struct ImapMutf7;
 impl CharacterSet for ImapMutf7 {
     fn charset() -> base64::CharacterSet {
@@ -212,7 +205,6 @@ impl CharacterSet for ImapMutf7 {
 /// The character set used in BinHex 4.0 files.
 ///
 /// See [BinHex 4.0 Definition](http://files.stairways.com/other/binhex-40-specs-info.txt).
-#[derive(Copy, Clone, Debug, Default)]
 pub struct BinHex;
 impl CharacterSet for BinHex {
     fn charset() -> base64::CharacterSet {

--- a/serde_with/src/content/ser.rs
+++ b/serde_with/src/content/ser.rs
@@ -15,7 +15,6 @@ use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 use core::marker::PhantomData;
 use serde::ser::{self, Serialize, Serializer};
 
-#[derive(Debug)]
 pub(crate) enum Content {
     Bool(bool),
 

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -113,7 +113,6 @@ pub trait DeserializeAs<'de, T>: Sized {
 }
 
 /// Helper type to implement [`DeserializeAs`] for container-like types.
-#[derive(Debug)]
 pub struct DeserializeAsWrap<T, U> {
     value: T,
     marker: PhantomData<U>,

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -159,7 +159,6 @@ use serde::{
 /// assert_eq!(values, deserialized);
 /// # }
 /// ```
-#[derive(Debug, Copy, Clone)]
 pub struct EnumMap;
 
 impl<T> SerializeAs<Vec<T>> for EnumMap

--- a/serde_with/src/formats.rs
+++ b/serde_with/src/formats.rs
@@ -22,8 +22,7 @@ macro_rules! create_format {
     ($(#[$attr:meta] $t:ident)*) => {
         $(
             #[$attr]
-            #[derive(Copy, Clone, Debug, Default)]
-            pub struct $t;
+                        pub struct $t;
             impl_format!(#[$attr] $t);
         )*
     };
@@ -87,11 +86,9 @@ create_format!(
 pub trait Strictness {}
 
 /// Use strict deserialization behavior, see [`Strictness`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Strict;
 impl Strictness for Strict {}
 
 /// Use a flexible deserialization behavior, see [`Strictness`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Flexible;
 impl Strictness for Flexible {}

--- a/serde_with/src/hex.rs
+++ b/serde_with/src/hex.rs
@@ -104,7 +104,6 @@ use serde::{de::Error, Deserialize, Deserializer, Serializer};
 /// error_result.unwrap_err();
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Hex<FORMAT: Format = Lowercase>(PhantomData<FORMAT>);
 
 impl<T> SerializeAs<T> for Hex<Lowercase>

--- a/serde_with/src/json.rs
+++ b/serde_with/src/json.rs
@@ -48,7 +48,6 @@ pub mod nested {
         D: Deserializer<'de>,
         T: DeserializeOwned,
     {
-        #[derive(Default)]
         struct Helper<S: DeserializeOwned>(PhantomData<S>);
 
         impl<'de, S> Visitor<'de> for Helper<S>
@@ -122,7 +121,6 @@ pub mod nested {
 /// );
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct JsonString;
 
 impl<T> SerializeAs<T> for JsonString

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1,8 +1,6 @@
 #![warn(
     clippy::semicolon_if_nothing_returned,
-    missing_copy_implementations,
     // missing_crate_level_docs, not available in MSRV
-    missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
     trivial_casts,
@@ -14,7 +12,6 @@
 )]
 #![doc(test(attr(forbid(unsafe_code))))]
 #![doc(test(attr(deny(
-    missing_copy_implementations,
     missing_debug_implementations,
     trivial_casts,
     trivial_numeric_casts,
@@ -362,7 +359,6 @@ pub trait Separator {
 }
 
 /// Predefined separator using a single space
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct SpaceSeparator;
 
 impl Separator for SpaceSeparator {
@@ -373,7 +369,6 @@ impl Separator for SpaceSeparator {
 }
 
 /// Predefined separator using a single comma
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct CommaSeparator;
 
 impl Separator for CommaSeparator {
@@ -423,7 +418,6 @@ impl Separator for CommaSeparator {
 /// ```
 ///
 /// [serde_as]: https://docs.rs/serde_with/1.14.0/serde_with/attr.serde_as.html
-#[derive(Copy, Clone, Debug, Default)]
 pub struct As<T: ?Sized>(PhantomData<T>);
 
 impl<T: ?Sized> As<T> {
@@ -460,7 +454,6 @@ impl<T: ?Sized> As<T> {
 /// This is the counter-type to [`As`][].
 /// It can be used whenever a type implementing [`DeserializeAs`][]/[`SerializeAs`][] is required but the normal `Deserialize`/`Serialize` traits should be used.
 /// Check [`As`] for an example.
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Same;
 
 /// De/Serialize using [`Display`] and [`FromStr`] implementation
@@ -511,7 +504,6 @@ pub struct Same;
 ///
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DisplayFromStr;
 
 /// De/Serialize a [`Option<String>`] type while transforming the empty string to [`None`]
@@ -555,7 +547,6 @@ pub struct DisplayFromStr;
 /// ```
 ///
 /// [`FromStr`]: std::str::FromStr
-#[derive(Copy, Clone, Debug, Default)]
 pub struct NoneAsEmptyString;
 
 /// Deserialize value and return [`Default`] on error
@@ -647,7 +638,6 @@ pub struct NoneAsEmptyString;
 /// # }
 /// ```
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DefaultOnError<T = Same>(PhantomData<T>);
 
 /// Deserialize [`Default`] from `null` values
@@ -705,7 +695,6 @@ pub struct DefaultOnError<T = Same>(PhantomData<T>);
 /// assert_eq!(vec![1, 2, 0, 0, 5], c.value);
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DefaultOnNull<T = Same>(PhantomData<T>);
 
 /// Deserialize from bytes or string
@@ -755,7 +744,6 @@ pub struct DefaultOnNull<T = Same>(PhantomData<T>);
 /// ```
 /// [`String`]: std::string::String
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct BytesOrString;
 
 /// De/Serialize Durations as number of seconds.
@@ -895,7 +883,6 @@ pub struct BytesOrString;
 ///
 /// [`chrono::Duration`]: ::chrono::Duration
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1024,7 +1011,6 @@ pub struct DurationSeconds<
 ///
 /// [`chrono::Duration`]: ::chrono::Duration
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1033,7 +1019,6 @@ pub struct DurationSecondsWithFrac<
 /// Equivalent to [`DurationSeconds`] with milli-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSeconds`] except that each unit represents 1 milli-second instead of 1 second for [`DurationSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationMilliSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1042,7 +1027,6 @@ pub struct DurationMilliSeconds<
 /// Equivalent to [`DurationSecondsWithFrac`] with milli-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSecondsWithFrac`] except that each unit represents 1 milli-second instead of 1 second for [`DurationSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationMilliSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1051,7 +1035,6 @@ pub struct DurationMilliSecondsWithFrac<
 /// Equivalent to [`DurationSeconds`] with micro-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSeconds`] except that each unit represents 1 micro-second instead of 1 second for [`DurationSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationMicroSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1060,7 +1043,6 @@ pub struct DurationMicroSeconds<
 /// Equivalent to [`DurationSecondsWithFrac`] with micro-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSecondsWithFrac`] except that each unit represents 1 micro-second instead of 1 second for [`DurationSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationMicroSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1069,7 +1051,6 @@ pub struct DurationMicroSecondsWithFrac<
 /// Equivalent to [`DurationSeconds`] with nano-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSeconds`] except that each unit represents 1 nano-second instead of 1 second for [`DurationSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationNanoSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1078,7 +1059,6 @@ pub struct DurationNanoSeconds<
 /// Equivalent to [`DurationSecondsWithFrac`] with nano-seconds as base unit.
 ///
 /// This type is equivalent to [`DurationSecondsWithFrac`] except that each unit represents 1 nano-second instead of 1 second for [`DurationSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct DurationNanoSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1226,7 +1206,6 @@ pub struct DurationNanoSecondsWithFrac<
 /// [`SystemTime`]: std::time::SystemTime
 /// [DateTime]: ::chrono::DateTime
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1363,7 +1342,6 @@ pub struct TimestampSeconds<
 /// [DateTime]: ::chrono::DateTime
 /// [NaiveDateTime]: ::chrono::NaiveDateTime
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1372,7 +1350,6 @@ pub struct TimestampSecondsWithFrac<
 /// Equivalent to [`TimestampSeconds`] with milli-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSeconds`] except that each unit represents 1 milli-second instead of 1 second for [`TimestampSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampMilliSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1381,7 +1358,6 @@ pub struct TimestampMilliSeconds<
 /// Equivalent to [`TimestampSecondsWithFrac`] with milli-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSecondsWithFrac`] except that each unit represents 1 milli-second instead of 1 second for [`TimestampSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampMilliSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1390,7 +1366,6 @@ pub struct TimestampMilliSecondsWithFrac<
 /// Equivalent to [`TimestampSeconds`] with micro-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSeconds`] except that each unit represents 1 micro-second instead of 1 second for [`TimestampSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampMicroSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1399,7 +1374,6 @@ pub struct TimestampMicroSeconds<
 /// Equivalent to [`TimestampSecondsWithFrac`] with micro-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSecondsWithFrac`] except that each unit represents 1 micro-second instead of 1 second for [`TimestampSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampMicroSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1408,7 +1382,6 @@ pub struct TimestampMicroSecondsWithFrac<
 /// Equivalent to [`TimestampSeconds`] with nano-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSeconds`] except that each unit represents 1 nano-second instead of 1 second for [`TimestampSeconds`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampNanoSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1417,7 +1390,6 @@ pub struct TimestampNanoSeconds<
 /// Equivalent to [`TimestampSecondsWithFrac`] with nano-seconds as base unit.
 ///
 /// This type is equivalent to [`TimestampSecondsWithFrac`] except that each unit represents 1 nano-second instead of 1 second for [`TimestampSecondsWithFrac`].
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TimestampNanoSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1590,7 +1562,6 @@ pub struct TimestampNanoSecondsWithFrac<
 /// # ), serde_json::to_value(&test).unwrap());
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct Bytes;
 
 /// Deserialize one or many elements
@@ -1651,7 +1622,6 @@ pub struct Bytes;
 /// # }
 /// ```
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomData<(T, FORMAT)>);
 
 /// Try multiple deserialization options until one succeeds.
@@ -1713,7 +1683,6 @@ pub struct OneOrMany<T, FORMAT: formats::Format = formats::PreferOne>(PhantomDat
 /// # }
 /// ```
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct PickFirst<T>(PhantomData<T>);
 
 /// Serialize value by converting to/from a proxy type with serde support.
@@ -1796,7 +1765,6 @@ pub struct PickFirst<T>(PhantomData<T>);
 /// assert_eq!(color, serde_json::from_value(j).unwrap());
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct FromInto<T>(PhantomData<T>);
 
 /// Serialize value by converting to/from a proxy type with serde support.
@@ -1887,7 +1855,6 @@ pub struct FromInto<T>(PhantomData<T>);
 /// assert_eq!("Boolikes can only be constructed from 0 or 1 but found 2", serde_json::from_value::<Data>(j).unwrap_err().to_string());
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct TryFromInto<T>(PhantomData<T>);
 
 /// Borrow `Cow` data during deserialization when possible.
@@ -1957,7 +1924,6 @@ pub struct TryFromInto<T>(PhantomData<T>);
 /// # }
 /// ```
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct BorrowCow;
 
 /// Deserialize a sequence into `Vec<T>`, skipping elements which fail to deserialize.
@@ -1995,7 +1961,6 @@ pub struct BorrowCow;
 /// # }
 /// ```
 #[cfg(feature = "alloc")]
-#[derive(Copy, Clone, Debug, Default)]
 pub struct VecSkipError<T>(PhantomData<T>);
 
 /// Deserialize a boolean from a number
@@ -2044,5 +2009,4 @@ pub struct VecSkipError<T>(PhantomData<T>);
 /// assert_eq!(data, serde_json::from_value(j).unwrap());
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
 pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>);

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -6,9 +6,7 @@ use alloc::collections::BTreeMap;
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 use core::{
-    cmp::Eq,
     fmt::{self, Display},
-    hash::Hash,
     iter::FromIterator,
     marker::PhantomData,
     str::FromStr,
@@ -322,7 +320,6 @@ pub mod seq_display_fromstr {
 /// ```
 ///
 /// [`serde_as`]: crate::guide::serde_as
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StringWithSeparator<Sep, T = ()>(PhantomData<(Sep, T)>);
 
 impl<Sep> StringWithSeparator<Sep>
@@ -1775,7 +1772,7 @@ pub mod default_on_error {
         D: Deserializer<'de>,
         T: Deserialize<'de> + Default,
     {
-        #[derive(Debug, serde::Deserialize)]
+        #[derive(serde::Deserialize)]
         #[serde(untagged)]
         enum GoodOrError<T> {
             Good(T),

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -110,7 +110,6 @@ pub trait SerializeAs<T: ?Sized> {
 }
 
 /// Helper type to implement [`SerializeAs`] for container-like types.
-#[derive(Debug)]
 pub struct SerializeAsWrap<'a, T: ?Sized, U: ?Sized> {
     value: &'a T,
     marker: PhantomData<U>,

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -19,7 +19,8 @@ use serde::{
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(Debug))]
 pub(crate) enum Sign {
     Positive,
     Negative,
@@ -47,7 +48,7 @@ impl Sign {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub(crate) struct DurationSigned {
     pub(crate) sign: Sign,
     pub(crate) duration: Duration,
@@ -482,7 +483,7 @@ where
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub(crate) enum ParseFloatError {
     InvalidValue,
     #[cfg(not(feature = "alloc"))]

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -530,7 +530,7 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// [re-exporting `serde_as`]: https://docs.rs/serde_with/1.14.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
-    #[derive(FromMeta, Debug)]
+    #[derive(FromMeta)]
     struct SerdeContainerOptions {
         #[darling(rename = "crate")]
         alt_crate_path: Option<String>,
@@ -570,7 +570,7 @@ fn serde_as_add_attr_to_field(
     field: &mut Field,
     serde_with_crate_path: &Path,
 ) -> Result<(), DarlingError> {
-    #[derive(FromField, Debug)]
+    #[derive(FromField)]
     #[darling(attributes(serde_as))]
     struct SerdeAsOptions {
         #[darling(rename = "as")]
@@ -586,7 +586,7 @@ fn serde_as_add_attr_to_field(
         }
     }
 
-    #[derive(FromField, Debug)]
+    #[derive(FromField)]
     #[darling(attributes(serde), allow_unknown_fields)]
     struct SerdeOptions {
         with: Option<String>,

--- a/serde_with_macros/src/utils.rs
+++ b/serde_with_macros/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) trait IteratorExt {
 impl<I> IteratorExt for I where I: Iterator<Item = Result<(), Error>> + Sized {}
 
 /// Attributes usable for derive macros
-#[derive(FromDeriveInput, Debug)]
+#[derive(FromDeriveInput)]
 #[darling(attributes(serde_with))]
 pub(crate) struct DeriveOptions {
     /// Path to the crate


### PR DESCRIPTION
Conversion types are never used as a value, but only within the
`serde_as` annotation. Therefore, they do not need `Clone`, or `Debug`
implementations, since they will never be printed.

This removes all those derives where not needed. They are left in place
in tests.

Closes #339