### PR TITLE
Explain better how to use serde_as

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Check the [feature flags][] section for information about all available features
 Annotate your struct or enum to enable the custom de/serializer.
 The `#[serde_as]` attribute must be placed *before* the `#[derive]`.
 
+The `as` is analogous to the `with` attribute of serde.
+You mirror the type structure of the field you want to de/serialize.
+You can specify converters for the inner types of a field, e.g., `Vec<DisplayFromStr>`.
+The default de/serialization behavior can be restored by using `_` as a placeholder, e.g., `BTreeMap<_, DisplayFromStr>`.
+
 ### `DisplayFromStr`
 
 [![Rustexplorer](https://img.shields.io/badge/Try%20on-rustexplorer-lightgrey?logo=rust&logoColor=orange)](https://www.rustexplorer.com/b/py7ida)
@@ -130,6 +135,8 @@ This example is mainly supposed to highlight the flexibility of the `serde_as`-a
 More details about `serde_as` can be found in the [user guide].
 
 ```rust
+use std::time::Duration;
+
 #[serde_as]
 #[derive(Deserialize, Serialize)]
 enum Foo {

--- a/serde_with/src/guide.md
+++ b/serde_with/src/guide.md
@@ -14,6 +14,10 @@ This is an alternative to [serde's with-annotation][with-annotation], which adds
 The main downside is that it work with fewer types than [with-annotations][with-annotation].
 However, all types from the Rust Standard Library should be supported in all combinations and any missing entry is a bug.
 
+You mirror the type structure of the field you want to de/serialize.
+You can specify converters for the inner types of a field, e.g., `Vec<DisplayFromStr>`.
+The default de/serialization behavior can be restored by using `_` as a placeholder, e.g., `BTreeMap<_, DisplayFromStr>`.
+
 The `serde_as` scheme is based on two new traits: [`SerializeAs`] and [`DeserializeAs`].  
 [Check out the detailed page about `serde_as` and the available features.](crate::guide::serde_as)
 

--- a/serde_with/src/guide/serde_as.md
+++ b/serde_with/src/guide/serde_as.md
@@ -34,6 +34,9 @@ you now have to write
 
 and place the `#[serde_as]` attribute *before* the `#[derive]` attribute.
 You still need the `#[derive(Serialize, Deserialize)]` on the struct/enum.
+You mirror the type structure of the field you want to de/serialize.
+You can specify converters for the inner types of a field, e.g., `Vec<DisplayFromStr>`.
+The default de/serialization behavior can be restored by using `_` as a placeholder, e.g., `BTreeMap<_, DisplayFromStr>`.
 
 All together, this looks like:
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -84,6 +84,11 @@
 //! Annotate your struct or enum to enable the custom de/serializer.
 //! The `#[serde_as]` attribute must be placed *before* the `#[derive]`.
 //!
+//! The `as` is analogous to the `with` attribute of serde.
+//! You mirror the type structure of the field you want to de/serialize.
+//! You can specify converters for the inner types of a field, e.g., `Vec<DisplayFromStr>`.
+//! The default de/serialization behavior can be restored by using `_` as a placeholder, e.g., `BTreeMap<_, DisplayFromStr>`.
+//!
 //! ## `DisplayFromStr`
 //!
 //! [![Rustexplorer](https://img.shields.io/badge/Try%20on-rustexplorer-lightgrey?logo=rust&logoColor=orange)](https://www.rustexplorer.com/b/py7ida)


### PR DESCRIPTION
Mention that it is supposed to mirror the type structure of the field
and what the special `_` placeholder means.

This was mentioned as insufficiently explained in #582.

bors r+