### PR TITLE
Fix type pattern matching in apply macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,14 @@ Foo::Bytes {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/2.1.0/serde_with/struct.DisplayFromStr.html
-[`with_prefix!`]: https://docs.rs/serde_with/2.1.0/serde_with/macro.with_prefix.html
-[feature flags]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/2.1.0/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/2.1.0/serde_with/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/2.1.0/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/2.2.0/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/2.2.0/serde_with/macro.with_prefix.html
+[feature flags]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/2.2.0/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/2.2.0/serde_with/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/2.2.0/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
-[as-annotation]: https://docs.rs/serde_with/2.1.0/serde_with/guide/serde_as/index.html
+[as-annotation]: https://docs.rs/serde_with/2.2.0/serde_with/guide/serde_as/index.html
 
 ## License
 

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,10 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add new `Map` and `Seq` types for converting between maps and tuple lists. (#527)
+
+    The behavior is not new, but already present using `BTreeMap`/`HashMap` or `Vec`.
+    However, the new types `Map` and `Seq` are also available on `no_std`, even without the `alloc` feature.
+
 ### Changed
 
 * Pin the `serde_with_macros` dependency to the same version as the main crate.
     This simplifies publishing and ensures that always a compatible version is picked.
+
+### Fixed
+
+* `serde_with::apply` had an issue matching types when invisible token groups where in use (#538)
+    The token groups can stem from macro_rules expansion, but should be treated mostly transparent.
+    The old code required a group to match a group, while now groups are silently removed when checking for type patterns.
 
 ## [2.1.0] - 2022-11-16
 

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-01-09
+
 ### Added
 
 * Add new `Map` and `Seq` types for converting between maps and tuple lists. (#527)

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 name = "serde_with"
 rust-version = "1.60"
-version = "2.1.0"
+version = "2.2.0"
 
 categories = ["encoding", "no-std"]
 description = "Custom de/serialization functions for Rust's serde"
@@ -67,7 +67,7 @@ hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.45", optional = true, default-features = false}
-serde_with_macros = {path = "../serde_with_macros", version = "=2.1.0", optional = true}
+serde_with_macros = {path = "../serde_with_macros", version = "=2.2.0", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}
 
 [dev-dependencies]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -26,7 +26,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/2.1.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with/2.2.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     // clippy is broken and shows wrong warnings
@@ -276,14 +276,14 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/2.1.0/serde_with/struct.DisplayFromStr.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/2.1.0/serde_with/macro.with_prefix.html
-//! [feature flags]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/2.1.0/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/2.1.0/serde_with/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/2.1.0/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/2.2.0/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/2.2.0/serde_with/macro.with_prefix.html
+//! [feature flags]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/2.2.0/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/2.2.0/serde_with/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/2.2.0/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
-//! [as-annotation]: https://docs.rs/serde_with/2.1.0/serde_with/guide/serde_as/index.html
+//! [as-annotation]: https://docs.rs/serde_with/2.2.0/serde_with/guide/serde_as/index.html
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -477,7 +477,7 @@ pub use serde_with_macros::*;
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/2.1.0/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/2.2.0/serde_with/attr.serde_as.html
 pub struct As<T: ?Sized>(PhantomData<T>);
 
 /// Adapter to convert from `serde_as` to the serde traits.
@@ -905,7 +905,7 @@ pub struct BytesOrString;
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1033,7 +1033,7 @@ pub struct DurationSeconds<
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1229,7 +1229,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// [`SystemTime`]: std::time::SystemTime
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
-/// [feature flag]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1367,7 +1367,7 @@ pub struct TimestampSeconds<
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
 /// [NaiveDateTime]: ::chrono_0_4::NaiveDateTime
-/// [feature flag]: https://docs.rs/serde_with/2.1.0/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/2.2.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,

--- a/serde_with/tests/version_numbers.rs
+++ b/serde_with/tests/version_numbers.rs
@@ -18,7 +18,7 @@ fn test_html_root_url() {
 fn test_serde_with_macros_dependency() {
     version_sync::assert_contains_regex!(
         "../serde_with/Cargo.toml",
-        r#"^serde_with_macros = .*? version = "=?{version}""#
+        r#"^serde_with_macros = .*? version = "={version}""#
     );
     version_sync::assert_contains_regex!(
         "../serde_with_macros/Cargo.toml",

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-01-09
+
 ### Fixed
 
 * `serde_with::apply` had an issue matching types when invisible token groups where in use (#538)

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-* Add new `Map` and `Seq` types for converting between maps and tuple lists. (#527)
-
-    The behavior is not new, but already present using `BTreeMap`/`HashMap` or `Vec`.
-    However, the new types `Map` and `Seq` are also available on `no_std`, even without the `alloc` feature.
+* `serde_with::apply` had an issue matching types when invisible token groups where in use (#538)
+    The token groups can stem from macro_rules expansion, but should be treated mostly transparent.
+    The old code required a group to match a group, while now groups are silently removed when checking for type patterns.
 
 ## [2.1.0] - 2022-11-16
 

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jonas Bushart"]
 name = "serde_with_macros"
 rust-version = "1.60"
-version = "2.1.0"
+version = "2.2.0"
 
 categories = ["encoding"]
 description = "proc-macro library for serde_with"

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -26,7 +26,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/2.1.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/2.2.0")]
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Necessary for nightly clippy lints
@@ -579,8 +579,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// }
 /// ```
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/2.1.0/serde_with/guide/index.html
-/// [re-exporting `serde_as`]: https://docs.rs/serde_with/2.1.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [`serde_as`]: https://docs.rs/serde_with/2.2.0/serde_with/guide/index.html
+/// [re-exporting `serde_as`]: https://docs.rs/serde_with/2.2.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(FromMeta)]
@@ -970,7 +970,7 @@ fn has_type_embedded(type_: &Type, embedded_type: &syn::Ident) -> bool {
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/2.1.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/2.2.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(DeserializeFromStr, attributes(serde_with))]
 pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
@@ -1090,7 +1090,7 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/2.1.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/2.2.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(SerializeDisplay, attributes(serde_with))]
 pub fn derive_serialize_display(item: TokenStream) -> TokenStream {

--- a/serde_with_macros/tests/serde_as_issue_538.rs
+++ b/serde_with_macros/tests/serde_as_issue_538.rs
@@ -1,0 +1,30 @@
+//! Check for the correct processing of ExprGroups in types
+//!
+//! They occur when the types is passed in as a macro_rules argument like here.
+//! https://github.com/jonasbb/serde_with/issues/538
+
+macro_rules! t {
+    ($($param:ident : $ty:ty),*) => {
+        #[derive(Default)]
+        #[serde_with_macros::apply(
+            crate = "serde_with_macros",
+            Option => #[serde(skip_serializing_if = "Option::is_none")],
+        )]
+        #[derive(serde::Serialize)]
+        struct Data {
+            a: Option<String>,
+            b: Option<u64>,
+            c: Option<String>,
+            $(pub $param: $ty),*
+        }
+    }
+}
+
+t!(d: Option<bool>);
+
+#[test]
+fn t() {
+    let expected = r#"{}"#;
+    let data: Data = Default::default();
+    assert_eq!(expected, serde_json::to_string(&data).unwrap());
+}

--- a/serde_with_macros/tests/version_numbers.rs
+++ b/serde_with_macros/tests/version_numbers.rs
@@ -16,6 +16,6 @@ fn test_changelog() {
 fn test_serde_with_dependency() {
     version_sync::assert_contains_regex!(
         "../serde_with/Cargo.toml",
-        r#"^serde_with_macros = .*? version = "=?{version}""#
+        r#"^serde_with_macros = .*? version = "={version}""#
     );
 }


### PR DESCRIPTION
The macro had a problem with invisible token groups, which can stem from macro_rules expansion. The token groups should be treated mostly transparent. This is now achieved by always looking through the groups first before continuing with any other type pattern matching.

Fixes #538

Prepare new release.

bors r+