### PR TITLE
Avoid absolut import in macros and always import through the `serde_with` crate

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -126,6 +126,16 @@ name = "derives"
 path = "tests/derives/lib.rs"
 required-features = ["macros"]
 
+[[test]]
+name = "with_prefix"
+path = "tests/with_prefix.rs"
+required-features = ["macros"]
+
+[[test]]
+name = "rust"
+path = "tests/rust.rs"
+required-features = ["alloc"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = [

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -993,7 +993,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
 impl<'de, SEPARATOR, I, T> DeserializeAs<'de, I> for StringWithSeparator<SEPARATOR, T>
 where
     SEPARATOR: Separator,
-    I: core::iter::FromIterator<T>,
+    I: FromIterator<T>,
     T: FromStr,
     T::Err: Display,
 {
@@ -1006,7 +1006,7 @@ where
         impl<'de, SEPARATOR, I, T> Visitor<'de> for Helper<SEPARATOR, I, T>
         where
             SEPARATOR: Separator,
-            I: core::iter::FromIterator<T>,
+            I: FromIterator<T>,
             T: FromStr,
             T::Err: Display,
         {

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,42 +1,6 @@
-use super::*;
-#[cfg(feature = "alloc")]
-use crate::formats::Format;
-#[cfg(feature = "std")]
-use crate::utils::duration::DurationSigned;
-use crate::{
-    formats::{Flexible, Separator, Strict},
-    utils, StringWithSeparator,
-};
-#[cfg(feature = "alloc")]
-use alloc::{
-    borrow::{Cow, ToOwned},
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
-    rc::{Rc, Weak as RcWeak},
-    string::String,
-    sync::{Arc, Weak as ArcWeak},
-    vec::Vec,
-};
-#[cfg(any(feature = "std", feature = "indexmap_1"))]
-use core::hash::{BuildHasher, Hash};
-#[cfg(feature = "std")]
-use core::time::Duration;
-use core::{
-    cell::{Cell, RefCell},
-    convert::TryInto,
-    fmt::{self, Display},
-    iter::FromIterator,
-    str::FromStr,
-};
+use crate::{formats::*, prelude::*};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
-use serde::de::*;
-#[cfg(feature = "std")]
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Mutex, RwLock},
-    time::SystemTime,
-};
 
 ///////////////////////////////////////////////////////////////////////////////
 // region: Simple Wrapper types (e.g., Box, Option)
@@ -79,7 +43,7 @@ where
             #[inline]
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(None)
             }
@@ -87,7 +51,7 @@ where
             #[inline]
             fn visit_none<E>(self) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(None)
             }
@@ -507,7 +471,7 @@ macro_rules! tuple_impl {
                         $(
                             let $t: DeserializeAsWrap<$t, $tas> = match seq.next_element()? {
                                 Some(value) => value,
-                                None => return Err(Error::invalid_length($n, &self)),
+                                None => return Err(DeError::invalid_length($n, &self)),
                             };
                         )+
 
@@ -829,9 +793,9 @@ where
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
-                value.parse::<Self::Value>().map_err(Error::custom)
+                value.parse::<Self::Value>().map_err(DeError::custom)
             }
         }
 
@@ -927,18 +891,18 @@ where
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match value {
                     "" => Ok(None),
-                    v => S::from_str(v).map(Some).map_err(Error::custom),
+                    v => S::from_str(v).map(Some).map_err(DeError::custom),
                 }
             }
 
             // handles the `null` case
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(None)
             }
@@ -1029,7 +993,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
 impl<'de, SEPARATOR, I, T> DeserializeAs<'de, I> for StringWithSeparator<SEPARATOR, T>
 where
     SEPARATOR: Separator,
-    I: FromIterator<T>,
+    I: core::iter::FromIterator<T>,
     T: FromStr,
     T::Err: Display,
 {
@@ -1042,7 +1006,7 @@ where
         impl<'de, SEPARATOR, I, T> Visitor<'de> for Helper<SEPARATOR, I, T>
         where
             SEPARATOR: Separator,
-            I: FromIterator<T>,
+            I: core::iter::FromIterator<T>,
             T: FromStr,
             T::Err: Display,
         {
@@ -1054,7 +1018,7 @@ where
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 if value.is_empty() {
                     Ok(None.into_iter().collect())
@@ -1063,7 +1027,7 @@ where
                         .split(SEPARATOR::separator())
                         .map(FromStr::from_str)
                         .collect::<Result<_, _>>()
-                        .map_err(Error::custom)
+                        .map_err(DeError::custom)
                 }
             }
         }
@@ -1217,28 +1181,28 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Bytes {
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v.to_vec())
             }
 
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v.as_bytes().to_vec())
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v.into_bytes())
             }
@@ -1287,42 +1251,42 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
 
             fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Borrowed(v))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Borrowed(v.as_bytes()))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v.to_vec()))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v.as_bytes().to_vec()))
             }
 
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v.into_bytes()))
             }
