### PR TITLE
Generalize how to implement traits for many collection types.

### DIFF
--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -15,7 +15,7 @@ macro_rules! foreach_map {
         $m!(BTreeMap<K, V>);
         #[cfg(feature = "std")]
         $m!(HashMap<K, V, H: Sized>);
-        #[cfg(all(feature = "std", feature = "indexmap_1"))]
+        #[cfg(all(feature = "indexmap_1"))]
         $m!(IndexMap<K, V, H: Sized>);
     };
 }
@@ -27,7 +27,7 @@ macro_rules! foreach_set {
         $m!(BTreeSet<$T>);
         #[cfg(feature = "std")]
         $m!(HashSet<$T, H: Sized>);
-        #[cfg(all(feature = "std", feature = "indexmap_1"))]
+        #[cfg(all(feature = "indexmap_1"))]
         $m!(IndexSet<$T, H: Sized>);
     };
     ($m:ident) => {


### PR DESCRIPTION
Add new macros like `foreach_map` which expand once for each supported
map type, e.g., `BTreeMap`, `HashMap`, `IndexMap`.
They take another macro as input and pass the map as the first argument.

It is used like `foreach_map!(map_impl);` and
`foreach_map!(map_as_tuple_seq);`.

This also helps for future implementations.