### PR TITLE
Rename crate feature to indicate the specific versions

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -30,7 +30,7 @@ alloc = [
     "serde/alloc",
 
     "base64?/alloc",
-    "chrono?/alloc",
+    "chrono_0_4?/alloc",
     "hex?/alloc",
     "serde_json?/alloc",
     "time_0_3?/alloc",
@@ -40,15 +40,16 @@ std = [
     "serde/std",
 
     # Enables `Local` type
-    "chrono?/clock",
-    "chrono?/std",
+    "chrono_0_4?/clock",
+    "chrono_0_4?/std",
     "indexmap?/std",
     "time_0_3?/serde-well-known",
     "time_0_3?/std",
 ]
 
 base64 = ["dep:base64", "alloc"]
-chrono = ["dep:chrono"]
+chrono = ["chrono_0_4"]
+chrono_0_4 = ["dep:chrono_0_4"]
 guide = ["dep:doc-comment", "macros", "std"]
 hex = ["dep:hex", "alloc"]
 indexmap = ["dep:indexmap", "alloc"]
@@ -59,7 +60,7 @@ time_0_3 = ["dep:time_0_3"]
 # When adding new optional dependencies update the documentation in feature-flags.md
 [dependencies]
 base64 = {version = "0.13.0", optional = true, default-features = false}
-chrono = {version = "0.4.10", optional = true, default-features = false, features = ["serde"]}
+chrono_0_4 = {package = "chrono", version = "0.4.10", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap = {version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
@@ -90,9 +91,9 @@ path = "tests/base64.rs"
 required-features = ["base64", "macros"]
 
 [[test]]
-name = "chrono"
-path = "tests/chrono.rs"
-required-features = ["chrono", "macros"]
+name = "chrono_0_4"
+path = "tests/chrono_0_4.rs"
+required-features = ["chrono_0_4", "macros"]
 
 [[test]]
 name = "hex"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -42,7 +42,7 @@ std = [
     # Enables `Local` type
     "chrono_0_4?/clock",
     "chrono_0_4?/std",
-    "indexmap?/std",
+    "indexmap_1?/std",
     "time_0_3?/serde-well-known",
     "time_0_3?/std",
 ]
@@ -52,7 +52,8 @@ chrono = ["chrono_0_4"]
 chrono_0_4 = ["dep:chrono_0_4"]
 guide = ["dep:doc-comment", "macros", "std"]
 hex = ["dep:hex", "alloc"]
-indexmap = ["dep:indexmap", "alloc"]
+indexmap = ["indexmap_1"]
+indexmap_1 = ["dep:indexmap_1", "alloc"]
 json = ["dep:serde_json", "alloc"]
 macros = ["dep:serde_with_macros"]
 time_0_3 = ["dep:time_0_3"]
@@ -63,7 +64,7 @@ base64 = {version = "0.13.0", optional = true, default-features = false}
 chrono_0_4 = {package = "chrono", version = "0.4.10", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.3", optional = true, default-features = false}
-indexmap = {version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
+indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "1.5.2", optional = true}
@@ -101,9 +102,9 @@ path = "tests/hex.rs"
 required-features = ["hex", "macros"]
 
 [[test]]
-name = "indexmap"
-path = "tests/indexmap.rs"
-required-features = ["indexmap", "macros"]
+name = "indexmap_1"
+path = "tests/indexmap_1.rs"
+required-features = ["indexmap_1", "macros"]
 
 [[test]]
 name = "json"

--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -1,6 +1,6 @@
-//! De/Serialization of [chrono][] types
+//! De/Serialization of [chrono] types
 //!
-//! This modules is only available if using the `chrono` feature of the crate.
+//! This modules is only available if using the `chrono_0_4` feature of the crate.
 //!
 //! [chrono]: https://docs.rs/chrono/
 
@@ -20,8 +20,8 @@ use alloc::string::String;
 #[cfg(feature = "std")]
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
-use chrono::Local;
-use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
+use chrono_0_4::Local;
+use chrono_0_4::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 #[cfg(feature = "std")]
 use core::fmt;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -49,12 +49,12 @@ fn unix_epoch_naive() -> NaiveDateTime {
 /// # Examples
 ///
 /// ```
-/// # use chrono::{DateTime, Utc};
+/// # use chrono_0_4::{DateTime, Utc};
 /// # use serde::Deserialize;
 /// #
 /// #[derive(Debug, Deserialize)]
 /// struct S {
-///     #[serde(with = "serde_with::chrono::datetime_utc_ts_seconds_from_any")]
+///     #[serde(with = "serde_with::chrono_0_4::datetime_utc_ts_seconds_from_any")]
 ///     date: DateTime<Utc>,
 /// }
 ///
@@ -69,7 +69,7 @@ fn unix_epoch_naive() -> NaiveDateTime {
 #[cfg(feature = "std")]
 pub mod datetime_utc_ts_seconds_from_any {
     use super::*;
-    use chrono::{DateTime, NaiveDateTime, Utc};
+    use chrono_0_4::{DateTime, NaiveDateTime, Utc};
     use serde::de::{Deserializer, Error, Unexpected, Visitor};
 
     /// Deserialize a Unix timestamp with optional subsecond precision into a `DateTime<Utc>`.
@@ -213,7 +213,7 @@ impl<'de> DeserializeAs<'de, NaiveDateTime> for DateTime<Utc> {
     }
 }
 
-/// Convert a [`chrono::Duration`] into a [`DurationSigned`]
+/// Convert a [`chrono_0_4::Duration`] into a [`DurationSigned`]
 fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
     match dur.to_std() {
         Ok(dur) => DurationSigned::with_duration(Sign::Positive, dur),
@@ -227,7 +227,7 @@ fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
     }
 }
 
-/// Convert a [`DurationSigned`] into a [`chrono::Duration`]
+/// Convert a [`DurationSigned`] into a [`chrono_0_4::Duration`]
 fn duration_from_duration_signed<'de, D>(dur: DurationSigned) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -17,7 +17,7 @@ use alloc::{
     sync::{Arc, Weak as ArcWeak},
     vec::Vec,
 };
-#[cfg(any(feature = "std", feature = "indexmap"))]
+#[cfg(any(feature = "std", feature = "indexmap_1"))]
 use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "std")]
 use core::time::Duration;
@@ -28,8 +28,8 @@ use core::{
     iter::FromIterator,
     str::FromStr,
 };
-#[cfg(feature = "indexmap")]
-use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "indexmap_1")]
+use indexmap_1::{IndexMap, IndexSet};
 use serde::de::*;
 #[cfg(feature = "std")]
 use std::{
@@ -389,7 +389,7 @@ seq_impl!(
     VecDeque::with_capacity(utils::size_hint_cautious(seq.size_hint())),
     push_back
 );
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 seq_impl!(
     IndexSet<T: Eq + Hash, S: BuildHasher + Default>,
     seq,
@@ -470,7 +470,7 @@ map_impl!(
     HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
     map,
     HashMap::with_capacity_and_hasher(utils::size_hint_cautious(map.size_hint()), S::default()));
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 map_impl!(
     IndexMap<K: Eq + Hash, V, S: BuildHasher + Default>,
     map,
@@ -599,7 +599,7 @@ macro_rules! map_as_tuple_seq {
 map_as_tuple_seq!(BTreeMap<K: Ord, V>);
 #[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K: Eq + Hash, V>);
-#[cfg(all(feature = "std", feature = "indexmap"))]
+#[cfg(all(feature = "std", feature = "indexmap_1"))]
 map_as_tuple_seq!(IndexMap<K: Eq + Hash, V>);
 
 #[cfg(feature = "alloc")]
@@ -678,7 +678,7 @@ tuple_seq_as_map_impl! {
 }
 #[cfg(feature = "std")]
 tuple_seq_as_map_impl!(HashSet<(K: Eq + Hash, V: Eq + Hash)>);
-#[cfg(all(feature = "std", feature = "indexmap"))]
+#[cfg(all(feature = "std", feature = "indexmap_1"))]
 tuple_seq_as_map_impl!(IndexSet<(K: Eq + Hash, V: Eq + Hash)>);
 
 #[cfg(feature = "alloc")]

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,8 +1,8 @@
 use alloc::collections::{BTreeMap, BTreeSet};
-#[cfg(any(feature = "std", feature = "indexmap"))]
+#[cfg(any(feature = "std", feature = "indexmap_1"))]
 use core::hash::{BuildHasher, Hash};
-#[cfg(feature = "indexmap")]
-use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "indexmap_1")]
+use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
@@ -40,7 +40,7 @@ where
     }
 }
 
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 impl<T, S> PreventDuplicateInsertsSet<T> for IndexSet<T, S>
 where
     T: Eq + Hash,