@@ -1364,19 +1328,19 @@ impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Bytes {
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 v.try_into()
-                    .map_err(|_| Error::invalid_length(v.len(), &self))
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 v.as_bytes()
                     .try_into()
-                    .map_err(|_| Error::invalid_length(v.len(), &self))
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
         }
 
@@ -1400,19 +1364,19 @@ impl<'de, const N: usize> DeserializeAs<'de, &'de [u8; N]> for Bytes {
 
             fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 v.try_into()
-                    .map_err(|_| Error::invalid_length(v.len(), &self))
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 v.as_bytes()
                     .try_into()
-                    .map_err(|_| Error::invalid_length(v.len(), &self))
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
         }
 
@@ -1437,68 +1401,68 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
 
             fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Borrowed(
                     v.try_into()
-                        .map_err(|_| Error::invalid_length(v.len(), &self))?,
+                        .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Borrowed(
                     v.as_bytes()
                         .try_into()
-                        .map_err(|_| Error::invalid_length(v.len(), &self))?,
+                        .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(
                     v.to_vec()
                         .try_into()
-                        .map_err(|_| Error::invalid_length(v.len(), &self))?,
+                        .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(
                     v.as_bytes()
                         .to_vec()
                         .try_into()
-                        .map_err(|_| Error::invalid_length(v.len(), &self))?,
+                        .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
 
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 let len = v.len();
                 Ok(Cow::Owned(
                     v.try_into()
-                        .map_err(|_| Error::invalid_length(len, &self))?,
+                        .map_err(|_| DeError::invalid_length(len, &self))?,
                 ))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 let len = v.len();
                 Ok(Cow::Owned(
                     v.into_bytes()
                         .try_into()
-                        .map_err(|_| Error::invalid_length(len, &self))?,
+                        .map_err(|_| DeError::invalid_length(len, &self))?,
                 ))
             }
 
@@ -1733,7 +1697,7 @@ where
     {
         U::deserialize(deserializer)?
             .try_into()
-            .map_err(Error::custom)
+            .map_err(DeError::custom)
     }
 }
 
@@ -1754,21 +1718,21 @@ impl<'de> DeserializeAs<'de, Cow<'de, str>> for BorrowCow {
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Borrowed(v))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v.to_owned()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(Cow::Owned(v))
             }
@@ -1813,12 +1777,12 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(
+                    unexp => Err(DeError::invalid_value(
                         Unexpected::Unsigned(unexp as u64),
                         &"0 or 1",
                     )),
@@ -1827,12 +1791,12 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(
+                    unexp => Err(DeError::invalid_value(
                         Unexpected::Signed(unexp as i64),
                         &"0 or 1",
                     )),
@@ -1841,34 +1805,37 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(Unexpected::Unsigned(unexp), &"0 or 1")),
+                    unexp => Err(DeError::invalid_value(
+                        Unexpected::Unsigned(unexp),
+                        &"0 or 1",
+                    )),
                 }
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(Unexpected::Signed(unexp), &"0 or 1")),
+                    unexp => Err(DeError::invalid_value(Unexpected::Signed(unexp), &"0 or 1")),
                 }
             }
 
             fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(
+                    unexp => Err(DeError::invalid_value(
                         Unexpected::Unsigned(unexp as u64),
                         &"0 or 1",
                     )),
@@ -1877,12 +1844,12 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
 
             fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 match v {
                     0 => Ok(false),
                     1 => Ok(true),
-                    unexp => Err(Error::invalid_value(
+                    unexp => Err(DeError::invalid_value(
                         Unexpected::Unsigned(unexp as u64),
                         &"0 or 1",
                     )),
@@ -1909,42 +1876,42 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Flexible> {
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }
 
             fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }
 
             fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: DeError,
             {
                 Ok(v != 0)
             }

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -9,7 +9,7 @@
 
 mod impls;
 
-use super::*;
+use crate::prelude::*;
 
 /// A **data structure** that can be deserialized from any data format supported by Serde, analogue to [`Deserialize`].
 ///
@@ -137,5 +137,20 @@ where
             value,
             marker: PhantomData,
         })
+    }
+}
+
+impl<T: ?Sized> As<T> {
+    /// Deserialize type `T` using [`DeserializeAs`][]
+    ///
+    /// The function signature is compatible with [serde's with-annotation][with-annotation].
+    ///
+    /// [with-annotation]: https://serde.rs/field-attrs.html#with
+    pub fn deserialize<'de, D, I>(deserializer: D) -> Result<I, D::Error>
+    where
+        T: DeserializeAs<'de, I>,
+        D: Deserializer<'de>,
+    {
+        T::deserialize_as(deserializer)
     }
 }

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,10 +1,6 @@
-use alloc::collections::{BTreeMap, BTreeSet};
-#[cfg(any(feature = "std", feature = "indexmap_1"))]
-use core::hash::{BuildHasher, Hash};
+use crate::prelude::*;
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
-#[cfg(feature = "std")]
-use std::collections::{HashMap, HashSet};
 
 pub trait PreventDuplicateInsertsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,10 +1,6 @@
