### PR TITLE
Recommend `cargo add` in the install instructions instead of a toml snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,8 @@ For bugs, please open a [new issue](https://github.com/jonasbb/serde_with/issues
 
 ## Use `serde_with` in your Project
 
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies.serde_with]
-version = "2.0.0"
-features = [ "..." ]
+```bash
+cargo add serde_with
 ```
 
 The crate contains different features for integration with other common crates.

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -67,12 +67,9 @@
 //!
 //! # Use `serde_with` in your Project
 //!
-//! Add this to your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies.serde_with]
-//! version = "2.0.0"
-//! features = [ "..." ]
+//! ```bash
+//! # Add the current version to your Cargo.toml
+//! cargo add serde_with
 //! ```
 //!
 //! The crate contains different features for integration with other common crates.

--- a/serde_with/tests/version_numbers.rs
+++ b/serde_with/tests/version_numbers.rs
@@ -2,19 +2,7 @@
 // The non_fmt_panic lint is not yet available on most Rust versions
 #![allow(unknown_lints, non_fmt_panics)]
 
-use version_sync::{
-    assert_contains_regex, assert_html_root_url_updated, assert_markdown_deps_updated,
-};
-
-#[test]
-fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_readme_deps_in_lib() {
-    assert_contains_regex!("src/lib.rs", r#"^//! version = "{version}""#);
-}
+use version_sync::{assert_contains_regex, assert_html_root_url_updated};
 
 #[test]
 fn test_changelog() {


### PR DESCRIPTION
bors r+