### PR TITLE
Add  parametrised version of "skip_serializing_none"

### DIFF
--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -632,7 +632,7 @@ fn skip_serializing_if_add_attr_to_field(
     field: &mut Field,
     token: &TokenStream,
 ) -> Result<(), String> {
-    let token_string = token.to_string().replace("\"", "");
+    let token_string = token.to_string().replace('"', "");
     let expected_type = match token_string.rsplit_once("::") {
         Some((expected_type, _method)) => expected_type,
         None => {
@@ -640,7 +640,7 @@ fn skip_serializing_if_add_attr_to_field(
         }
     };
 
-    if is_of_expected_type(&field.ty, &expected_type) {
+    if is_of_expected_type(&field.ty, expected_type) {
         let has_skip_serializing_if = field_has_attribute(field, "serde", "skip_serializing_if");
 
         // Remove the `serialize_always` attribute

--- a/serde_with_macros/tests/skip_serializing_if.rs
+++ b/serde_with_macros/tests/skip_serializing_if.rs
@@ -1,0 +1,70 @@
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_with_macros::skip_serializing_if;
+
+mod wrapper {
+    #[derive(serde::Serialize, serde::Deserialize, Eq, PartialEq, Debug)]
+    pub enum Wrapper {
+        Nothing,
+        Something(i32),
+    }
+
+    impl Wrapper {
+        pub fn is_nothing(&self) -> bool {
+            match self {
+                Wrapper::Nothing => true,
+                Wrapper::Something(_) => false,
+            }
+        }
+    }
+
+    impl Default for Wrapper {
+        fn default() -> Self {
+            Self::Nothing
+        }
+    }
+}
+
+#[test]
+fn test_basic() {
+    use serde_with_macros::skip_serializing_if;
+    use wrapper::Wrapper;
+
+    #[skip_serializing_if("Wrapper::is_nothing")]
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Default)]
+    #[serde(default)]
+    struct DataBasic {
+        a: Wrapper,
+        b: Wrapper,
+        c: Wrapper,
+        d: Wrapper,
+    }
+
+    let expected = json!({});
+    let data = DataBasic::default();
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+    assert_eq!(data, serde_json::from_value(res).unwrap());
+}
+
+#[test]
+fn test_qualified() {
+    use serde_with_macros::skip_serializing_if;
+
+    #[skip_serializing_if("wrapper::Wrapper::is_nothing")]
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Default)]
+    #[serde(default)]
+    struct DataBasic {
+        a: wrapper::Wrapper,
+        b: wrapper::Wrapper,
+        c: wrapper::Wrapper,
+        d: wrapper::Wrapper,
+    }
+
+    let expected = json!({});
+    let data = DataBasic::default();
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+    assert_eq!(data, serde_json::from_value(res).unwrap());
+}


### PR DESCRIPTION
I have an use case where I need to use `#[serde(skip_serializing_if = "Foo::bar")]` on almost all fields of the struct. Existing `skip_serializing_none` is not good enough.

This mr adds `skip_serializing_if` which is parametrised version of `skip_serializing_none`. In above use case, it would be used as `#[skip_serializing_if("Foo::bar")`. I am not sure if the name I selected is correct (probably not). I was also considering `skip_serializing_when`, but I am up for a discussion.

Additionally we could change `skip_serializing_none` to use `#[skip_serializing_if("Option::is_none")]` under the hood.