### PR TITLE
The time crate added support for `Iso8601` as a well-known format.

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `time` added support for the well-known `Iso8601` format.
+    This extends the existing support of `Rfc2822` and `Rfc3339`.
+
 ## [2.0.0] - 2022-07-17
 
 ### Added

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -68,7 +68,7 @@ indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-fe
 serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "2.0.0", optional = true}
-time_0_3 = {package = "time", version = "~0.3", optional = true, default-features = false}
+time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}
 
 [dev-dependencies]
 expect-test = "1.3.0"

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -479,7 +479,7 @@ The [inverse operation](#maps-to-vec-of-tuples) is also available.
 ## Well-known time formats for `OffsetDateTime`
 
 [`time::OffsetDateTime`] can be serialized in string format in different well-known formats.
-Two formats are supported, [`time::format_description::well_known::Rfc2822`] and [`time::format_description::well_known::Rfc3339`].
+Three formats are supported, [`time::format_description::well_known::Rfc2822`], [`time::format_description::well_known::Rfc3339`], and [`time::format_description::well_known::Iso8601`].
 
 ```ignore
 // Rust
@@ -487,10 +487,13 @@ Two formats are supported, [`time::format_description::well_known::Rfc2822`] and
 rfc_2822: OffsetDateTime,
 #[serde_as(as = "time::format_description::well_known::Rfc3339")]
 rfc_3339: OffsetDateTime,
+#[serde_as(as = "time::format_description::well_known::Iso8601<Config>")]
+iso_8601: OffsetDateTime,
 
 // JSON
 "rfc_2822": "Fri, 21 Nov 1997 09:55:06 -0600",
 "rfc_3339": "1997-11-21T09:55:06-06:00",
+"iso_8061": "1997-11-21T09:55:06-06:00",
 ```
 
 These conversions are available with the `time_0_3` feature flag.
@@ -516,6 +519,7 @@ These conversions are available with the `time_0_3` feature flag.
 [`OneOrMany`]: crate::OneOrMany
 [`PickFirst`]: crate::PickFirst
 [`time::Duration`]: time_0_3::Duration
+[`time::format_description::well_known::Iso8601`]: time_0_3::format_description::well_known::Iso8601
 [`time::format_description::well_known::Rfc2822`]: time_0_3::format_description::well_known::Rfc2822
 [`time::format_description::well_known::Rfc3339`]: time_0_3::format_description::well_known::Rfc3339
 [`time::OffsetDateTime`]: time_0_3::OffsetDateTime


### PR DESCRIPTION
This adds `serde_as` support for `Iso8601`.

bors r+