### PR TITLE
Better handle serde_as on enum variants #499

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `time` added support for the well-known `Iso8601` format.
     This extends the existing support of `Rfc2822` and `Rfc3339`.
 
+### Changed
+
+* Warn if `serde_as` is used on an enum variant.
+    Attributes on enum variants were never supported.
+    But `#[serde(with = "...")]` can be added on variants, such that some confusion can occur when migration ([#499](https://github.com/jonasbb/serde_with/issues/499)).
+
 ## [2.0.0] - 2022-07-17
 
 ### Added

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -121,7 +121,6 @@
 //! The `serde_as` attribute allows circumventing this restriction, even for nested types and nested arrays.
 //!
 //! ```rust
-//! # #[cfg(FALSE)] {
 //! # #[cfg(feature = "macros")]
 //! # use serde::{Deserialize, Serialize};
 //! # #[cfg(feature = "macros")]
@@ -149,7 +148,6 @@
 //!     optional: Some([222; 128])
 //! };
 //! assert!(serde_json::to_string(&arrays).is_ok());
-//! # }
 //! # }
 //! ```
 //!
@@ -196,7 +194,7 @@
 //! ## Advanced `serde_as` usage
 //!
 //! This example is mainly supposed to highlight the flexibility of the `serde_as`-annotation compared to [serde's with-annotation][with-annotation].
-//! More details about `serde_as` can be found in the [user guide][].
+//! More details about `serde_as` can be found in the [user guide].
 //!
 //! ```rust
 //! # #[cfg(all(feature = "macros", feature = "hex"))]
@@ -210,22 +208,40 @@
 //! #[serde_as]
 //! # #[derive(Debug, Eq, PartialEq)]
 //! #[derive(Deserialize, Serialize)]
-//! struct Foo {
-//!      // Serialize them into a list of number as seconds
-//!      #[serde_as(as = "Vec<DurationSeconds>")]
-//!      durations: Vec<Duration>,
-//!      // We can treat a Vec like a map with duplicates.
-//!      // JSON only allows string keys, so convert i32 to strings
-//!      // The bytes will be hex encoded
-//!      #[serde_as(as = "BTreeMap<DisplayFromStr, Hex>")]
-//!      bytes: Vec<(i32, Vec<u8>)>,
+//! enum Foo {
+//!     Durations(
+//!         // Serialize them into a list of number as seconds
+//!         #[serde_as(as = "Vec<DurationSeconds>")]
+//!         Vec<Duration>,
+//!     ),
+//!     Bytes {
+//!         // We can treat a Vec like a map with duplicates.
+//!         // JSON only allows string keys, so convert i32 to strings
+//!         // The bytes will be hex encoded
+//!         #[serde_as(as = "BTreeMap<DisplayFromStr, Hex>")]
+//!         bytes: Vec<(i32, Vec<u8>)>,
+//!     }
 //! }
 //!
 //! # #[cfg(all(feature = "macros", feature = "json", feature = "hex"))] {
 //! // This will serialize
 //! # let foo =
-//! Foo {
-//!     durations: vec![Duration::new(5, 0), Duration::new(3600, 0), Duration::new(0, 0)],
+//! Foo::Durations(
+//!     vec![Duration::new(5, 0), Duration::new(3600, 0), Duration::new(0, 0)]
+//! )
+//! # ;
+//! // into this JSON
+//! # let json = r#"
+//! {
+//!     "Durations": [5, 3600, 0]
+//! }
+//! # "#;
+//! # assert_eq!(json.replace(" ", "").replace("\n", ""), serde_json::to_string(&foo).unwrap());
+//! # assert_eq!(foo, serde_json::from_str(&json).unwrap());
+//!
+//! // and serializes
+//! # let foo =
+//! Foo::Bytes {
 //!     bytes: vec![
 //!         (1, vec![0, 1, 2]),
 //!         (-100, vec![100, 200, 255]),
@@ -233,15 +249,15 @@
 //!     ],
 //! }
 //! # ;
-//!
 //! // into this JSON
 //! # let json = r#"
 //! {
-//!     "durations": [5, 3600, 0],
-//!     "bytes": {
-//!         "1": "000102",
-//!         "-100": "64c8ff",
-//!         "1": "006fde"
+//!     "Bytes": {
+//!         "bytes": {
+//!             "1": "000102",
+//!             "-100": "64c8ff",
+//!             "1": "006fde"
+//!         }
 //!     }
 //! }
 //! # "#;

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Warn if `serde_as` is used on an enum variant.
+    Attributes on enum variants were never supported.
+    But `#[serde(with = "...")]` can be added on variants, such that some confusion can occur when migration ([#499](https://github.com/jonasbb/serde_with/issues/499)).
+
 ## [2.0.0] - 2022-07-17
 
 No changes compared to v2.0.0-rc.0.

--- a/serde_with_macros/tests/compile-fail/serde_as-enum-variant-499.rs
+++ b/serde_with_macros/tests/compile-fail/serde_as-enum-variant-499.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use serde_with_macros::serde_as;
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "messageType", content = "content")]
+/// The contents of a message combined with the `MessageType`
+pub enum MessageContentJsonStringEnum {
+    /// A normal message
+    Text(String),
+    /// Fancy object message
+    #[serde_as(as = "serde_with::json::JsonString")]
+    Object(String),
+}
+
+fn main() {}

--- a/serde_with_macros/tests/compile-fail/serde_as-enum-variant-499.stderr
+++ b/serde_with_macros/tests/compile-fail/serde_as-enum-variant-499.stderr
@@ -1,0 +1,5 @@
+error: serde_as attribute is not allowed on enum variants
+  --> tests/compile-fail/serde_as-enum-variant-499.rs:12:5
+   |
+12 |     #[serde_as(as = "serde_with::json::JsonString")]
+   |     ^


### PR DESCRIPTION
Change the serde_as macro to warn on serde_as attributes on enum variant
fields. They are unsupported (in contrast to serde_derive), so showing
an error is better and avoids confusion when migrating.
Also update the main examples to include an enum.

Closes #499