### PR TITLE
Update devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,65 +10,77 @@
             "VARIANT": "bullseye"
         }
     },
-    "runArgs": [
-        "--init",
-        "--cap-add=SYS_PTRACE",
-        "--security-opt",
+    // Passes the --init flag when creating the dev container.
+    "init": true,
+    // Passes docker capabilities to include when creating the dev container.
+    "capAdd": ["SYS_PTRACE"],
+    // Passes docker security options to include when creating the dev container.
+    "securityOpt": [
         "seccomp=unconfined",
-        "--security-opt",
         "label=disable"
     ],
-
-    // Set *default* container specific settings.json values on container create.
-    "settings": {
-        "lldb.executable": "/usr/bin/lldb",
-        // VS Code don't watch files under ./target
-        "files.watcherExclude": {
-            "**/target/**": true
-        },
-
-        // List of features to activate. Set this to "all" to pass --all-features to cargo.
-        "rust-analyzer.cargo.features": "all",
-        // Cargo command to use for cargo check.
-        "rust-analyzer.checkOnSave.command": "clippy",
-        // Check all targets and tests (--all-targets).
-        "rust-analyzer.checkOnSave.allTargets": true,
-        // The path structure for newly inserted paths to use.
-        //
-        // self: Insert import paths relative to the current module, using up to one `super` prefix
-        // if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.
-        "rust-analyzer.imports.prefix": "self",
-        // How imports should be grouped into use statements.
-        // module: Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.
-        "rust-analyzer.imports.granularity.group": "crate",
-        // Group inserted imports by the following order. Groups are separated by newlines.
-        "rust-analyzer.imports.group.enable": false,
-    },
-
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-        "cschleiden.vscode-github-actions",
-        "github.codespaces",
-        "github.vscode-pull-request-github",
-        "rust-lang.rust-analyzer",
-        "redhat.vscode-yaml",
-        "tamasfe.even-better-toml",
-        "vadimcn.vscode-lldb",
-    ],
-
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
 
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "pre-commit install --install-hooks",
 
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    // "remoteUser": "vscode",
+    "remoteUser": "root",
+    "containerUser": "root",
 
     // Features to add to the dev container.
+    // https://containers.dev/features
     "features": {
-        "git": "latest",
-        "github-cli": "latest",
-        "fish": "latest",
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "latest"
+        },
+        "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {
+            "version": "latest"
+        }
+    },
+
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.executable": "/usr/bin/lldb",
+                // VS Code don't watch files under ./target
+                "files.watcherExclude": {
+                    "**/target/**": true
+                },
+
+                // List of features to activate. Set this to "all" to pass --all-features to cargo.
+                "rust-analyzer.cargo.features": "all",
+                // Cargo command to use for cargo check.
+                "rust-analyzer.checkOnSave.command": "clippy",
+                // Check all targets and tests (--all-targets).
+                "rust-analyzer.checkOnSave.allTargets": true,
+                // The path structure for newly inserted paths to use.
+                //
+                // self: Insert import paths relative to the current module, using up to one `super` prefix
+                // if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.
+                "rust-analyzer.imports.prefix": "self",
+                // How imports should be grouped into use statements.
+                // module: Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.
+                "rust-analyzer.imports.granularity.group": "crate",
+                // Group inserted imports by the following order. Groups are separated by newlines.
+                "rust-analyzer.imports.group.enable": false,
+                // Prefer to unconditionally use imports of the core and alloc crate, over the std crate.
+                "rust-analyzer.imports.prefer.no.std": true
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "cschleiden.vscode-github-actions",
+                "github.codespaces",
+                "github.vscode-pull-request-github",
+                "rust-lang.rust-analyzer",
+                "redhat.vscode-yaml",
+                "tamasfe.even-better-toml",
+                "vadimcn.vscode-lldb"
+            ]
+        }
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
+    // The path structure for newly inserted paths to use.
+    //
+    // self: Insert import paths relative to the current module, using up to one `super` prefix
+    // if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.
+    "rust-analyzer.imports.prefix": "self",
+    // How imports should be grouped into use statements.
+    // module: Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.
+    "rust-analyzer.imports.granularity.group": "crate",
+    // Group inserted imports by the following order. Groups are separated by newlines.
+    "rust-analyzer.imports.group.enable": false,
+    // Prefer to unconditionally use imports of the core and alloc crate, over the std crate.
+    "rust-analyzer.imports.prefer.no.std": true,
+
     "cSpell.words": [
         "accu",
         "binhex",


### PR DESCRIPTION
Modernize the devcontainer config.
Use proper fields instead of runArgs where possible.
Put the vscode stuff under the new `customizations` field.
Use the repository based feature names.

bors r+