### PR TITLE
Provide length when serializing sequence

### DIFF
--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -352,3 +352,336 @@ fn test_map_as_tuple_with_nested_complex_type() {
             ]"#]],
     );
 }
+
+#[test]
+fn test_map_as_tuple_list_works_with_serializer_that_needs_length_to_serialize_sequence() {
+    use serde::{
+        ser::{
+            SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+            SerializeTupleStruct, SerializeTupleVariant,
+        },
+        Serializer,
+    };
+    use std::fmt::{self, Debug, Display};
+
+    #[derive(Debug)]
+    enum TestError {
+        LengthRequired,
+        Other,
+    }
+
+    impl Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Debug::fmt(self, f)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    impl serde::ser::Error for TestError {
+        fn custom<T>(_: T) -> Self
+        where
+            T: Display,
+        {
+            TestError::Other
+        }
+    }
+
+    struct TestSerializer;
+
+    impl<'a> Serializer for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+        type SerializeSeq = Self;
+        type SerializeTuple = Self;
+        type SerializeTupleStruct = Self;
+        type SerializeTupleVariant = Self;
+        type SerializeMap = Self;
+        type SerializeStruct = Self;
+        type SerializeStructVariant = Self;
+
+        fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_str(self, _: &str) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_some<T>(self, v: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            v.serialize(self)
+        }
+
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_unit_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+
+        fn serialize_newtype_struct<T>(
+            self,
+            _: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(self)
+        }
+
+        fn serialize_newtype_variant<T>(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(self)
+        }
+
+        fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            len.map(|_| self).ok_or(TestError::LengthRequired)
+        }
+
+        fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            Ok(self)
+        }
+
+        fn serialize_tuple_struct(
+            self,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            Ok(self)
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Ok(self)
+        }
+
+        fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            Ok(self)
+        }
+
+        fn serialize_struct(
+            self,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            Ok(self)
+        }
+
+        fn serialize_struct_variant(
+            self,
+            _: &'static str,
+            _: u32,
+            _: &'static str,
+            _: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            Ok(self)
+        }
+    }
+
+    impl<'a> SerializeMap for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            key.serialize(&mut **self)
+        }
+
+        fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeSeq for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeStruct for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_field<T>(&mut self, _: &'static str, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeStructVariant for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_field<T>(&mut self, _: &'static str, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeTuple for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeTupleStruct for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl<'a> SerializeTupleVariant for &'a mut TestSerializer {
+        type Ok = ();
+        type Error = TestError;
+
+        fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: Serialize + ?Sized,
+        {
+            value.serialize(&mut **self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[serde_as]
+    #[derive(Debug, Default, Serialize)]
+    struct Data {
+        #[serde_as(as = "Seq<(_, _)>")]
+        xs: HashMap<i32, i32>,
+    }
+
+    Data::default().serialize(&mut TestSerializer).unwrap();
+}


### PR DESCRIPTION
Some serializers (e.g. bincode) require a length to serialize a sequence. This code does what `iterator_len_hint` does (called by `collect_seq` in `serde`).

Resolves #570