@@ -95,7 +95,7 @@ where
     }
 }
 
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 impl<K, V, S> PreventDuplicateInsertsMap<K, V> for IndexMap<K, V, S>
 where
     K: Eq + Hash,

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,8 +1,8 @@
 use alloc::collections::BTreeMap;
-#[cfg(any(feature = "std", feature = "indexmap"))]
+#[cfg(any(feature = "std", feature = "indexmap_1"))]
 use core::hash::{BuildHasher, Hash};
-#[cfg(feature = "indexmap")]
-use indexmap::IndexMap;
+#[cfg(feature = "indexmap_1")]
+use indexmap_1::IndexMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
@@ -41,7 +41,7 @@ where
     }
 }
 
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 impl<K, V, S> DuplicateInsertsFirstWinsMap<K, V> for IndexMap<K, V, S>
 where
     K: Eq + Hash,
@@ -57,7 +57,7 @@ where
 
     #[inline]
     fn insert(&mut self, key: K, value: V) {
-        use indexmap::map::Entry;
+        use indexmap_1::map::Entry;
 
         match self.entry(key) {
             // we want to keep the first value, so do nothing

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,8 +1,8 @@
 use alloc::collections::BTreeSet;
-#[cfg(any(feature = "std", feature = "indexmap"))]
+#[cfg(any(feature = "std", feature = "indexmap_1"))]
 use core::hash::{BuildHasher, Hash};
-#[cfg(feature = "indexmap")]
-use indexmap::IndexSet;
+#[cfg(feature = "indexmap_1")]
+use indexmap_1::IndexSet;
 #[cfg(feature = "std")]
 use std::collections::HashSet;
 
@@ -34,7 +34,7 @@ where
     }
 }
 
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 impl<T, S> DuplicateInsertsLastWinsSet<T> for IndexSet<T, S>
 where
     T: Eq + Hash,

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -12,7 +12,7 @@ Using it in a `no_std` environment requires using `default-features = false`, si
 4. [`chrono_0_4`](#chrono_0_4)
 5. [`guide`](#guide)
 6. [`hex`](#hex)
-7. [`indexmap`](#indexmap)
+7. [`indexmap_1`](#indexmap_1)
 8. [`json`](#json)
 9. [`macros` (default)](#macros-default)
 10. [`time_0_3`](#time_0_3)
@@ -55,10 +55,11 @@ The `hex` feature enables serializing data in hex format.
 This pulls in `hex` as a dependency.
 It enables the `alloc` feature.
 
-## `indexmap`
+## `indexmap_1`
 
-The `indexmap` feature enables implementations of `indexmap` specific checks.
+The `indexmap_1` feature enables implementations of `indexmap_1` specific checks.
 This includes support for checking duplicate keys and duplicate values.
+The legacy feature name `indexmap` is still available for v1 compatability.
 
 This pulls in `indexmap` as a dependency.
 It enables the `alloc` feature.

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -9,7 +9,7 @@ Using it in a `no_std` environment requires using `default-features = false`, si
 1. [`alloc`](#alloc)
 2. [`std` (default)](#std-default)
 3. [`base64`](#base64)
-4. [`chrono`](#chrono)
+4. [`chrono_0_4`](#chrono_0_4)
 5. [`guide`](#guide)
 6. [`hex`](#hex)
 7. [`indexmap`](#indexmap)
@@ -34,13 +34,14 @@ The `base64` feature enables serializing data in base64 format.
 This pulls in `base64` as a dependency.
 It enables the `alloc` feature.
 
-## `chrono`
+## `chrono_0_4`
 
-The `chrono` feature enables integration of `chrono` specific conversions.
+The `chrono_0_4` feature enables integration of `chrono_0_4` specific conversions.
 This includes support for the timestamp and duration types.
 More features are available in combination with `alloc` or `std`.
+The legacy feature name `chrono` is still available for v1 compatability.
 
-This pulls in `chrono` as a dependency.
+This pulls in `chrono` v0.4 as a dependency.
 
 ## `guide`
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -267,9 +267,15 @@ extern crate std;
 #[cfg(feature = "base64")]
 #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub mod base64;
+#[cfg(feature = "chrono_0_4")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono_0_4")))]
+pub mod chrono_0_4;
+/// Legacy export of the [`chrono_0_4`] module.
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
-pub mod chrono;
+pub mod chrono {
+    pub use chrono_0_4::*;
+}
 #[cfg(feature = "alloc")]
 mod content;
 pub mod de;
@@ -722,7 +728,7 @@ pub struct BytesOrString;
 /// [`formats::Flexible`] means that deserialization will perform a best effort to extract the correct duration and allows deserialization from any type.
 /// For example, deserializing `DurationSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
-/// This type also supports [`chrono::Duration`] with the `chrono`-[feature flag].
+/// This type also supports [`chrono::Duration`] with the `chrono_0_4`-[feature flag].
 /// This type also supports [`time::Duration`][::time_0_3::Duration] with the `time_0_3`-[feature flag].
 ///
 /// | Duration Type         | Converter                 | Available `FORMAT`s    |
@@ -788,15 +794,15 @@ pub struct BytesOrString;
 /// # }
 /// ```
 ///
-/// [`chrono::Duration`] is also supported when using the `chrono` feature.
+/// [`chrono::Duration`] is also supported when using the `chrono_0_4` feature.
 /// It is a signed duration, thus can be de/serialized as an `i64` instead of a `u64`.
 ///
 /// ```rust
-/// # #[cfg(all(feature = "macros", feature = "chrono"))] {
+/// # #[cfg(all(feature = "macros", feature = "chrono_0_4"))] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, DurationSeconds};
-/// # use chrono::Duration;
+/// # use chrono_0_4::Duration;
 /// # /* Ugliness to make the docs look nicer since I want to hide the rename of the chrono crate
 /// use chrono::Duration;
 /// # */
@@ -846,7 +852,7 @@ pub struct BytesOrString;
 /// # }
 /// ```
 ///
-/// [`chrono::Duration`]: ::chrono::Duration
+/// [`chrono::Duration`]: ::chrono_0_4::Duration
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
@@ -924,15 +930,15 @@ pub struct DurationSeconds<
 /// # }
 /// ```
 ///
-/// [`chrono::Duration`] is also supported when using the `chrono` feature.
+/// [`chrono::Duration`] is also supported when using the `chrono_0_4` feature.
 /// It is a signed duration, thus can be de/serialized as an `i64` instead of a `u64`.
 ///
 /// ```rust
-/// # #[cfg(all(feature = "macros", feature = "chrono"))] {
+/// # #[cfg(all(feature = "macros", feature = "chrono_0_4"))] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, DurationSecondsWithFrac};
-/// # use chrono::Duration;
+/// # use chrono_0_4::Duration;
 /// # /* Ugliness to make the docs look nicer since I want to hide the rename of the chrono crate
 /// use chrono::Duration;
 /// # */
@@ -974,7 +980,7 @@ pub struct DurationSeconds<
 /// # }
 /// ```
 ///
-/// [`chrono::Duration`]: ::chrono::Duration
+/// [`chrono::Duration`]: ::chrono_0_4::Duration
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
@@ -1040,7 +1046,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// [`formats::Flexible`] means that deserialization will perform a best effort to extract the correct timestamp and allows deserialization from any type.
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
-/// This type also supports [`chrono::DateTime`][DateTime] with the `chrono`-[feature flag].
+/// This type also supports [`chrono::DateTime`] with the `chrono_0_4`-[feature flag].
 /// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// | Timestamp Type            | Converter                  | Available `FORMAT`s    |
@@ -1110,15 +1116,15 @@ pub struct DurationNanoSecondsWithFrac<
 /// # }
 /// ```
 ///
-/// [`chrono::DateTime<Utc>`][DateTime] and [`chrono::DateTime<Local>`][DateTime] are also supported when using the `chrono` feature.
+/// [`chrono::DateTime<Utc>`] and [`chrono::DateTime<Local>`] are also supported when using the `chrono` feature.
 /// Like [`SystemTime`], it is a signed timestamp, thus can be de/serialized as an `i64`.
 ///
 /// ```rust
-/// # #[cfg(all(feature = "macros", feature = "chrono"))] {
+/// # #[cfg(all(feature = "macros", feature = "chrono_0_4"))] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, TimestampSeconds};
-/// # use chrono::{DateTime, Local, TimeZone, Utc};
+/// # use chrono_0_4::{DateTime, Local, TimeZone, Utc};
 /// # /* Ugliness to make the docs look nicer since I want to hide the rename of the chrono crate
 /// use chrono::{DateTime, Local, TimeZone, Utc};
 /// # */
@@ -1169,7 +1175,8 @@ pub struct DurationNanoSecondsWithFrac<
 /// ```
 ///
 /// [`SystemTime`]: std::time::SystemTime
-/// [DateTime]: ::chrono::DateTime
+/// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
+/// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
@@ -1187,7 +1194,7 @@ pub struct TimestampSeconds<
 /// [`formats::Flexible`] means that deserialization will perform a best effort to extract the correct timestamp and allows deserialization from any type.
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
-/// This type also supports [`chrono::DateTime`][DateTime] and [`chrono::NaiveDateTime`][NaiveDateTime] with the `chrono`-[feature flag].
+/// This type also supports [`chrono::DateTime`] and [`chrono::NaiveDateTime`][NaiveDateTime] with the `chrono`-[feature flag].
 /// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// | Timestamp Type            | Converter                  | Available `FORMAT`s    |
@@ -1253,15 +1260,15 @@ pub struct TimestampSeconds<
 /// # }
 /// ```
 ///
-/// [`chrono::DateTime<Utc>`][DateTime] and [`chrono::DateTime<Local>`][DateTime] are also supported when using the `chrono` feature.
+/// [`chrono::DateTime<Utc>`] and [`chrono::DateTime<Local>`] are also supported when using the `chrono_0_4` feature.
 /// Like [`SystemTime`], it is a signed timestamp, thus can be de/serialized as an `i64`.
 ///
 /// ```rust
-/// # #[cfg(all(feature = "macros", feature = "chrono"))] {
+/// # #[cfg(all(feature = "macros", feature = "chrono_0_4"))] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// # use serde_with::{serde_as, TimestampSecondsWithFrac};
-/// # use chrono::{DateTime, Local, TimeZone, Utc};
+/// # use chrono_0_4::{DateTime, Local, TimeZone, Utc};
 /// # /* Ugliness to make the docs look nicer since I want to hide the rename of the chrono crate
 /// use chrono::{DateTime, Local, TimeZone, Utc};
 /// # */
@@ -1304,8 +1311,10 @@ pub struct TimestampSeconds<
 /// ```
 ///
 /// [`SystemTime`]: std::time::SystemTime
-/// [DateTime]: ::chrono::DateTime
-/// [NaiveDateTime]: ::chrono::NaiveDateTime
+/// [`chrono::DateTime`]: ::chrono_0_4::DateTime
+/// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
+/// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
+/// [NaiveDateTime]: ::chrono_0_4::NaiveDateTime
 /// [feature flag]: https://docs.rs/serde_with/1.14.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -20,8 +20,8 @@ use core::{
     fmt::Display,
     time::Duration,
 };
-#[cfg(feature = "indexmap")]
-use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "indexmap_1")]
+use indexmap_1::{IndexMap, IndexSet};
 use serde::ser::Error;
 #[cfg(feature = "std")]
 use std::{
@@ -277,7 +277,7 @@ seq_impl!(Slice<T>);
 seq_impl!(Vec<T>);
 #[cfg(feature = "alloc")]
 seq_impl!(VecDeque<T>);
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 seq_impl!(IndexSet<T, H: Sized>);
 
 #[cfg(feature = "alloc")]
@@ -304,7 +304,7 @@ macro_rules! map_impl {
 map_impl!(BTreeMap<K, V>);
 #[cfg(feature = "std")]
 map_impl!(HashMap<K, V, H: Sized>);
-#[cfg(feature = "indexmap")]
+#[cfg(feature = "indexmap_1")]
 map_impl!(IndexMap<K, V, H: Sized>);
 
 macro_rules! tuple_impl {
@@ -372,7 +372,7 @@ map_as_tuple_seq!(BTreeMap<K, V>);
 // TODO HashMap with a custom hasher support would be better, but results in "unconstrained type parameter"
 #[cfg(feature = "std")]
 map_as_tuple_seq!(HashMap<K, V>);
-#[cfg(all(feature = "std", feature = "indexmap"))]
+#[cfg(all(feature = "std", feature = "indexmap_1"))]
 map_as_tuple_seq!(IndexMap<K, V>);
 
 #[cfg(feature = "alloc")]
@@ -420,7 +420,7 @@ tuple_seq_as_map_impl! {
 }
 #[cfg(feature = "std")]
 tuple_seq_as_map_impl!(HashSet<(K, V)>);
-#[cfg(all(feature = "std", feature = "indexmap"))]
+#[cfg(all(feature = "std", feature = "indexmap_1"))]
 tuple_seq_as_map_impl!(IndexSet<(K, V)>);
 
 #[cfg(feature = "alloc")]

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -62,7 +62,7 @@ impl DurationSigned {
         }
     }
 
-    #[cfg(any(feature = "chrono", feature = "time_0_3"))]
+    #[cfg(any(feature = "chrono_0_4", feature = "time_0_3"))]
     pub(crate) fn with_duration(sign: Sign, duration: Duration) -> Self {
         Self { sign, duration }
     }

--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -14,7 +14,7 @@ use crate::utils::{
     check_deserialization, check_error_deserialization, check_serialization, is_equal,
 };
 use alloc::collections::BTreeMap;
-use chrono::{DateTime, Duration, Local, NaiveDateTime, Utc};
+use chrono_0_4::{DateTime, Duration, Local, NaiveDateTime, Utc};
 use core::{iter::FromIterator, str::FromStr};
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,9 @@ fn new_datetime(secs: i64, nsecs: u32) -> DateTime<Utc> {
 #[test]
 fn json_datetime_from_any_to_string_deserialization() {
     #[derive(Debug, PartialEq, Deserialize)]
-    struct S(#[serde(with = "serde_with::chrono::datetime_utc_ts_seconds_from_any")] DateTime<Utc>);
+    struct S(
+        #[serde(with = "serde_with::chrono_0_4::datetime_utc_ts_seconds_from_any")] DateTime<Utc>,
+    );
 
     // just integers
     check_deserialization(

--- a/serde_with/tests/indexmap_1.rs
+++ b/serde_with/tests/indexmap_1.rs
@@ -11,7 +11,7 @@ mod utils;
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
 use core::iter::FromIterator;
 use expect_test::expect;
-use indexmap::{IndexMap, IndexSet};
+use indexmap_1::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Same};
 use std::net::IpAddr;


### PR DESCRIPTION
* Rename `chrono` to `chrono_0_4`
* Rename `indexmap` to `indexmap_1`
* Rename the `chrono` module.
* Add aliases for the old names and module, such that no changes in other crates should be necessary.