### PR TITLE
Some more cleanups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,13 @@ be dual licensed as above, without any additional terms or conditions.
 
 ## Adding support for new crates
 
-`serde_with` takes a liberal approach to crate compatability and provides additional implementations for well-known crates, such as `chrono` or `indexmap`.
+`serde_with` takes a liberal approach to crate compatibility and provides additional implementations for well-known crates, such as `chrono` or `indexmap`.
 New crates should always be optional and only be enabled with an explicit feature.
 The feature name should include the major version of the crate.
 This allows adding support for new breaking releases of these crates.
 For example, `chrono` is currently at v0.4, so the feature name should be `chrono_0_4`.
 A new chrono v0.5 would get the feature name `chrono_0_5` and the v1 release `chrono_1`.
 
-`serde_with` depends also on further crates to implement the convertesrs, such as `base64` or `hex`.
+`serde_with` depends also on further crates to implement the converters, such as `base64` or `hex`.
 Here the feature name should not depend on the crate, but rather describe the added functionality enabled by it.
 For example, additional JSON functionality is behind the `json` feature and it depends on `serde_json` for the implementation.

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     * `string_empty_as_none` can be replaced with `#[serde_as(as = "NoneAsEmptyString")]`.
     * `StringWithSeparator` can now only be used in `serde_as`.
         The definition of the `Separator` trait and its implementations have been moved to the `formats` module.
+    * `json::nested` can be replaced with `#[serde_as(as = "json::JsonString")]`.
 
 * Remove previously deprecated modules.
 

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -14,7 +14,7 @@ use super::*;
 /// A **data structure** that can be deserialized from any data format supported by Serde, analogue to [`Deserialize`].
 ///
 /// The trait is analogue to the [`serde::Deserialize`][`Deserialize`] trait, with the same meaning of input and output arguments.
-/// It can and should the implemented using the same code structure as the [`Deserialize`] trait.
+/// It can and should be implemented using the same code structure as the [`Deserialize`] trait.
 /// As such, the same advice for [implementing `Deserialize`][impl-deserialize] applies here.
 ///
 /// # Differences to [`Deserialize`]

--- a/serde_with/src/guide/serde_as.md
+++ b/serde_with/src/guide/serde_as.md
@@ -67,9 +67,18 @@ struct A {
 
 ### Deserializing Optional Fields
 
-During deserialization, serde treats fields of `Option<T>` as optional and does not require them to be present.
-This breaks when adding either the `serde_as` annotation or serde's `with` annotation.
-The default behavior can be restored by adding serde's `default` attribute.
+In many cases using `serde_as` on a field of type `Option` should behave as expected.
+This mean the field can still be missing during deserialization and will be filled with the value `None`.
+
+This "magic" can break in some cases. Then it becomes necessary to apply `#[serde(default)]` on the field in question.
+If the field is of type `Option<T>` and the conversion type is of `Option<S>`, the default attribute is automatically applied.
+These variants are detected as `Option`.
+* `Option`
+* `std::option::Option`, with or without leading `::`
+* `core::option::Option`, with or without leading `::`
+
+Any renaming will interfere with the detection, such as `use std::option::Option as StdOption;`.
+For more information you can inspect the documentation of the `serde_as` macro.
 
 ```rust
 # use serde::{Deserialize, Serialize};
@@ -79,8 +88,8 @@ The default behavior can be restored by adding serde's `default` attribute.
 #[derive(Serialize, Deserialize)]
 struct A {
     #[serde_as(as = "Option<DisplayFromStr>")]
-    // Allows deserialization without providing a value for `val`
-    #[serde(default)]
+    // In this situation boths `Option`s will be correctly identified and
+    // `#[serde(default)]` will be applied on this field.
     val: Option<u32>,
 }
 ```

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -425,7 +425,7 @@ value: SystemTime,
 
 The same conversions are also implemented for [`chrono::DateTime<Utc>`], [`chrono::DateTime<Local>`], and [`chrono::NaiveDateTime`] with the `chrono` feature.
 
-The conversions are availble for [`time::OffsetDateTime`] and [`time::PrimitiveDateTime`] with the `time_0_3` feature enabled.
+The conversions are available for [`time::OffsetDateTime`] and [`time::PrimitiveDateTime`] with the `time_0_3` feature enabled.
 
 ## Value into JSON String
 
@@ -485,7 +485,7 @@ rfc_3339: OffsetDateTime,
 "rfc_3339": "1997-11-21T09:55:06-06:00",
 ```
 
-These conversions are availble with the `time_0_3` feature flag.
+These conversions are available with the `time_0_3` feature flag.
 
 [`Base64`]: crate::base64::Base64
 [`BoolFromInt<Flexible>`]: crate::BoolFromInt

