### PR TITLE
Use synchronized version numbers for serde_with and serde_with_macros

### DIFF
--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - "v*"
-      - "macros-v*"
 permissions: read-all
 
 jobs:
@@ -48,47 +47,6 @@ jobs:
       - run: cargo login ${CRATES_IO_TOKEN}
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - run: cd serde_with && cargo publish
-
-  publish_serde_with_macros:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/macros-v')
-    permissions:
-      # Needed to publish releases
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Install/Update the Rust version"
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          cargo --version
-          rustc --version
-      - name: Get version from tag
-        id: tag_name
-        run: |
-          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/macros-v}
-        shell: bash
-      - name: Get Changelog Entry
-        id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          version: ${{ steps.tag_name.outputs.current_version }}
-          path: ./serde_with_macros/CHANGELOG.md
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # This pulls from the "Get Changelog Entry" step above, referencing it's ID to get its outputs object.
-          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          tag_name: "macros-v${{ steps.changelog_reader.outputs.version }}"
-          name: "serde_with_macros v${{ steps.changelog_reader.outputs.version }}"
-          body: ${{ steps.changelog_reader.outputs.changes }}
-          prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
-          draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
-      - run: cargo login ${CRATES_IO_TOKEN}
-        env:
-          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - run: cd serde_with_macros && cargo publish
+      # The programs wait until the package is in the index.
+      - run: cargo publish --package serde_with_macros
+      - run: cargo publish --package serde_with

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Pin the `serde_with_macros` dependency to the same version as the main crate.
+    This simplifies publishing and ensures that always a compatible version is picked.
+
 ## [2.1.0] - 2022-11-16
 
 ### Added

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -67,7 +67,7 @@ hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.45", optional = true, default-features = false}
-serde_with_macros = {path = "../serde_with_macros", version = "2.1.0", optional = true}
+serde_with_macros = {path = "../serde_with_macros", version = "=2.1.0", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}
 
 [dev-dependencies]

--- a/serde_with/tests/version_numbers.rs
+++ b/serde_with/tests/version_numbers.rs
@@ -14,6 +14,18 @@ fn test_html_root_url() {
     assert_html_root_url_updated!("src/lib.rs");
 }
 
+#[test]
+fn test_serde_with_macros_dependency() {
+    version_sync::assert_contains_regex!(
+        "../serde_with/Cargo.toml",
+        r#"^serde_with_macros = .*? version = "=?{version}""#
+    );
+    version_sync::assert_contains_regex!(
+        "../serde_with_macros/Cargo.toml",
+        r#"^version = "{version}""#
+    );
+}
+
 /// Check that all docs.rs links point to the current version
 ///
 /// Parse all docs.rs links in `*.rs` and `*.md` files and check that they point to the current version.


### PR DESCRIPTION
This pins serde_with_macros to a single version. This simplifies updates and publishing. It also ensures that the macros dependency always gets updated when the main crate does.