### PR TITLE
Bump fixed chrono 0.4.20

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,10 +1,6 @@
 [advisories]
-ignore = [
-    # chrono: Potential segfault in `localtime_r` invocations
-    # chrono is an optional depenency, so we can ignore the warning.
-    # Right now there is no safe version of chrono to upgrade to.
-    "RUSTSEC-2020-0159",
-]
+#ignore = [
+#]
 # warn for categories of informational advisories
 informational_warnings = [
     "unmaintained",

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -61,7 +61,7 @@ time_0_3 = ["dep:time_0_3"]
 # When adding new optional dependencies update the documentation in feature-flags.md
 [dependencies]
 base64 = {version = "0.13.0", optional = true, default-features = false}
-chrono_0_4 = {package = "chrono", version = "0.4.10", optional = true, default-features = false, features = ["serde"]}
+chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}


### PR DESCRIPTION
Chrono now - 0.4.20 - has localtime_r RIR that has addressed the past security issue around it :partying_face:

We've updated here:
https://rustsec.org/advisories/RUSTSEC-2020-0159.html