### PR TITLE
Make the `JsonString` smarter

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Make `JsonString<T>` smarter by allowing nesting `serde_as` definitions.
+    This allows applying custom serialization logic, before the value gets converted into a JSON string.
+
+    ```rust
+    // Rust
+    #[serde_as(as = "JsonString<Vec<(JsonString, _)>>")]
+    value: BTreeMap<[u8; 2], u32>,
+
+    // JSON
+    {"value":"[[\"[1,2]\",3],[\"[4,5]\",6]]"}
+    ```
+
 ## [2.0.0-rc.0] - 2022-06-29
 
 ### Changed

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -449,6 +449,14 @@ value: OtherStruct,
 "value": "{\"value\":5}",
 ```
 
+```ignore
+#[serde_as(as = "JsonString<Vec<(JsonString, _)>>")]
+value: BTreeMap<[u8; 2], u32>,
+
+// JSON
+{"value":"[[\"[1,2]\",3],[\"[4,5]\",6]]"}
+```
+
 ## `Vec` of tuples to `Maps`
 
 ```ignore

--- a/serde_with/tests/json.rs
+++ b/serde_with/tests/json.rs
@@ -12,9 +12,10 @@ use crate::utils::is_equal;
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{json::JsonString, serde_as, DisplayFromStr};
+use std::collections::BTreeMap;
 
 #[test]
-fn test_nested_json() {
+fn test_jsonstring() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Struct {
@@ -36,6 +37,26 @@ fn test_nested_json() {
         expect![[r#"
             {
               "value": "{\"value\":\"444\"}"
+            }"#]],
+    );
+}
+
+#[test]
+fn test_jsonstring_nested() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Struct {
+        #[serde_as(as = "JsonString<Vec<(JsonString, _)>>")]
+        value: BTreeMap<[u8; 2], u32>,
+    }
+
+    is_equal(
+        Struct {
+            value: BTreeMap::from([([1, 2], 3), ([4, 5], 6)]),
+        },
+        expect![[r#"
+            {
+              "value": "[[\"[1,2]\",3],[\"[4,5]\",6]]"
             }"#]],
     );
 }


### PR DESCRIPTION
This allow nested application of `serde_as` logic on the inner value.

```rust
// Rust
value: BTreeMap<[u8; 2], u32>,

// JSON
{"value":"[[\"[1,2]\",3],[\"[4,5]\",6]]"}
```

Closes #485

bors r+