### PR TITLE
Provide cargo-release configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,11 @@ members = [
     "serde_with_test",
 ]
 resolver = "2"
+
+[workspace.metadata.release]
+consolidate-commits = true
+publish = false
+push = false
+shared-version = true
+sign-tag = true
+tag = false

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -145,3 +145,13 @@ rustdoc-args = [
     # https://github.com/rust-lang/rust/pull/84176
     "-Zunstable-options", "--generate-link-to-definition"
 ]
+
+[package.metadata.release]
+pre-release-replacements = [
+    {file = "CHANGELOG.md", search = "\\[Unreleased\\]", replace = "[Unreleased]\n\n## [{{version}}] - {{date}}"},
+    {file = "src/lib.rs", search = "https://docs\\.rs/serde_with/[\\d.]+/", replace = "https://docs.rs/serde_with/{{version}}/"},
+    {file = "README.md", search = "https://docs\\.rs/serde_with/[\\d.]+/", replace = "https://docs.rs/serde_with/{{version}}/"},
+]
+tag = true
+tag-message = "{{crate_name}} v{{version}}"
+tag-name = "v{{version}}"

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -26,7 +26,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/2.2.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with/2.2.0/")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     // clippy is broken and shows wrong warnings

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -53,3 +53,11 @@ version-sync = "0.9.1"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[package.metadata.release]
+pre-release-replacements = [
+    {file = "CHANGELOG.md", search = "\\[Unreleased\\]", replace = "[Unreleased]\n\n## [{{version}}] - {{date}}"},
+    {file = "src/lib.rs", search = "https://docs\\.rs/serde_with/[\\d.]+/", replace = "https://docs.rs/serde_with/{{version}}/"},
+    {file = "src/lib.rs", search = "https://docs\\.rs/serde_with_macros/[\\d.]+/", replace = "https://docs.rs/serde_with_macros/{{version}}/"},
+]
+tag = false

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -26,7 +26,7 @@
 #![doc(test(attr(warn(rust_2018_idioms))))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/2.2.0")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/2.2.0/")]
 // Necessary to silence the warning about clippy::unknown_clippy_lints on nightly
 #![allow(renamed_and_removed_lints)]
 // Necessary for nightly clippy lints

--- a/serde_with_test/Cargo.toml
+++ b/serde_with_test/Cargo.toml
@@ -11,3 +11,6 @@ rust-version = "1.60"
 s = {package = "serde", version = "1.0.75", features = ["derive"]}
 s_json = {package = "serde_json", version = "1.0.59"}
 s_with = {package = "serde_with", path = "../serde_with"}
+
+[package.metadata.release]
+release = false


### PR DESCRIPTION
This will simplify updating version numbers, updating links, and creating tags.

bors r+