### PR TITLE
Create `Map` and `Seq` types to map to tuple list conversion

### DIFF
--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -715,7 +715,6 @@ tuple_seq_as_map_option_impl!(BTreeMap);
 #[cfg(feature = "std")]
 tuple_seq_as_map_option_impl!(HashMap);
 
-#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_arr {
     ($tyorig:ty, $ty:ident <KAs, VAs>) => {
         #[allow(clippy::implicit_hasher)]
@@ -763,6 +762,7 @@ macro_rules! tuple_seq_as_map_arr {
         }
     }
 }
+tuple_seq_as_map_arr!([(K, V); N], Map<KAs, VAs>);
 #[cfg(feature = "alloc")]
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<KAs, VAs>);
 #[cfg(feature = "std")]

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -315,8 +315,8 @@ VecEnumValues(vec![
 
 ```ignore
 // Rust
-#[serde_as(as = "Vec<(_, _)>")]
-value: HashMap<String, u32>, // also works with BTreeMap
+#[serde_as(as = "Seq<(_, _)>")] // also works with Vec
+value: HashMap<String, u32>, // also works with other maps like BTreeMap or IndexMap
 
 // JSON
 "value": [
@@ -461,7 +461,7 @@ value: BTreeMap<[u8; 2], u32>,
 
 ```ignore
 // Rust
-#[serde_as(as = "HashMap<_, _>")] // also works with BTreeMap
+#[serde_as(as = "Map<_, _>")] // also works with BTreeMap and HashMap
 value: Vec<(String, u32)>,
 
 // JSON

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -2081,3 +2081,6 @@ pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>)
 /// [`Separator`]: crate::formats::Separator
 /// [`serde_as`]: crate::guide::serde_as
 pub struct StringWithSeparator<Sep, T>(PhantomData<(Sep, T)>);
+
+pub struct Map<K, V>(PhantomData<(K, V)>);
+pub struct Seq<V>(PhantomData<V>);

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -2082,5 +2082,106 @@ pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>)
 /// [`serde_as`]: crate::guide::serde_as
 pub struct StringWithSeparator<Sep, T>(PhantomData<(Sep, T)>);
 
+/// This serializes a list of tuples into a map
+///
+/// Normally, you want to use a [`HashMap`] or a [`BTreeMap`] when deserializing a map.
+/// However, sometimes this is not possible due to type constraints, e.g., if the type implements neither [`Hash`] nor [`Ord`].
+/// Another use case is deserializing a map with duplicate keys.
+///
+/// The implementation is generic using the [`FromIterator`] and [`IntoIterator`] traits.
+/// Therefore, all of [`Vec`], [`VecDeque`](std::collections::VecDeque), and [`LinkedList`](std::collections::LinkedList) and anything which implements those are supported.
+///
+/// # Examples
+///
+/// `Wrapper` does not implement [`Hash`] nor [`Ord`], thus prohibiting the use [`HashMap`] or [`BTreeMap`].
+/// The JSON also contains a duplicate key.
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
+/// [`HashMap`]: std::collections::HashMap
+/// [`Vec`]: std::vec::Vec
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, Map};
+/// #
+/// #[serde_as]
+/// #[derive(Debug, Deserialize, Serialize, Default)]
+/// struct S {
+///     #[serde_as(as = "Map<_, _>")]
+///     s: Vec<(Wrapper<i32>, String)>,
+/// }
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// #[serde(transparent)]
+/// struct Wrapper<T>(T);
+///
+/// let data = S {
+///     s: vec![
+///         (Wrapper(1), "a".to_string()),
+///         (Wrapper(2), "b".to_string()),
+///         (Wrapper(3), "c".to_string()),
+///         (Wrapper(2), "d".to_string()),
+///     ],
+/// };
+///
+/// let json = r#"{
+///   "s": {
+///     "1": "a",
+///     "2": "b",
+///     "3": "c",
+///     "2": "d"
+///   }
+/// }"#;
+/// assert_eq!(json, serde_json::to_string_pretty(&data).unwrap());
+/// # }
+/// ```
 pub struct Map<K, V>(PhantomData<(K, V)>);
