### PR TITLE
Make all uses of the `serde_as` macros require an extra import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
             entry: cargo +nightly fmt --all -- --check --color always
             language: system
             pass_filenames: false
+          - id: use-serde-as-with-import
+            name: Use serde_as with import
+            description: 'Prevent attributes of the form #[serde_with::serde_as]'
+            language: pygrep
+            entry: '#\[serde_with::serde_as\]'
+            types: ["rust"]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ enum Foo {
         // We can treat a Vec like a map with duplicates.
         // JSON only allows string keys, so convert i32 to strings
         // The bytes will be hex encoded
-        #[serde_as(as = "BTreeMap<DisplayFromStr, Hex>")]
+        #[serde_as(as = "Map<DisplayFromStr, Hex>")]
         bytes: Vec<(i32, Vec<u8>)>,
     }
 }

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -75,7 +75,7 @@ use crate::prelude::*;
 /// # #[cfg(all(feature = "macros"))] {
 /// # use serde::Deserialize;
 /// # use serde::de::Error;
-/// # use serde_with::DeserializeAs;
+/// # use serde_with::{serde_as, DeserializeAs};
 /// # use std::str::FromStr;
 /// # use std::fmt::Display;
 /// struct DisplayFromStr;
@@ -94,7 +94,7 @@ use crate::prelude::*;
 ///     }
 /// }
 /// #
