### PR TITLE
Mention "Bytes" on README.md and lib.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ let arrays: Arrays<100, 128> = Arrays {
     nested: Box::new([[111; 64]; 100]),
     optional: Some([222; 128]),
     bytes: [0x42; 128],
-
 };
 assert!(serde_json::to_string(&arrays).is_ok());
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Foo {bar: 12}
 serde does not support arrays with more than 32 elements or using const-generics.
 The `serde_as` attribute allows circumventing this restriction, even for nested types and nested arrays.
 
+On top of it, `[u8; N]` (aka, bytes) can use the specialized `"Bytes"` for efficiency much like the `serde_bytes` crate.
+
 [![Rustexplorer](https://img.shields.io/badge/Try%20on-rustexplorer-lightgrey?logo=rust&logoColor=orange)](https://www.rustexplorer.com/b/um0xyi)
 ```rust
 #[serde_as]
@@ -80,13 +82,18 @@ struct Arrays<const N: usize, const M: usize> {
 
     #[serde_as(as = "Option<[_; M]>")]
     optional: Option<[u8; M]>,
+
+    #[serde_as(as = "Bytes")]
+    bytes: [u8; M],
 }
 
 // This allows us to serialize a struct like this
 let arrays: Arrays<100, 128> = Arrays {
     constgeneric: [true; 100],
     nested: Box::new([[111; 64]; 100]),
-    optional: Some([222; 128])
+    optional: Some([222; 128]),
+    bytes: [0x42; 128],
+
 };
 assert!(serde_json::to_string(&arrays).is_ok());
 ```

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -129,7 +129,7 @@
 //! # #[cfg(feature = "macros")]
 //! # use serde::{Deserialize, Serialize};
 //! # #[cfg(feature = "macros")]
-//! # use serde_with::serde_as;
+//! # use serde_with::{serde_as, Bytes};
 //! # #[cfg(feature = "macros")]
 //! #[serde_as]
 //! # #[derive(Debug, Eq, PartialEq)]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -122,6 +122,8 @@
 //! serde does not support arrays with more than 32 elements or using const-generics.
 //! The `serde_as` attribute allows circumventing this restriction, even for nested types and nested arrays.
 //!
+//! On top of it, `[u8; N]` (aka, bytes) can use the specialized `"Bytes"` for efficiency much like the `serde_bytes` crate.
+//!
 //! [![Rustexplorer](https://img.shields.io/badge/Try%20on-rustexplorer-lightgrey?logo=rust&logoColor=orange)](https://www.rustexplorer.com/b/um0xyi)
 //! ```rust
 //! # #[cfg(feature = "macros")]
@@ -141,6 +143,9 @@
 //!
 //!     #[serde_as(as = "Option<[_; M]>")]
 //!     optional: Option<[u8; M]>,
+//!
+//!     #[serde_as(as = "Bytes")]
+//!     bytes: [u8; M],
 //! }
 //!
 //! # #[cfg(all(feature = "macros", feature = "json"))] {
@@ -148,7 +153,8 @@
 //! let arrays: Arrays<100, 128> = Arrays {
 //!     constgeneric: [true; 100],
 //!     nested: Box::new([[111; 64]; 100]),
-//!     optional: Some([222; 128])
+//!     optional: Some([222; 128]),
+//!     bytes: [0x42; 128],
 //! };
 //! assert!(serde_json::to_string(&arrays).is_ok());
 //! # }


### PR DESCRIPTION
I think https://github.com/jonasbb/serde_with/pull/277 can be more promoted. :)

As I wrote the current status of serialization of const generics like bytes (https://github.com/solana-labs/solana/pull/29196#discussion_r1052189935), i think `"Bytes"` is best solution so far.

@jonasbb hey, this functionary saved us. however it took a while to spot this. I think `Bytes` can be promoted. :)