--- a/serde_with/src/json.rs
+++ b/serde_with/src/json.rs
@@ -3,93 +3,23 @@
 //! This modules is only available when using the `json` feature of the crate.
 
 use crate::{de::DeserializeAs, ser::SerializeAs};
-use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
+use core::{fmt, marker::PhantomData};
+use serde::{
+    de,
+    de::{DeserializeOwned, Deserializer, Visitor},
+    ser,
+    ser::{Serialize, Serializer},
+};
 
 /// Serialize value as string containing JSON
 ///
-/// The same functionality is also available as [`serde_with::json::JsonString`][crate::json::JsonString] compatible with the `serde_as`-annotation.
+/// *Note*: This type is not necessary for normal usage of serde with JSON.
+/// It is only required if the serialized format contains a string, which itself contains JSON.
 ///
-/// # Examples
+/// # Errors
 ///
-/// ```
-/// # use serde::{Deserialize, Serialize};
-/// #
-/// #[derive(Deserialize, Serialize)]
-/// struct A {
-///     #[serde(with = "serde_with::json::nested")]
-///     other_struct: B,
-/// }
-/// #[derive(Deserialize, Serialize)]
-/// struct B {
-///     value: usize,
-/// }
-///
-/// let v: A = serde_json::from_str(r#"{"other_struct":"{\"value\":5}"}"#).unwrap();
-/// assert_eq!(5, v.other_struct.value);
-///
-/// let x = A {
-///     other_struct: B { value: 10 },
-/// };
-/// assert_eq!(
-///     r#"{"other_struct":"{\"value\":10}"}"#,
-///     serde_json::to_string(&x).unwrap()
-/// );
-/// ```
-pub mod nested {
-    use core::{fmt, marker::PhantomData};
-    use serde::{
-        de::{DeserializeOwned, Deserializer, Error, Visitor},
-        ser::{self, Serialize, Serializer},
-    };
-
-    /// Deserialize value from a string which is valid JSON
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-        T: DeserializeOwned,
-    {
-        struct Helper<S: DeserializeOwned>(PhantomData<S>);
-
-        impl<'de, S> Visitor<'de> for Helper<S>
-        where
-            S: DeserializeOwned,
-        {
-            type Value = S;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("valid json object")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<S, E>
-            where
-                E: Error,
-            {
-                serde_json::from_str(value).map_err(Error::custom)
-            }
-        }
-
-        deserializer.deserialize_str(Helper(PhantomData))
-    }
-
-    /// Serialize value as string containing JSON
-    ///
-    /// # Errors
-    ///
-    /// Serialization can fail if `T`'s implementation of `Serialize` decides to
-    /// fail, or if `T` contains a map with non-string keys.
-    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        T: Serialize,
-        S: Serializer,
-    {
-        let s = serde_json::to_string(value).map_err(ser::Error::custom)?;
-        serializer.serialize_str(&*s)
-    }
-}
-
-/// Serialize value as string containing JSON
-///
-/// The same functionality is also available as [`serde_with::json::nested`][crate::json::nested] compatible with serde's with-annotation.
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
 ///
 /// # Examples
 ///
@@ -131,7 +61,8 @@ where
     where
         S: Serializer,
     {
-        crate::json::nested::serialize(source, serializer)
+        let s = serde_json::to_string(source).map_err(ser::Error::custom)?;
+        serializer.serialize_str(&*s)
     }
 }
 
@@ -143,6 +74,26 @@ where
     where
         D: Deserializer<'de>,
     {
-        crate::json::nested::deserialize(deserializer)
+        struct Helper<S: DeserializeOwned>(PhantomData<S>);
+
+        impl<'de, S> Visitor<'de> for Helper<S>
+        where
+            S: DeserializeOwned,
+        {
+            type Value = S;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("valid json object")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<S, E>
+            where
+                E: de::Error,
+            {
+                serde_json::from_str(value).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(Helper(PhantomData))
     }
 }

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -14,7 +14,7 @@ use super::*;
 /// A **data structure** that can be serialized into any data format supported by Serde, analogue to [`Serialize`].
 ///
 /// The trait is analogue to the [`serde::Serialize`][`Serialize`] trait, with the same meaning of input and output arguments.
-/// It can and should the implemented using the same code structure as the [`Serialize`] trait.
+/// It can and should be implemented using the same code structure as the [`Serialize`] trait.
 /// As such, the same advice for [implementing `Serialize`][impl-serialize] applies here.
 ///
 /// # Differences to [`Serialize`]


### PR DESCRIPTION
* Previously forgot to remove `json::nested` which can be replaced with `json::JsonString`.
* Some typos.
* Update the guide to include the new rules for optional fields.

bors r+