### PR TITLE
Generalize the trait bounds of `Seq`

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     },
     ```
 
+### Changed
+
+* Relax the trait bounds of `Seq` to allow for more custom types. (#565)
+    This extends the support beyond tuples.
+
 ### Fixed
 
 * `EnumMap` passes the `human_readable` status of the `Serializer` to more places.

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -348,23 +348,21 @@ tuple_impl!(16 0 T0 As0 1 T1 As1 2 T2 As2 3 T3 As3 4 T4 As4 5 T5 As5 6 T6 As6 7 
 
 #[cfg(feature = "alloc")]
 macro_rules! map_as_tuple_seq_intern {
-    ($tyorig:ident < K, V $(, $typaram:ident : $bound:ident)* >, $ty:ident <(K, V)>) => {
-        impl<K, KAs, V, VAs $(, $typaram)*> SerializeAs<$tyorig<K, V $(, $typaram)*>> for $ty<(KAs, VAs)>
+    ($tyorig:ident < K, V $(, $typaram:ident : $bound:ident)* >, $ty:ident <TAs>) => {
+        impl<K, V, TAs $(, $typaram)*> SerializeAs<$tyorig<K, V $(, $typaram)*>> for $ty<TAs>
         where
-            KAs: SerializeAs<K>,
-            VAs: SerializeAs<V>,
+            for<'a> TAs: SerializeAs<(&'a K, &'a V)>,
             $($typaram: ?Sized + $bound,)*
         {
             fn serialize_as<S>(source: &$tyorig<K, V $(, $typaram)*>, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: Serializer,
             {
-                serializer.collect_seq(source.iter().map(|(k, v)| {
-                    (
-                        SerializeAsWrap::<K, KAs>::new(k),
-                        SerializeAsWrap::<V, VAs>::new(v),
-                    )
-                }))
+                let mut seq = serializer.serialize_seq(None)?;
+                for (k, v) in source {
+                    seq.serialize_element(&SerializeAsWrap::<(&K, &V), TAs>::new(&(k, v)))?;
+                }
+                seq.end()
             }
         }
     };
@@ -372,9 +370,9 @@ macro_rules! map_as_tuple_seq_intern {
 #[cfg(feature = "alloc")]
 macro_rules! map_as_tuple_seq {
     ($tyorig:ident < K, V $(, $typaram:ident : $bound:ident)* >) => {
-        map_as_tuple_seq_intern!($tyorig<K, V $(, $typaram: $bound)* >, Seq<(K, V)>);
+        map_as_tuple_seq_intern!($tyorig<K, V $(, $typaram: $bound)* >, Seq<TAs>);
         #[cfg(feature = "alloc")]
-        map_as_tuple_seq_intern!($tyorig<K, V $(, $typaram: $bound)* >, Vec<(K, V)>);
+        map_as_tuple_seq_intern!($tyorig<K, V $(, $typaram: $bound)* >, Vec<TAs>);
     }
 }
 foreach_map!(map_as_tuple_seq);

--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -319,3 +319,74 @@ fn test_tuple_array_as_map() {
             }"#]],
     );
 }
+
+#[test]
+fn test_map_as_custom_struct() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
+
+    use serde_with::{de::DeserializeAsWrap, ser::SerializeAsWrap, DeserializeAs, SerializeAs};
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Custom<K, V> {
+        custom_key: K,
+        v: V,
+    }
+
+    impl<K, KAs, V, VAs> SerializeAs<(K, V)> for Custom<KAs, VAs>
+    where
+        KAs: SerializeAs<K>,
+        VAs: SerializeAs<V>,
+    {
+        fn serialize_as<S>((k, v): &(K, V), serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            (Custom {
+                custom_key: SerializeAsWrap::<K, KAs>::new(k),
+                v: SerializeAsWrap::<V, VAs>::new(v),
+            })
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de, K, KAs, V, VAs> DeserializeAs<'de, (K, V)> for Custom<KAs, VAs>
+    where
+        KAs: DeserializeAs<'de, K>,
+        VAs: DeserializeAs<'de, V>,
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<(K, V), D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let c = <Custom<DeserializeAsWrap<K, KAs>, DeserializeAsWrap<V, VAs>>>::deserialize(
+                deserializer,
+            )?;
+            Ok((c.custom_key.into_inner(), c.v.into_inner()))
+        }
+    }
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SM(#[serde_as(as = "Seq<Custom<_, _>>")] BTreeMap<u32, IpAddr>);
+
+    let map: BTreeMap<_, _> = vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect();
+    is_equal(
+        SM(map),
+        expect![[r#"
+            [
+              {
+                "custom_key": 1,
+                "v": "1.2.3.4"
+              },
+              {
+                "custom_key": 10,
+                "v": "1.2.3.4"
+              },
+              {
+                "custom_key": 200,
+                "v": "255.255.255.255"
+              }
+            ]"#]],
+    );
+}


### PR DESCRIPTION
Generalize the trait bounds of `Seq` to allow for more flexible. Instead of forcing the inner type to be a tuple, take anything convertible to/from a tuple. This can be expressed using the

Closes #565