### PR TITLE
Update audit handling and ignore advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,14 @@
 [advisories]
-#ignore = [
-#]
+ignore = [
+    # ansi_term is Unmaintained
+    # Inactionable, since this is a transitive dependency of pretty_assertions
+    # Only used in test code.
+    "RUSTSEC-2021-0139",
+    # xml-rs is Unmaintained
+    # Inactionable, since this is a transitive dependency of serde-xml-rs
+    # Only used in test code.
+    "RUSTSEC-2022-0048",
+]
 # warn for categories of informational advisories
 informational_warnings = [
     "unmaintained",

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -23,6 +23,4 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rust-lang/audit@v1


### PR DESCRIPTION
Use a maintained action for auditing Rust dependencies.

Ignore advisories:
* RUSTSEC-2021-0139: ansi_term is Unmaintained

    Inactionable, since this is a transitive dependency of pretty_assertions
    Only used in test code.

* RUSTSEC-2022-0048: xml-rs is Unmaintained
    Inactionable, since this is a transitive dependency of serde-xml-rs
    Only used in test code.

Closes #504
Closes #508