-/// # #[serde_with::serde_as]
+/// # #[serde_as]
 /// # #[derive(serde::Deserialize)]
 /// # struct S (#[serde_as(as = "DisplayFromStr")] bool);
 /// #

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -19,7 +19,7 @@ use crate::{
 /// ```rust
 /// # #[cfg(feature = "macros")] {
 /// # use serde::{Deserialize, Serialize};
-/// use serde_with::EnumMap;
+/// use serde_with::{serde_as, EnumMap};
 ///
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
@@ -35,7 +35,7 @@ use crate::{
 ///     },
 /// }
 ///
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
 /// struct VecEnumValues (
@@ -97,7 +97,7 @@ use crate::{
 /// ```
 /// # #[cfg(feature = "macros")] {
 /// # use serde::{Deserialize, Serialize};
-/// use serde_with::EnumMap;
+/// use serde_with::{serde_as, EnumMap};
 ///
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
@@ -107,7 +107,7 @@ use crate::{
 ///     Unit,
 /// }
 ///
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
 /// struct VecEnumValues {

--- a/serde_with/src/guide.md
+++ b/serde_with/src/guide.md
@@ -21,8 +21,7 @@ The `serde_as` scheme is based on two new traits: [`SerializeAs`] and [`Deserial
 
 ```rust
 # use serde::{Deserialize, Serialize};
-# use serde_with::{serde_as, DisplayFromStr};
-# use std::collections::HashMap;
+# use serde_with::{serde_as, DisplayFromStr, Map};
 # use std::net::Ipv4Addr;
 #
 #[serde_as]
@@ -34,7 +33,7 @@ struct Data {
     address: Ipv4Addr,
     // Treat the Vec like a map with duplicates
     // Convert u32 into a String and keep the String the same type
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+    #[serde_as(as = "Map<DisplayFromStr, _>")]
     vec_as_map: Vec<(u32, String)>,
 }
 

--- a/serde_with/src/key_value_map.rs
+++ b/serde_with/src/key_value_map.rs
@@ -25,7 +25,7 @@ use crate::{
 /// ```rust
 /// # #[cfg(feature = "macros")] {
 /// # use serde::{Deserialize, Serialize};
-/// use serde_with::KeyValueMap;
+/// use serde_with::{serde_as, KeyValueMap};
 ///
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
@@ -37,7 +37,7 @@ use crate::{
 ///     i: i32,
 /// }
 ///
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
 /// struct KVMap(
@@ -96,7 +96,7 @@ use crate::{
 /// ```rust
 /// # #[cfg(feature = "macros")] {
 /// # use serde::{Deserialize, Serialize};
-/// use serde_with::KeyValueMap;
+/// use serde_with::{serde_as, KeyValueMap};
 /// use std::net::IpAddr;
 /// # use std::str::FromStr;
 ///
@@ -108,7 +108,7 @@ use crate::{
 ///     bool,
 /// );
 ///
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Clone, PartialEq, Eq)]
 /// #[derive(Serialize, Deserialize)]
 /// struct KVMap(

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -2215,9 +2215,9 @@ pub struct Seq<V>(PhantomData<V>);
 /// # #[cfg(feature = "macros")] {
 /// # use serde::Deserialize;
 /// # use std::collections::HashMap;
-/// # use serde_with::MapPreventDuplicates;
+/// # use serde_with::{serde_as, MapPreventDuplicates};
 /// #
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Eq, PartialEq)]
 /// #[derive(Deserialize)]
 /// struct Doc {
@@ -2275,9 +2275,9 @@ pub struct MapFirstKeyWins<K, V>(PhantomData<(K, V)>);
 /// # #[cfg(feature = "macros")] {
 /// # use std::collections::HashSet;
 /// # use serde::Deserialize;
-/// # use serde_with::SetPreventDuplicates;
+/// # use serde_with::{serde_as, SetPreventDuplicates};
 /// #
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// # #[derive(Debug, Eq, PartialEq)]
 /// #[derive(Deserialize)]
 /// struct Doc {

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -210,9 +210,8 @@
 //! # #[cfg(all(feature = "macros", feature = "hex"))]
 //! # use {
 //! #     serde::{Deserialize, Serialize},
-//! #     serde_with::{serde_as, DisplayFromStr, DurationSeconds, hex::Hex},
+//! #     serde_with::{serde_as, DisplayFromStr, DurationSeconds, hex::Hex, Map},
 //! #     std::time::Duration,
-//! #     std::collections::BTreeMap,
 //! # };
 //! # #[cfg(all(feature = "macros", feature = "hex"))]
 //! #[serde_as]
@@ -228,7 +227,7 @@
 //!         // We can treat a Vec like a map with duplicates.
 //!         // JSON only allows string keys, so convert i32 to strings
 //!         // The bytes will be hex encoded
-//!         #[serde_as(as = "BTreeMap<DisplayFromStr, Hex>")]
+//!         #[serde_as(as = "Map<DisplayFromStr, Hex>")]
 //!         bytes: Vec<(i32, Vec<u8>)>,
 //!     }
 //! }

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -74,7 +74,7 @@ use crate::prelude::*;
 ///
 /// ```rust
 /// # #[cfg(all(feature = "macros"))] {
-/// # use serde_with::SerializeAs;
+/// # use serde_with::{serde_as, SerializeAs};
 /// # use std::fmt::Display;
 /// struct DisplayFromStr;
 ///
@@ -90,7 +90,7 @@ use crate::prelude::*;
 ///     }
 /// }
 /// #
-/// # #[serde_with::serde_as]
+/// # #[serde_as]
 /// # #[derive(serde::Serialize)]
 /// # struct S (#[serde_as(as = "DisplayFromStr")] bool);
 /// #

--- a/serde_with/src/serde_conv.rs
+++ b/serde_with/src/serde_conv.rs
@@ -22,6 +22,7 @@
 /// ```rust
 /// # #[cfg(feature = "macros")] {
 /// # use serde::{Serialize, Deserialize};
+/// # use serde_with::serde_as;
 ///
 /// #[derive(Clone, Copy, Debug, PartialEq)]
 /// struct Rgb {
@@ -55,7 +56,7 @@
 ///
 /// // We can now use the `RgbAsArray` adapter with `serde_as`.
 ///
-/// #[serde_with::serde_as]
+/// #[serde_as]
 /// #[derive(Debug, PartialEq, Serialize, Deserialize)]
 /// struct Colors {
 ///     #[serde_as(as = "RgbAsArray")]

--- a/serde_with/tests/serde_as/key_value_map.rs
+++ b/serde_with/tests/serde_as/key_value_map.rs
@@ -1,10 +1,10 @@
 use super::*;
 use core::str::FromStr;
 use serde_test::Configure;
-use serde_with::KeyValueMap;
+use serde_with::{serde_as, KeyValueMap};
 use std::net::IpAddr;
 
-#[serde_with::serde_as]
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 struct KVMap<E> {

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -461,8 +461,7 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// # Example
 ///
 /// ```rust,ignore
-/// use serde_with::{serde_as, DisplayFromStr};
-/// use std::collections::HashMap;
+/// use serde_with::{serde_as, DisplayFromStr, Map};
 ///
 /// #[serde_as]
 /// #[derive(Serialize, Deserialize)]
@@ -476,7 +475,7 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 ///     b: u32,
 ///
 ///     /// Serialize into a map from String to String
-///     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+///     #[serde_as(as = "Map<DisplayFromStr, _>")]
 ///     c: Vec<(u32, String)>,
 /// }
 /// ```


### PR DESCRIPTION
bors r+