### PR TITLE
Support targets without `alloc::sync`/atomic pointers.

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * `EnumMap` passes the `human_readable` status of the `Serializer` to more places.
+* Support `alloc` on targets without `target_has_atomic = "ptr"`. (#560)
+    Thanks to @vembacher for reporting and fixing the issue.
 
 ## [2.2.0] - 2023-01-09
 

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -98,7 +98,7 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
 impl<'de, T, U> DeserializeAs<'de, Arc<T>> for Arc<U>
 where
     U: DeserializeAs<'de, T>,
@@ -113,7 +113,7 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
 impl<'de, T, U> DeserializeAs<'de, ArcWeak<T>> for ArcWeak<U>
 where
     U: DeserializeAs<'de, T>,

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -379,6 +379,8 @@ pub(crate) mod prelude {
 
     pub(crate) use crate::utils::duration::{DurationSigned, Sign};
     pub use crate::{de::*, ser::*, *};
+    #[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+    pub use alloc::sync::{Arc, Weak as ArcWeak};
     #[cfg(feature = "alloc")]
     pub use alloc::{
         borrow::{Cow, ToOwned},
@@ -386,7 +388,6 @@ pub(crate) mod prelude {
         collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
         rc::{Rc, Weak as RcWeak},
         string::{String, ToString},
-        sync::{Arc, Weak as ArcWeak},
         vec::Vec,
     };
     pub use core::{

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -145,7 +145,7 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
 impl<T, U> SerializeAs<Arc<T>> for Arc<U>
 where
     U: SerializeAs<T>,
@@ -158,7 +158,7 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
 impl<T, U> SerializeAs<ArcWeak<T>> for ArcWeak<U>
 where
     U: SerializeAs<T>,


### PR DESCRIPTION
## Motivation

This is a fix for the issue described in: #559

## Changes

- I added a check to require `target_has_atomic = "ptr"` for imports and implemenations related to `Arc` and `Weak/WeakArc`.
- That should be sufficient to support such targets without requiring new feature flags.

Closes #559