### PR TITLE
Document why `double_option` cannot be used in `serde_as`

### DIFF
--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -18,8 +18,12 @@ use crate::prelude::*;
 /// This cannot work, since there is no way to tell the `Vec` to skip the inner `DoubleOption` if it is `None`.
 ///
 /// ```rust
+/// # #[cfg(FALSE)] {
+/// # struct Foobar {
 /// #[serde_as(as = "Vec<DoubleOption<_>>")]
 /// data: Vec<Option<Option<i32>>>,
+/// # }
+/// # }
 /// ```
 ///
 /// # Examples

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -13,6 +13,15 @@ use crate::prelude::*;
 /// * `Some(None)`: Represents a `null` value.
 /// * `Some(Some(value))`: Represents an existing value.
 ///
+/// Note: This cannot be made compatible to `serde_as`, since skipping of values is only available on the field level.
+/// A hypothetical `DoubleOption<T>` with a `SerializeAs` implementation would allow writing something like this.
+/// This cannot work, since there is no way to tell the `Vec` to skip the inner `DoubleOption` if it is `None`.
+///
+/// ```rust
+/// #[serde_as(as = "Vec<DoubleOption<_>>")]
+/// data: Vec<Option<Option<i32>>>,
+/// ```
+///
 /// # Examples
 ///
 /// ```rust

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,5 +1,3 @@
-// This test fails for older compiler versions since the error messages are different.
-#[rustversion::attr(before(1.54), ignore)]
 #[cfg_attr(tarpaulin, ignore)]
 // The error messages are different on beta and nightly, thus breaking the test.
 #[rustversion::attr(beta, ignore)]


### PR DESCRIPTION
And remove an outdated version check.

bors r+