+
+/// De/Serialize a Map into a list of tuples
+///
+/// Some formats, like JSON, have limitations on the types of keys for maps.
+/// In case of JSON, keys are restricted to strings.
+/// Rust features more powerful keys, for example tuples, which can not be serialized to JSON.
+///
+/// This helper serializes the Map into a list of tuples, which do not have the same type restrictions.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "macros")] {
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, Seq};
+/// # use std::collections::BTreeMap;
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct A {
+///     #[serde_as(as = "Seq<(_, _)>")]
+///     s: BTreeMap<(String, u32), u32>,
+/// }
+///
+/// // This converts the Rust type
+/// let data = A {
+///     s: BTreeMap::from([
+///         (("Hello".to_string(), 123), 0),
+///         (("World".to_string(), 456), 1),
+///     ]),
+/// };
+///
+/// // into this JSON
+/// let value = json!({
+///     "s": [
+///         [["Hello", 123], 0],
+///         [["World", 456], 1]
+///     ]
+/// });
+///
+/// assert_eq!(value, serde_json::to_value(&data).unwrap());
+/// assert_eq!(data, serde_json::from_value(value).unwrap());
+/// # }
+/// ```
 pub struct Seq<V>(PhantomData<V>);

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -402,7 +402,6 @@ tuple_seq_as_map_impl!(HashSet<(K, V)>);
 #[cfg(all(feature = "std", feature = "indexmap_1"))]
 tuple_seq_as_map_impl!(IndexSet<(K, V)>);
 
-#[cfg(feature = "alloc")]
 macro_rules! tuple_seq_as_map_arr {
     ($tyorig:ty, $ty:ident <K, V>) => {
         #[allow(clippy::implicit_hasher)]
@@ -425,6 +424,7 @@ macro_rules! tuple_seq_as_map_arr {
         }
     };
 }
+tuple_seq_as_map_arr!([(K, V); N], Map<K, V>);
 #[cfg(feature = "alloc")]
 tuple_seq_as_map_arr!([(K, V); N], BTreeMap<K, V>);
 #[cfg(feature = "std")]

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -21,7 +21,6 @@ pub(crate) struct MapIter<'de, A, K, V> {
 }
 
 impl<'de, A, K, V> MapIter<'de, A, K, V> {
-    #[cfg(feature = "alloc")]
     pub(crate) fn new(access: A) -> Self
     where
         A: MapAccess<'de>,

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -31,8 +31,8 @@ use expect_test::expect;
 use serde::{Deserialize, Serialize};
 use serde_with::{
     formats::{CommaSeparator, Flexible, Strict},
-    serde_as, BoolFromInt, BytesOrString, DisplayFromStr, NoneAsEmptyString, OneOrMany, Same,
-    StringWithSeparator,
+    serde_as, BoolFromInt, BytesOrString, DisplayFromStr, Map, NoneAsEmptyString, OneOrMany, Same,
+    Seq, StringWithSeparator,
 };
 use std::{
     collections::HashMap,

--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -8,6 +8,30 @@ fn test_map_as_tuple_list() {
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SM(#[serde_as(as = "Seq<(DisplayFromStr, DisplayFromStr)>")] BTreeMap<u32, IpAddr>);
+
+    let map: BTreeMap<_, _> = vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect();
+    is_equal(
+        SM(map),
+        expect![[r#"
+            [
+              [
+                "1",
+                "1.2.3.4"
+              ],
+              [
+                "10",
+                "1.2.3.4"
+              ],
+              [
+                "200",
+                "255.255.255.255"
+              ]
+            ]"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct SB(#[serde_as(as = "Vec<(DisplayFromStr, DisplayFromStr)>")] BTreeMap<u32, IpAddr>);
 
     let map: BTreeMap<_, _> = vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect();
@@ -110,6 +134,20 @@ fn test_tuple_list_as_map() {
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SM(#[serde_as(as = "Map<DisplayFromStr, DisplayFromStr>")] Vec<(u32, IpAddr)>);
+
+    is_equal(
+        SM(vec![(1, ip), (10, ip), (200, ip2)]),
+        expect![[r#"
+            {
+              "1": "1.2.3.4",
+              "10": "1.2.3.4",
+              "200": "255.255.255.255"
+            }"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct SH(#[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")] Vec<(u32, IpAddr)>);
 
     is_equal(
@@ -184,13 +222,24 @@ fn test_tuple_list_as_map() {
 fn test_tuple_array_as_map() {
     #[serde_as]
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct S0(#[serde_as(as = "Map<_, _>")] [(u8, u8); 1]);
+    is_equal(
+        S1([(1, 2)]),
+        expect![[r#"
+          {
+            "1": 2
+          }"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
     struct S1(#[serde_as(as = "BTreeMap<_, _>")] [(u8, u8); 1]);
     is_equal(
         S1([(1, 2)]),
         expect![[r#"
-            {
-              "1": 2
-            }"#]],
+          {
+            "1": 2
+          }"#]],
     );
 
     #[serde_as]

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add new `Map` and `Seq` types for converting between maps and tuple lists. (#527)
+
+    The behavior is not new, but already present using `BTreeMap`/`HashMap` or `Vec`.
+    However, the new types `Map` and `Seq` are also available on `no_std`, even without the `alloc` feature.
+
 ## [2.1.0] - 2022-11-16
 
 ### Added


### PR DESCRIPTION
The behavior is not new, but already present using `BTreeMap`/`HashMap` or `Vec`.
However, the new types `Map` and `Seq` are also available on `no_std`, even without the `alloc` feature.

Closes #527 

bors r+