### PR TITLE
ansi_term is no longer a dependency, so we can remove the ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,9 +1,5 @@
 [advisories]
 ignore = [
-    # ansi_term is Unmaintained
-    # Inactionable, since this is a transitive dependency of pretty_assertions
-    # Only used in test code.
-    "RUSTSEC-2021-0139",
     # xml-rs is Unmaintained
     # Inactionable, since this is a transitive dependency of serde-xml-rs
     # Only used in test code.


### PR DESCRIPTION
bors r+