### PR TITLE
Implement `apply` attribute #85

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add new `apply` attribute to simplify repetitive attributes over many fields.
+    Multiple rules and multiple attributes can be provided each.
+
+    ```rust
+    #[serde_with::apply(
+        Option => #[serde(default)] #[serde(skip_serializing_if = "Option::is_none")],
+        Option<bool> => #[serde(rename = "bool")],
+    )]
+    #[derive(serde::Serialize)]
+    struct Data {
+        a: Option<String>,
+        b: Option<u64>,
+        c: Option<String>,
+        d: Option<bool>,
+    }
+    ```
+
+    The `apply` attribute will expand into this, applying the attributs to the matching fields:
+
+    ```rust
+    #[derive(serde::Serialize)]
+    struct Data {
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        a: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        b: Option<u64>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        c: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "bool")]
+        d: Option<bool>,
+    }
+    ```
+
+    The attribute supports field matching using many rules, such as `_` to apply to all fields and partial generics like `Option` to match any `Option` be it `Option<String>`, `Option<bool>`, or `Option<T>`.
+
 ## [2.0.1] - 2022-09-09
 
 ### Added

--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -14,18 +14,18 @@ use ::chrono_0_4::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 
 /// Create a [`DateTime`] for the Unix Epoch using the [`Utc`] timezone
 fn unix_epoch_utc() -> DateTime<Utc> {
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc)
+    DateTime::<Utc>::from_utc(unix_epoch_naive(), Utc)
 }
 
 /// Create a [`DateTime`] for the Unix Epoch using the [`Local`] timezone
 #[cfg(feature = "std")]
 fn unix_epoch_local() -> DateTime<Local> {
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc).with_timezone(&Local)
+    unix_epoch_utc().with_timezone(&Local)
 }
 
 /// Create a [`NaiveDateTime`] for the Unix Epoch
 fn unix_epoch_naive() -> NaiveDateTime {
-    NaiveDateTime::from_timestamp(0, 0)
+    NaiveDateTime::from_timestamp_opt(0, 0).unwrap()
 }
 
 /// Deserialize a Unix timestamp with optional subsecond precision into a `DateTime<Utc>`.

--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -27,7 +27,7 @@ use serde_with::{
 };
 
 fn new_datetime(secs: i64, nsecs: u32) -> DateTime<Utc> {
-    DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nsecs), Utc)
+    DateTime::from_utc(NaiveDateTime::from_timestamp_opt(secs, nsecs).unwrap(), Utc)
 }
 
 #[test]