-use alloc::collections::BTreeMap;
-#[cfg(any(feature = "std", feature = "indexmap_1"))]
-use core::hash::{BuildHasher, Hash};
+use crate::prelude::*;
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::IndexMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 pub trait DuplicateInsertsFirstWinsMap<K, V> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,10 +1,6 @@
-use alloc::collections::BTreeSet;
-#[cfg(any(feature = "std", feature = "indexmap_1"))]
-use core::hash::{BuildHasher, Hash};
+use crate::prelude::*;
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::IndexSet;
-#[cfg(feature = "std")]
-use std::collections::HashSet;
 
 pub trait DuplicateInsertsLastWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -1,14 +1,6 @@
 use crate::{
     content::ser::{Content, ContentSerializer},
-    DeserializeAs, SerializeAs,
-};
-use alloc::{string::ToString, vec::Vec};
-use core::{fmt, marker::PhantomData};
-use serde::{
-    de::{DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor},
-    ser,
-    ser::{Impossible, SerializeMap, SerializeSeq, SerializeStructVariant, SerializeTupleVariant},
-    Deserialize, Deserializer, Serialize, Serializer,
+    prelude::*,
 };
 
 /// Represent a list of enum values as a map.
@@ -228,86 +220,86 @@ where
     type SerializeStructVariant = Impossible<S::Ok, S::Error>;
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit_variant(
@@ -316,7 +308,7 @@ where
         _variant_index: u32,
         _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
@@ -327,7 +319,7 @@ where
     where
         T: Serialize,
     {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
@@ -340,7 +332,7 @@ where
     where
         T: Serialize,
     {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
@@ -354,7 +346,7 @@ where
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_tuple_struct(
@@ -362,7 +354,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_tuple_variant(
@@ -372,11 +364,11 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_struct(
@@ -384,7 +376,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_struct_variant(
@@ -394,7 +386,7 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 }
 
@@ -452,86 +444,86 @@ where
     type SerializeStructVariant = SerializeVariant<'a, M>;
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_unit_variant(
@@ -552,7 +544,7 @@ where
     where
         T: Serialize,
     {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
@@ -570,11 +562,11 @@ where
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_tuple_struct(
@@ -582,7 +574,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_tuple_variant(
@@ -601,7 +593,7 @@ where
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_struct(
@@ -609,7 +601,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(ser::Error::custom("wrong type for EnumMap"))
+        Err(SerError::custom("wrong type for EnumMap"))
     }
 
     fn serialize_struct_variant(
@@ -808,7 +800,7 @@ where
             Some(key) => Ok((key, self)),
 
             // Unfortunately we loose the optional aspect of MapAccess, so we need to special case an error value to mark the end of the map.
-            None => Err(Error::custom(END_OF_MAP_IDENTIFIER)),
+            None => Err(DeError::custom(END_OF_MAP_IDENTIFIER)),
         }
     }
 }

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -51,16 +51,18 @@
 #[macro_export]
 macro_rules! flattened_maybe {
     ($fn:ident, $field:literal) => {
-        fn $fn<'de, T, D>(deserializer: D) -> ::std::result::Result<T, D::Error>
+        fn $fn<'de, T, D>(deserializer: D) -> $crate::__private__::Result<T, D::Error>
         where
             T: $crate::serde::Deserialize<'de>,
             D: $crate::serde::Deserializer<'de>,
         {
-            use ::std::{
-                option::Option::{self, None, Some},
-                result::Result::{self, Err, Ok},
+            use $crate::{
+                __private__::{
+                    Option::{self, None, Some},
+                    Result::{self, Err, Ok},
+                },
+                serde,
             };
-            use $crate::serde;
 
             #[derive($crate::serde::Deserialize)]
             #[serde(crate = "serde")]

--- a/serde_with/src/formats.rs
+++ b/serde_with/src/formats.rs
@@ -1,5 +1,6 @@
 //! Specify the format and how lenient the deserialization is
 
+#[allow(unused_imports)]
 use crate::prelude::*;
 
 /// Specify how to serialize/deserialize a type

--- a/serde_with/src/formats.rs
+++ b/serde_with/src/formats.rs
@@ -1,7 +1,6 @@
 //! Specify the format and how lenient the deserialization is
 
-#[cfg(feature = "alloc")]
-use alloc::string::String;
+use crate::prelude::*;
 
 /// Specify how to serialize/deserialize a type
 ///

--- a/serde_with/src/json.rs
+++ b/serde_with/src/json.rs
@@ -2,18 +2,7 @@
 //!
 //! This modules is only available when using the `json` feature of the crate.
 
-use crate::{
-    de::{DeserializeAs, DeserializeAsWrap},
-    ser::{SerializeAs, SerializeAsWrap},
-    Same,
-};
-use core::{fmt, marker::PhantomData};
-use serde::{
-    de,
-    de::{Deserializer, Visitor},
-    ser,
-    ser::Serializer,
-};
+use crate::prelude::*;
 
 /// Serialize value as string containing JSON
 ///
@@ -92,7 +81,7 @@ where
     {
         serializer.serialize_str(
             &serde_json::to_string(&SerializeAsWrap::<T, TAs>::new(source))
-                .map_err(ser::Error::custom)?,
+                .map_err(SerError::custom)?,
         )
     }
 }
@@ -119,11 +108,11 @@ where
 
             fn visit_str<E>(self, value: &str) -> Result<S, E>
             where
-                E: de::Error,
+                E: DeError,
             {
                 serde_json::from_str(value)
                     .map(DeserializeAsWrap::<S, SAs>::into_inner)
-                    .map_err(de::Error::custom)
+                    .map_err(DeError::custom)
             }
         }
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -369,14 +369,10 @@ generate_guide! {
 pub(crate) mod prelude {
     #![allow(unused_imports)]
 
-    pub(crate) use crate::{
-        de::*,
-        ser::*,
-        utils::duration::{DurationSigned, Sign},
-        *,
-    };
+    pub(crate) use crate::utils::duration::{DurationSigned, Sign};
+    pub use crate::{de::*, ser::*, *};
     #[cfg(feature = "alloc")]
-    pub(crate) use alloc::{
+    pub use alloc::{
         borrow::{Cow, ToOwned},
         boxed::Box,
         collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
@@ -385,25 +381,34 @@ pub(crate) mod prelude {
         sync::{Arc, Weak as ArcWeak},
         vec::Vec,
     };
-    pub(crate) use core::{
+    pub use core::{
         cell::{Cell, RefCell},
         convert::{TryFrom, TryInto},
         fmt::{self, Display},
         hash::{BuildHasher, Hash},
+        option::Option,
+        result::Result,
         str::FromStr,
         time::Duration,
     };
-    pub(crate) use serde::{
+    pub use serde::{
         de::{Error as DeError, *},
         forward_to_deserialize_any,
         ser::{Error as SerError, *},
     };
     #[cfg(feature = "std")]
-    pub(crate) use std::{
+    pub use std::{
         collections::{HashMap, HashSet},
         sync::{Mutex, RwLock},
         time::SystemTime,
     };
+}
+/// This module is not part of the public API
+///
+/// Do not rely on any exports.
+#[doc(hidden)]
+pub mod __private__ {
+    pub use crate::prelude::*;
 }
 
 #[cfg(feature = "alloc")]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -282,6 +282,8 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[doc(hidden)]
+pub extern crate core;
+#[doc(hidden)]
 pub extern crate serde;
 #[cfg(feature = "std")]
 extern crate std;
@@ -386,6 +388,7 @@ pub(crate) mod prelude {
         convert::{TryFrom, TryInto},
         fmt::{self, Display},
         hash::{BuildHasher, Hash},
+        marker::PhantomData,
         option::Option,
         result::Result,
         str::FromStr,
@@ -403,6 +406,7 @@ pub(crate) mod prelude {
         time::SystemTime,
     };
 }
+
 /// This module is not part of the public API
 ///
 /// Do not rely on any exports.

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -441,6 +441,7 @@ pub use serde_with_macros::*;
 /// If the use of the use of the proc-macro is not acceptable, then `As` can be used directly with serde.
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_with::{As, DisplayFromStr};
 /// #
@@ -450,11 +451,13 @@ pub use serde_with_macros::*;
 /// #[serde(with = "As::<Vec<DisplayFromStr>>")]
 /// field: Vec<u8>,
 /// # }
+/// # }
 /// ```
 /// If the normal `Deserialize`/`Serialize` traits should be used, the placeholder type [`Same`] can be used.
 /// It implements [`DeserializeAs`][]/[`SerializeAs`][], when the underlying type implements `Deserialize`/`Serialize`.
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_with::{As, DisplayFromStr, Same};
 /// # use std::collections::BTreeMap;
@@ -464,6 +467,7 @@ pub use serde_with_macros::*;
 /// // Serialize map, turn keys into strings but keep type of value
 /// #[serde(with = "As::<BTreeMap<DisplayFromStr, Same>>")]
 /// field: BTreeMap<u8, i32>,
+/// # }
 /// # }
 /// ```
 ///
@@ -2038,6 +2042,7 @@ pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>)
 /// # Examples
 ///
 /// ```
+/// # #[cfg(feature = "macros")] {
 /// # use serde::{Deserialize, Serialize};
 /// #
 /// # use serde_with::{serde_as, StringWithSeparator};
@@ -2068,6 +2073,7 @@ pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>)
 ///     r#"{"tags":"1 2 3","more_tags":""}"#,
 ///     serde_json::to_string(&x).unwrap()
 /// );
+/// # }
 /// ```
 ///
 /// [`Display`]: core::fmt::Display

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -1,17 +1,6 @@
 //! De/Serialization for Rust's builtin and std types
 
-#[cfg(doc)]
-use alloc::collections::BTreeMap;
-#[cfg(feature = "alloc")]
-use core::{fmt, marker::PhantomData};
-#[cfg(feature = "alloc")]
-use serde::de::{Error, MapAccess, SeqAccess, Visitor};
-use serde::{
-    de::{Deserialize, DeserializeOwned, Deserializer},
-    ser::{Serialize, Serializer},
-};
-#[cfg(doc)]
-use std::collections::HashMap;
+use crate::prelude::*;
 
 /// Makes a distinction between a missing, unset, or existing value
 ///
@@ -241,7 +230,7 @@ pub mod sets_duplicate_value_is_error {
 
                 while let Some(value) = access.next_element()? {
                     if !values.insert(value) {
-                        return Err(Error::custom("invalid entry: found duplicate value"));
+                        return Err(DeError::custom("invalid entry: found duplicate value"));
                     };
                 }
 
@@ -347,7 +336,7 @@ pub mod maps_duplicate_key_is_error {
 
                 while let Some((key, value)) = access.next_entry()? {
                     if !values.insert(key, value) {
-                        return Err(Error::custom("invalid entry: found duplicate key"));
+                        return Err(DeError::custom("invalid entry: found duplicate key"));
                     };
                 }
 

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1,34 +1,6 @@
-use super::*;
-use crate::{
-    formats::{Separator, Strictness},
-    utils::duration::DurationSigned,
-    StringWithSeparator,
-};
-#[cfg(feature = "alloc")]
-use alloc::{
-    borrow::Cow,
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
-    rc::{Rc, Weak as RcWeak},
-    string::String,
-    sync::{Arc, Weak as ArcWeak},
-    vec::Vec,
-};
-use core::{
-    cell::{Cell, RefCell},
-    convert::TryInto,
-    fmt::Display,
-    time::Duration,
-};
+use crate::{formats, formats::Strictness, prelude::*};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
-use serde::ser::Error;
-#[cfg(feature = "std")]
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Mutex, RwLock},
-    time::SystemTime,
-};
 
 ///////////////////////////////////////////////////////////////////////////////
 // region: Simple Wrapper types (e.g., Box, Option)
@@ -228,7 +200,6 @@ where
     where
         S: Serializer,
     {
-        use serde::ser::SerializeTuple;
         let mut arr = serializer.serialize_tuple(N)?;
         for elem in array {
             arr.serialize_element(&SerializeAsWrap::<T, As>::new(elem))?;
@@ -533,7 +504,7 @@ impl SerializeAs<Vec<u8>> for BytesOrString {
 
 impl<SEPARATOR, I, T> SerializeAs<I> for StringWithSeparator<SEPARATOR, T>
 where
-    SEPARATOR: Separator,
+    SEPARATOR: formats::Separator,
     for<'x> &'x I: IntoIterator<Item = &'x T>,
     T: Display,
     // This set of bounds is enough to make the function compile but has inference issues
@@ -546,7 +517,6 @@ where
     where
         S: Serializer,
     {
-        use core::fmt;
         pub(crate) struct DisplayWithSeparator<'a, I, SEPARATOR>(&'a I, PhantomData<SEPARATOR>);
 
         impl<'a, I, SEPARATOR> DisplayWithSeparator<'a, I, SEPARATOR> {
@@ -557,7 +527,7 @@ where
 
         impl<'a, I, SEPARATOR> Display for DisplayWithSeparator<'a, I, SEPARATOR>
         where
-            SEPARATOR: Separator,
+            SEPARATOR: formats::Separator,
             &'a I: IntoIterator,
             <&'a I as IntoIterator>::Item: Display,
         {

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -9,7 +9,7 @@
 
 mod impls;
 
-use super::*;
+use crate::prelude::*;
 
 /// A **data structure** that can be serialized into any data format supported by Serde, analogue to [`Serialize`].
 ///
@@ -151,5 +151,21 @@ where
 {
     fn from(value: &'a T) -> Self {
         Self::new(value)
+    }
+}
+
+impl<T: ?Sized> As<T> {
+    /// Serialize type `T` using [`SerializeAs`][]
+    ///
+    /// The function signature is compatible with [serde's with-annotation][with-annotation].
+    ///
+    /// [with-annotation]: https://serde.rs/field-attrs.html#with
+    pub fn serialize<S, I>(value: &I, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: SerializeAs<I>,
+        I: ?Sized,
+    {
+        T::serialize_as(value, serializer)
     }
 }

--- a/serde_with/src/serde_conv.rs
+++ b/serde_with/src/serde_conv.rs
@@ -107,41 +107,43 @@ macro_rules! serde_conv {
         #[allow(non_camel_case_types)]
         $vis struct $m;
 
-        #[allow(clippy::ptr_arg)]
-        impl $m {
-            $vis fn serialize<S>(x: &$t, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
-            where
-                S: $crate::serde::Serializer,
-            {
-                let y = $ser(x);
-                $crate::serde::Serialize::serialize(&y, serializer)
+        const _:() = {
+            #[allow(clippy::ptr_arg)]
+            impl $m {
+                $vis fn serialize<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
+                where
+                    S: $crate::serde::Serializer,
+                {
+                    let y = $ser(x);
+                    $crate::serde::Serialize::serialize(&y, serializer)
+                }
+
+                $vis fn deserialize<'de, D>(deserializer: D) -> $crate::__private__::Result<$t, D::Error>
+                where
+                    D: $crate::serde::Deserializer<'de>,
+                {
+                    let y = $crate::serde::Deserialize::deserialize(deserializer)?;
+                    $de(y).map_err($crate::serde::de::Error::custom)
+                }
             }
 
-            $vis fn deserialize<'de, D>(deserializer: D) -> ::std::result::Result<$t, D::Error>
-            where
-                D: $crate::serde::Deserializer<'de>,
-            {
-                let y = $crate::serde::Deserialize::deserialize(deserializer)?;
-                $de(y).map_err($crate::serde::de::Error::custom)
+            impl $crate::SerializeAs<$t> for $m {
+                fn serialize_as<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
+                where
+                    S: $crate::serde::Serializer,
+                {
+                    Self::serialize(x, serializer)
+                }
             }
-        }
 
-        impl $crate::SerializeAs<$t> for $m {
-            fn serialize_as<S>(x: &$t, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
-            where
-                S: $crate::serde::Serializer,
-            {
-                Self::serialize(x, serializer)
+            impl<'de> $crate::DeserializeAs<'de, $t> for $m {
+                fn deserialize_as<D>(deserializer: D) -> $crate::__private__::Result<$t, D::Error>
+                where
+                    D: $crate::serde::Deserializer<'de>,
+                {
+                    Self::deserialize(deserializer)
+                }
             }
-        }
-
-        impl<'de> $crate::DeserializeAs<'de, $t> for $m {
-            fn deserialize_as<D>(deserializer: D) -> ::std::result::Result<$t, D::Error>
-            where
-                D: $crate::serde::Deserializer<'de>,
-            {
-                Self::deserialize(deserializer)
-            }
-        }
+        };
     };
 }

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -5,39 +5,26 @@
 //! [time]: https://docs.rs/time/0.3/
 
 use crate::{
-    de::DeserializeAs,
     formats::{Flexible, Format, Strict, Strictness},
-    ser::SerializeAs,
-    utils::duration::{DurationSigned, Sign},
-    DurationMicroSeconds, DurationMicroSecondsWithFrac, DurationMilliSeconds,
-    DurationMilliSecondsWithFrac, DurationNanoSeconds, DurationNanoSecondsWithFrac,
-    DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds, TimestampMicroSecondsWithFrac,
-    TimestampMilliSeconds, TimestampMilliSecondsWithFrac, TimestampNanoSeconds,
-    TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+    prelude::*,
 };
-#[cfg(feature = "alloc")]
-use alloc::string::String;
 #[cfg(feature = "std")]
-use core::fmt;
-use core::{convert::TryInto, time::Duration as StdDuration};
-use serde::{de, Deserializer, Serializer};
-#[cfg(feature = "std")]
-use serde::{ser::Error as _, Serialize as _};
-#[cfg(feature = "std")]
-use time_0_3::format_description::well_known::{iso8601::EncodedConfig, Iso8601, Rfc2822, Rfc3339};
-use time_0_3::{Duration, OffsetDateTime, PrimitiveDateTime};
+use ::time_0_3::format_description::well_known::{
+    iso8601::EncodedConfig, Iso8601, Rfc2822, Rfc3339,
+};
+use ::time_0_3::{Duration as Time03Duration, OffsetDateTime, PrimitiveDateTime};
 
 /// Create a [`PrimitiveDateTime`] for the Unix Epoch
 fn unix_epoch_primitive() -> PrimitiveDateTime {
     PrimitiveDateTime::new(
-        time_0_3::Date::from_ordinal_date(1970, 1).unwrap(),
-        time_0_3::Time::from_hms_nano(0, 0, 0, 0).unwrap(),
+        ::time_0_3::Date::from_ordinal_date(1970, 1).unwrap(),
+        ::time_0_3::Time::from_hms_nano(0, 0, 0, 0).unwrap(),
     )
 }
 
 /// Convert a [`time::Duration`][time_0_3::Duration] into a [`DurationSigned`]
-fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
-    let std_dur = StdDuration::new(
+fn duration_into_duration_signed(dur: &Time03Duration) -> DurationSigned {
+    let std_dur = Duration::new(
         dur.whole_seconds().unsigned_abs(),
         dur.subsec_nanoseconds().unsigned_abs(),
     );
@@ -54,14 +41,14 @@ fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
 }
 
 /// Convert a [`DurationSigned`] into a [`time_0_3::Duration`]
-fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<Duration, D::Error>
+fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<Time03Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let mut dur: Duration = match sdur.duration.try_into() {
+    let mut dur: Time03Duration = match sdur.duration.try_into() {
         Ok(dur) => dur,
         Err(msg) => {
-            return Err(de::Error::custom(format_args!(
+            return Err(DeError::custom(format_args!(
                 "Duration is outside of the representable range: {}",
                 msg
             )))
@@ -123,7 +110,7 @@ use_duration_signed_ser!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_into_duration_signed =>
+        Time03Duration; duration_into_duration_signed =>
         {i64, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -134,7 +121,7 @@ use_duration_signed_ser!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_into_duration_signed =>
+        Time03Duration; duration_into_duration_signed =>
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -145,7 +132,7 @@ use_duration_signed_ser!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_into_duration_signed =>
+        Time03Duration; duration_into_duration_signed =>
         {f64, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -222,7 +209,7 @@ use_duration_signed_ser!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; duration_into_duration_signed =>
+        Time03Duration; duration_into_duration_signed =>
         {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -233,7 +220,7 @@ use_duration_signed_ser!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; duration_into_duration_signed =>
+        Time03Duration; duration_into_duration_signed =>
         {f64, STRICTNESS => STRICTNESS: Strictness}
     }
 );
@@ -338,7 +325,7 @@ use_duration_signed_de!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {i64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
     }
@@ -350,7 +337,7 @@ use_duration_signed_de!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {String, Strict =>}
     }
 );
@@ -361,7 +348,7 @@ use_duration_signed_de!(
     DurationMicroSeconds DurationMicroSeconds,
     DurationNanoSeconds DurationNanoSeconds,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {f64, Strict =>}
     }
 );
@@ -439,7 +426,7 @@ use_duration_signed_de!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {FORMAT, Flexible => FORMAT: Format}
     }
 );
@@ -450,7 +437,7 @@ use_duration_signed_de!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {String, Strict =>}
     }
 );
@@ -461,7 +448,7 @@ use_duration_signed_de!(
     DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
-        Duration; duration_from_duration_signed =>
+        Time03Duration; duration_from_duration_signed =>
         {f64, Strict =>}
     }
 );
@@ -549,20 +536,20 @@ impl<'de> DeserializeAs<'de, OffsetDateTime> for Rfc2822 {
     where
         D: Deserializer<'de>,
     {
-        struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
+        struct Helper;
+        impl<'de> Visitor<'de> for Helper {
             type Value = OffsetDateTime;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a RFC2822-formatted `OffsetDateTime`")
             }
 
-            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
                 Self::Value::parse(value, &Rfc2822).map_err(E::custom)
             }
         }
 
-        deserializer.deserialize_str(Visitor)
+        deserializer.deserialize_str(Helper)
     }
 }
 
@@ -585,20 +572,20 @@ impl<'de> DeserializeAs<'de, OffsetDateTime> for Rfc3339 {
     where
         D: Deserializer<'de>,
     {
-        struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
+        struct Helper;
+        impl<'de> Visitor<'de> for Helper {
             type Value = OffsetDateTime;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a RFC3339-formatted `OffsetDateTime`")
             }
 
-            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
                 Self::Value::parse(value, &Rfc3339).map_err(E::custom)
             }
         }
 
-        deserializer.deserialize_str(Visitor)
+        deserializer.deserialize_str(Helper)
     }
 }
 
@@ -621,19 +608,19 @@ impl<'de, const CONFIG: EncodedConfig> DeserializeAs<'de, OffsetDateTime> for Is
     where
         D: Deserializer<'de>,
     {
-        struct Visitor<const CONFIG: EncodedConfig>;
-        impl<'de, const CONFIG: EncodedConfig> de::Visitor<'de> for Visitor<CONFIG> {
+        struct Helper<const CONFIG: EncodedConfig>;
+        impl<'de, const CONFIG: EncodedConfig> Visitor<'de> for Helper<CONFIG> {
             type Value = OffsetDateTime;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a ISO8601-formatted `OffsetDateTime`")
             }
 
-            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
                 Self::Value::parse(value, &Iso8601::<CONFIG>).map_err(E::custom)
             }
         }
 
-        deserializer.deserialize_str(Visitor::<CONFIG>)
+        deserializer.deserialize_str(Helper::<CONFIG>)
     }
 }

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -1,10 +1,4 @@
-use alloc::string::String;
-use core::fmt;
-use serde::{
-    de::{self, DeserializeSeed, Deserializer, IgnoredAny, IntoDeserializer, MapAccess, Visitor},
-    forward_to_deserialize_any,
-    ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer},
-};
+use crate::prelude::*;
 
 /// Serialize with an added prefix on every field name and deserialize by
 /// trimming away the prefix.
@@ -176,51 +170,51 @@ where
     type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
@@ -229,7 +223,7 @@ where
     }
 
     fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
@@ -247,11 +241,11 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_unit_variant(
@@ -271,7 +265,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_newtype_variant<T>(
@@ -284,15 +278,15 @@ where
     where
         T: ?Sized + Serialize,
     {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_tuple_struct(
@@ -300,7 +294,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_tuple_variant(
@@ -310,7 +304,7 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
@@ -335,7 +329,7 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(ser::Error::custom("wrong type for with_prefix"))
+        Err(SerError::custom("wrong type for with_prefix"))
     }
 }
 
@@ -533,7 +527,7 @@ where
 
     fn visit_unit<E>(self) -> Result<Self::Value, E>
     where
-        E: de::Error,
+        E: DeError,
     {
         self.delegate.visit_none()
     }

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -109,7 +109,7 @@ macro_rules! with_prefix {
             use $crate::with_prefix::WithPrefix;
 
             #[allow(dead_code)]
-            pub fn serialize<T, S>(object: &T, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            pub fn serialize<T, S>(object: &T, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
             where
                 T: Serialize,
                 S: Serializer,
@@ -121,7 +121,7 @@ macro_rules! with_prefix {
             }
 
             #[allow(dead_code)]
-            pub fn deserialize<'de, T, D>(deserializer: D) -> ::std::result::Result<T, D::Error>
+            pub fn deserialize<'de, T, D>(deserializer: D) -> $crate::__private__::Result<T, D::Error>
             where
                 T: Deserialize<'de>,
                 D: Deserializer<'de>,

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -960,48 +960,48 @@ pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
 fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> TokenStream2 {
     let ident = input.ident;
     let where_clause = &mut input.generics.make_where_clause().predicates;
-    where_clause.push(parse_quote!(Self: ::std::str::FromStr));
+    where_clause.push(parse_quote!(Self: #serde_with_crate_path::__private__::FromStr));
     where_clause.push(parse_quote!(
-        <Self as ::std::str::FromStr>::Err: ::std::fmt::Display
+        <Self as #serde_with_crate_path::__private__::FromStr>::Err: #serde_with_crate_path::__private__::Display
     ));
     let (de_impl_generics, ty_generics, where_clause) = split_with_de_lifetime(&input.generics);
     quote! {
         #[automatically_derived]
         impl #de_impl_generics #serde_with_crate_path::serde::Deserialize<'de> for #ident #ty_generics #where_clause {
-            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> #serde_with_crate_path::__private__::Result<Self, D::Error>
             where
                 D: #serde_with_crate_path::serde::Deserializer<'de>,
             {
-                struct Helper<S>(::std::marker::PhantomData<S>);
+                struct Helper<S>(#serde_with_crate_path::__private__::PhantomData<S>);
 
                 impl<'de, S> #serde_with_crate_path::serde::de::Visitor<'de> for Helper<S>
                 where
-                    S: ::std::str::FromStr,
-                    <S as ::std::str::FromStr>::Err: ::std::fmt::Display,
+                    S: #serde_with_crate_path::__private__::FromStr,
+                    <S as #serde_with_crate_path::__private__::FromStr>::Err: #serde_with_crate_path::__private__::Display,
                 {
                     type Value = S;
 
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        ::std::write!(formatter, "string")
+                    fn expecting(&self, formatter: &mut #serde_with_crate_path::core::fmt::Formatter<'_>) -> #serde_with_crate_path::core::fmt::Result {
+                        #serde_with_crate_path::__private__::Display::fmt("a string", formatter)
                     }
 
-                    fn visit_str<E>(self, value: &str) -> ::std::result::Result<Self::Value, E>
+                    fn visit_str<E>(self, value: &str) -> #serde_with_crate_path::__private__::Result<Self::Value, E>
                     where
                         E: #serde_with_crate_path::serde::de::Error,
                     {
                         value.parse::<Self::Value>().map_err(#serde_with_crate_path::serde::de::Error::custom)
                     }
 
-                    fn visit_bytes<E>(self, value: &[u8]) -> ::std::result::Result<Self::Value, E>
+                    fn visit_bytes<E>(self, value: &[u8]) -> #serde_with_crate_path::__private__::Result<Self::Value, E>
                     where
                         E: #serde_with_crate_path::serde::de::Error,
                     {
-                        let utf8 = ::std::str::from_utf8(value).map_err(#serde_with_crate_path::serde::de::Error::custom)?;
+                        let utf8 = #serde_with_crate_path::core::str::from_utf8(value).map_err(#serde_with_crate_path::serde::de::Error::custom)?;
                         self.visit_str(utf8)
                     }
                 }
 
-                deserializer.deserialize_str(Helper(::std::marker::PhantomData))
+                deserializer.deserialize_str(Helper(#serde_with_crate_path::__private__::PhantomData))
             }
         }
     }
@@ -1075,12 +1075,12 @@ fn serialize_display(mut input: DeriveInput, serde_with_crate_path: Path) -> Tok
         .generics
         .make_where_clause()
         .predicates
-        .push(parse_quote!(Self: ::std::fmt::Display));
+        .push(parse_quote!(Self: #serde_with_crate_path::__private__::Display));
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     quote! {
         #[automatically_derived]
         impl #impl_generics #serde_with_crate_path::serde::Serialize for #ident #ty_generics #where_clause {
-            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> #serde_with_crate_path::__private__::Result<S::Ok, S::Error>
             where
                 S: #serde_with_crate_path::serde::Serializer,
             {


### PR DESCRIPTION
Instead import names through the `serde_with` crate.
This should make the code more portable by avoiding references to std.
The `macro` feature still depends on `std`, but this might be removable
in the future.