@@ -360,7 +360,7 @@ fn test_chrono_duration_seconds_with_frac() {
 
 #[test]
 fn test_chrono_timestamp_seconds() {
-    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc);
     let one_second = zero + Duration::seconds(1);
     let half_second = zero + Duration::nanoseconds(500_000_000);
     let minus_one_second = zero - Duration::seconds(1);
@@ -498,7 +498,7 @@ fn test_chrono_timestamp_seconds() {
 
 #[test]
 fn test_chrono_timestamp_seconds_with_frac() {
-    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc);
     let one_second = zero + Duration::seconds(1);
     let half_second = zero + Duration::nanoseconds(500_000_000);
     let minus_one_second = zero - Duration::seconds(1);
@@ -634,7 +634,7 @@ fn test_duration_smoketest() {
 
 #[test]
 fn test_datetime_utc_smoketest() {
-    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc);
     let one_second = zero + Duration::seconds(1);
 
     smoketest! {
@@ -670,8 +670,8 @@ fn test_datetime_utc_smoketest() {
 
 #[test]
 fn test_datetime_local_smoketest() {
-    let zero =
-        DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc).with_timezone(&Local);
+    let zero = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc)
+        .with_timezone(&Local);
     let one_second = zero + Duration::seconds(1);
 
     smoketest! {
@@ -707,7 +707,7 @@ fn test_datetime_local_smoketest() {
 
 #[test]
 fn test_naive_datetime_smoketest() {
-    let zero = NaiveDateTime::from_timestamp(0, 0);
+    let zero = NaiveDateTime::from_timestamp_opt(0, 0).unwrap();
     let one_second = zero + Duration::seconds(1);
 
     smoketest! {

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add new `apply` attribute to simplify repetitive attributes over many fields.
+    Multiple rules and multiple attributes can be provided each.
+
+    ```rust
+    #[serde_with::apply(
+        Option => #[serde(default)] #[serde(skip_serializing_if = "Option::is_none")],
+        Option<bool> => #[serde(rename = "bool")],
+    )]
+    #[derive(serde::Serialize)]
+    struct Data {
+        a: Option<String>,
+        b: Option<u64>,
+        c: Option<String>,
+        d: Option<bool>,
+    }
+    ```
+
+    The `apply` attribute will expand into this, applying the attributs to the matching fields:
+
+    ```rust
+    #[derive(serde::Serialize)]
+    struct Data {
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        a: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        b: Option<u64>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        c: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "bool")]
+        d: Option<bool>,
+    }
+    ```
+
+    The attribute supports field matching using many rules, such as `_` to apply to all fields and partial generics like `Option` to match any `Option` be it `Option<String>`, `Option<bool>`, or `Option<T>`.
+
 ## [2.0.1] - 2022-09-09
 
 ### Changed

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -43,6 +43,7 @@ features = [
 version = "1.0.3"
 
 [dev-dependencies]
+expect-test = "1.4.0"
 pretty_assertions = "1.0.0"
 rustversion = "1.0.0"
 serde = {version = "1.0.75", features = ["derive"]}

--- a/serde_with_macros/src/apply.rs
+++ b/serde_with_macros/src/apply.rs
@@ -1,0 +1,304 @@
+use darling::{Error as DarlingError, FromMeta};
+use proc_macro::TokenStream;
+use quote::ToTokens as _;
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Attribute, Error, Field, NestedMeta, Path, Token, Type, TypeArray, TypeGroup, TypeParen,
+    TypePath, TypePtr, TypeReference, TypeSlice, TypeTuple,
+};
+
+/// Parsed form of a single rule in the `#[apply(...)]` attribute.
+///
+/// This parses tokens in the shape of `Type => Attribute`.
+/// For example, `Option<String> => #[serde(default)]`.
+struct AddAttributesRule {
+    /// A type pattern determining the fields to which the attributes are applied.
+    ty: Type,
+    /// The attributes to apply.
+    ///
+    /// All attributes are appended to the list of existing field attributes.
+    attrs: Vec<Attribute>,
+}
+
+impl Parse for AddAttributesRule {
+    fn parse(input: ParseStream<'_>) -> Result<Self, Error> {
+        let ty: Type = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let attr = Attribute::parse_outer(input)?;
+        Ok(AddAttributesRule { ty, attrs: attr })
+    }
+}
+
+/// Parsed form of the `#[apply(...)]` attribute.
+///
+/// The `apply` attribute takes a comma separated list of rules in the shape of `Type => Attribute`.
+/// Each rule is stored as a [`AddAttributesRule`].
+struct ApplyInput {
+    metas: Vec<NestedMeta>,
+    rules: Punctuated<AddAttributesRule, Token![,]>,
+}
+
+impl Parse for ApplyInput {
+    fn parse(input: ParseStream<'_>) -> Result<Self, Error> {
+        let mut metas: Vec<NestedMeta> = Vec::new();
+
+        while input.peek2(Token![=]) && !input.peek2(Token![=>]) {
+            let value = NestedMeta::parse(input)?;
+            metas.push(value);
+            if !input.peek(Token![,]) {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        let rules: Punctuated<AddAttributesRule, Token![,]> =
+            input.parse_terminated(AddAttributesRule::parse)?;
+        Ok(Self { metas, rules })
+    }
+}
+
+pub fn apply(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(args as ApplyInput);
+
+    #[derive(FromMeta)]
+    struct SerdeContainerOptions {
+        #[darling(rename = "crate")]
+        alt_crate_path: Option<Path>,
+    }
+
+    let container_options = match SerdeContainerOptions::from_list(&args.metas) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(e.write_errors());
+        }
+    };
+    let serde_with_crate_path = container_options
+        .alt_crate_path
+        .unwrap_or_else(|| syn::parse_quote!(::serde_with));
+
+    let res = match super::apply_function_to_struct_and_enum_fields_darling(
+        input,
+        &serde_with_crate_path,
+        &prepare_apply_attribute_to_field(args),
+    ) {
+        Ok(res) => res,
+        Err(err) => err.write_errors(),
+    };
+    TokenStream::from(res)
+}
+
+/// Create a function compatible with [`super::apply_function_to_struct_and_enum_fields`] based on [`Input`].
+///
+/// A single [`Input`] can apply to multiple field types.
+/// To account for this a new function must be created to stay compatible with the function signature or [`super::apply_function_to_struct_and_enum_fields`].
+fn prepare_apply_attribute_to_field(
+    input: ApplyInput,
+) -> impl Fn(&mut Field) -> Result<(), DarlingError> {
+    move |field: &mut Field| {
+        let has_skip_attr = super::field_has_attribute(field, "serde_with", "skip_apply");
+        if has_skip_attr {
+            return Ok(());
+        }
+
+        for matcher in input.rules.iter() {
+            if ty_pattern_matches_ty(&matcher.ty, &field.ty) {
+                field.attrs.extend(matcher.attrs.clone());
+            }
+        }
+        Ok(())
+    }
+}
+
+fn ty_pattern_matches_ty(ty_pattern: &Type, ty: &Type) -> bool {
+    match (ty_pattern, ty) {
+        (
+            Type::Array(TypeArray {
+                elem: ty_pattern,
+                len: len_pattern,
+                ..
+            }),
+            Type::Array(TypeArray { elem: ty, len, .. }),
+        ) => {
+            let ty_match = ty_pattern_matches_ty(ty_pattern, ty);
+            dbg!(len_pattern);
+            let len_match = len_pattern == len || len_pattern.to_token_stream().to_string() == "_";
+            ty_match && len_match
+        }
+        (Type::BareFn(ty_pattern), Type::BareFn(ty)) => ty_pattern == ty,
+        (
+            Type::Group(TypeGroup {
+                elem: ty_pattern, ..
+            }),
+            Type::Group(TypeGroup { elem: ty, .. }),
+        ) => ty_pattern_matches_ty(ty_pattern, ty),
+        (Type::ImplTrait(ty_pattern), Type::ImplTrait(ty)) => ty_pattern == ty,
+        (Type::Infer(_), _) => true,
+        (Type::Macro(ty_pattern), Type::Macro(ty)) => ty_pattern == ty,
+        (Type::Never(_), Type::Never(_)) => true,
+        (
+            Type::Paren(TypeParen {
+                elem: ty_pattern, ..
+            }),
+            Type::Paren(TypeParen { elem: ty, .. }),
+        ) => ty_pattern_matches_ty(ty_pattern, ty),
+        (
+            Type::Path(TypePath {
+                qself: qself_pattern,
+                path: path_pattern,
+            }),
+            Type::Path(TypePath { qself, path }),
+        ) => {
+            /// Compare two paths for relaxed equality.
+            ///
+            /// Two paths match if they are equal except for the path arguments.
+            /// Path arguments are generics on types or functions.
+            /// If the pattern has no argument, it can match with everthing.
+            /// If the pattern does have an argument, the other side must be equal.
+            fn path_pattern_matches_path(path_pattern: &Path, path: &Path) -> bool {
+                if path_pattern.leading_colon != path.leading_colon
+                    || path_pattern.segments.len() != path.segments.len()
+                {
+                    return false;
+                }
+                // Boths parts are equal length
+                std::iter::zip(&path_pattern.segments, &path.segments).all(
+                    |(path_pattern_segment, path_segment)| {
+                        let ident_equal = path_pattern_segment.ident == path_segment.ident;
+                        let args_match =
+                            match (&path_pattern_segment.arguments, &path_segment.arguments) {
+                                (syn::PathArguments::None, _) => true,
+                                (
+                                    syn::PathArguments::AngleBracketed(
+                                        syn::AngleBracketedGenericArguments {
+                                            args: args_pattern,
+                                            ..
+                                        },
+                                    ),
+                                    syn::PathArguments::AngleBracketed(
+                                        syn::AngleBracketedGenericArguments { args, .. },
+                                    ),
+                                ) => {
+                                    args_pattern.len() == args.len()
+                                        && std::iter::zip(args_pattern, args).all(|(a, b)| {
+                                            match (a, b) {
+                                                (
+                                                    syn::GenericArgument::Type(ty_pattern),
+                                                    syn::GenericArgument::Type(ty),
+                                                ) => ty_pattern_matches_ty(ty_pattern, ty),
+                                                (a, b) => a == b,
+                                            }
+                                        })
+                                }
+                                (args_pattern, args) => args_pattern == args,
+                            };
+                        ident_equal && args_match
+                    },
+                )
+            }
+            qself_pattern == qself && path_pattern_matches_path(path_pattern, path)
+        }
+        (
+            Type::Ptr(TypePtr {
+                const_token: const_token_pattern,
+                mutability: mutability_pattern,
+                elem: ty_pattern,
+                ..
+            }),
+            Type::Ptr(TypePtr {
+                const_token,
+                mutability,
+                elem: ty,
+                ..
+            }),
+        ) => {
+            const_token_pattern == const_token
+                && mutability_pattern == mutability
+                && ty_pattern_matches_ty(ty_pattern, ty)
+        }
+        (
+            Type::Reference(TypeReference {
+                lifetime: lifetime_pattern,
+                elem: ty_pattern,
+                ..
+            }),
+            Type::Reference(TypeReference {
+                lifetime, elem: ty, ..
+            }),
+        ) => {
+            (lifetime_pattern.is_none() || lifetime_pattern == lifetime)
+                && ty_pattern_matches_ty(ty_pattern, ty)
+        }
+        (
+            Type::Slice(TypeSlice {
+                elem: ty_pattern, ..
+            }),
+            Type::Slice(TypeSlice { elem: ty, .. }),
+        ) => ty_pattern_matches_ty(ty_pattern, ty),
+        (Type::TraitObject(ty_pattern), Type::TraitObject(ty)) => ty_pattern == ty,
+        (
+            Type::Tuple(TypeTuple {
+                elems: ty_pattern, ..
+            }),
+            Type::Tuple(TypeTuple { elems: ty, .. }),
+        ) => {
+            ty_pattern.len() == ty.len()
+                && std::iter::zip(ty_pattern, ty)
+                    .all(|(ty_pattern, ty)| ty_pattern_matches_ty(ty_pattern, ty))
+        }
+        (Type::Verbatim(_), Type::Verbatim(_)) => false,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[track_caller]
+    fn matches(ty_pattern: &str, ty: &str) -> bool {
+        let ty_pattern = syn::parse_str(ty_pattern).unwrap();
+        let ty = syn::parse_str(ty).unwrap();
+        ty_pattern_matches_ty(&ty_pattern, &ty)
+    }
+
+    #[test]
+    fn test_ty_generic() {
+        assert!(matches("Option<u8>", "Option<u8>"));
+        assert!(matches("Option", "Option<u8>"));
+        assert!(!matches("Option<u8>", "Option<String>"));
+
+        assert!(matches("BTreeMap<u8, u8>", "BTreeMap<u8, u8>"));
+        assert!(matches("BTreeMap", "BTreeMap<u8, u8>"));
+        assert!(!matches("BTreeMap<String, String>", "BTreeMap<u8, u8>"));
+        assert!(matches("BTreeMap<_, _>", "BTreeMap<u8, u8>"));
+        assert!(matches("BTreeMap<_, u8>", "BTreeMap<u8, u8>"));
+        assert!(!matches("BTreeMap<String, _>", "BTreeMap<u8, u8>"));
+    }
+
+    #[test]
+    fn test_array() {
+        assert!(matches("[u8; 1]", "[u8; 1]"));
+        assert!(matches("[_; 1]", "[u8; 1]"));
+        assert!(matches("[u8; _]", "[u8; 1]"));
+
+        assert!(!matches("[u8; 1]", "[u8; 2]"));
+        assert!(!matches("[u8; 1]", "[u8; _]"));
+        assert!(!matches("[u8; 1]", "[String; 1]"));
+    }
+
+    #[test]
+    fn test_reference() {
+        assert!(matches("&str", "&str"));
+        assert!(matches("&mut str", "&str"));
+        assert!(matches("&str", "&mut str"));
+        assert!(matches("&str", "&'a str"));
+        assert!(matches("&str", "&'static str"));
+        assert!(matches("&str", "&'static mut str"));
+
+        assert!(matches("&'a str", "&'a str"));
+        assert!(matches("&'a mut str", "&'a str"));
+
+        assert!(!matches("&'b str", "&'a str"));
+    }
+}

--- a/serde_with_macros/src/apply.rs
+++ b/serde_with_macros/src/apply.rs
@@ -88,9 +88,9 @@ pub fn apply(args: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(res)
 }
 
-/// Create a function compatible with [`super::apply_function_to_struct_and_enum_fields`] based on [`Input`].
+/// Create a function compatible with [`super::apply_function_to_struct_and_enum_fields`] based on [`ApplyInput`].
 ///
-/// A single [`Input`] can apply to multiple field types.
+/// A single [`ApplyInput`] can apply to multiple field types.
 /// To account for this a new function must be created to stay compatible with the function signature or [`super::apply_function_to_struct_and_enum_fields`].
 fn prepare_apply_attribute_to_field(
     input: ApplyInput,
@@ -281,6 +281,7 @@ mod test {
         assert!(matches("[u8; 1]", "[u8; 1]"));
         assert!(matches("[_; 1]", "[u8; 1]"));
         assert!(matches("[u8; _]", "[u8; 1]"));
+        assert!(matches("[u8; _]", "[u8; N]"));
 
         assert!(!matches("[u8; 1]", "[u8; 2]"));
         assert!(!matches("[u8; 1]", "[u8; _]"));

--- a/serde_with_macros/tests/apply.rs
+++ b/serde_with_macros/tests/apply.rs
@@ -1,0 +1,247 @@
+#![allow(dead_code)]
+
+use expect_test::expect;
+use serde_with_macros::apply;
+use std::collections::BTreeMap;
+
+/// Fields `a` and `c` match, as each has a fully specified pattern.
+#[test]
+fn test_apply_fully_specified() {
+    #[apply(
+    crate="serde_with_macros",
+
+    Option<String> => #[serde(skip)],
+    BTreeMap<String, String> => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "b": null,
+          "d": {},
+          "e": {},
+          "f": "",
+          "g": "",
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// All fields match as `_` matches any type.
+///
+/// The `skip` field is ignored because of the `#[serde_with(skip_apply)]` attribute.
+#[test]
+fn test_apply_all() {
+    #[apply(
+    crate="serde_with_macros",
+
+    _ => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// Fields `a` and `b` match, since both are variants of `Option`.
+///
+/// No generic in the pattern allows matching with any number of generics on the fields.
+/// The `skip` field is ignored because of the `#[serde_with(skip_apply)]` attribute.
+#[test]
+fn test_apply_partial_no_generic() {
+    #[apply(
+    crate="serde_with_macros",
+
+    Option => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "c": {},
+          "d": {},
+          "e": {},
+          "f": "",
+          "g": "",
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// Fields `c` and `d` match, as both have a `String` key and `_` matches any type.
+#[test]
+fn test_apply_partial_generic() {
+    #[apply(
+    crate="serde_with_macros",
+
+    BTreeMap<String, _> => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "a": null,
+          "b": null,
+          "e": {},
+          "f": "",
+          "g": "",
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// Fields `f` and `g` match, since no lifetime matches any reference.
+#[test]
+fn test_apply_no_lifetime() {
+    #[apply(
+    crate="serde_with_macros",
+
+    &str => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "a": null,
+          "b": null,
+          "c": {},
+          "d": {},
+          "e": {},
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// Field `f` matches as the lifetime is identical and `mut` is ignored.
+#[test]
+fn test_apply_lifetime() {
+    #[apply(
+    crate="serde_with_macros",
+
+    &'a mut str => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "a": null,
+          "b": null,
+          "c": {},
+          "d": {},
+          "e": {},
+          "g": "",
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}
+
+/// No field matches as the explicit lifetimes are different
+#[test]
+fn test_apply_mismatched_lifetime() {
+    #[apply(
+    crate="serde_with_macros",
+
+    &'b str => #[serde(skip)],
+)]
+    #[derive(Default, serde::Serialize)]
+    struct FooBar<'a> {
+        a: Option<String>,
+        b: Option<i32>,
+        c: BTreeMap<String, String>,
+        d: BTreeMap<String, i32>,
+        e: BTreeMap<i32, String>,
+        f: &'a str,
+        g: &'static str,
+
+        #[serde_with(skip_apply)]
+        skip: Option<String>,
+    }
+
+    expect![[r#"
+        {
+          "a": null,
+          "b": null,
+          "c": {},
+          "d": {},
+          "e": {},
+          "f": "",
+          "g": "",
+          "skip": null
+        }"#]]
+    .assert_eq(&serde_json::to_string_pretty(&FooBar::<'static>::default()).unwrap());
+}


### PR DESCRIPTION
This `apply` proc-macro takes a list of type patterns and a list of attributes for each. On each field where the type matches, the list of attributes will be added to the existing field attributes.

```rust
#[serde_with::apply(
    Option => #[serde(default)] #[serde(skip_serializing_if = "Option::is_none")],
    Option<bool> => #[serde(rename = "bool")],
)]
#[derive(serde::Serialize)]
struct Data {
    a: Option<String>,
    b: Option<u64>,
    c: Option<String>,
    d: Option<bool>,
}
```

The `apply` attribute will expand into this, applying the attributs to the matching fields:

```rust
#[derive(serde::Serialize)]
struct Data {
    #[serde(default)]
    #[serde(skip_serializing_if = "Option::is_none")]
    a: Option<String>,
    #[serde(default)]
    #[serde(skip_serializing_if = "Option::is_none")]
    b: Option<u64>,
    #[serde(default)]
    #[serde(skip_serializing_if = "Option::is_none")]
    c: Option<String>,
    #[serde(default)]
    #[serde(skip_serializing_if = "Option::is_none")]
    #[serde(rename = "bool")]
    d: Option<bool>,
}
```

bors r+