### PR TITLE
Improve error messaged by dropping untagged enums

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Improve the error message when deserializing `OneOrMany` or `PickFirst` fails.
+    It now includes the original error message for each of the individual variants.
+    This is possible by dropping untagged enums as the internal implementations, since they will likely never support this, as these old PRs show [serde#2376](https://github.com/serde-rs/serde/pull/2376) and [serde#1544](https://github.com/serde-rs/serde/pull/1544).
+
+    The new errors look like:
+
+    ```text
+    OneOrMany could not deserialize any variant:
+      One: invalid type: map, expected u32
+      Many: invalid type: map, expected a sequence
+    ```
+
+    ```text
+    PickFirst could not deserialize any variant:
+      First: invalid type: string "Abc", expected u32
+      Second: invalid digit found in string
+    ```
+
 ## [2.3.1] - 2023-03-10
 
 ### Fixed

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -65,6 +65,8 @@ chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-f
 doc-comment = {version = "0.3.3", optional = true}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
+# The derive feature is needed for the flattened_maybe macro.
+# https://github.com/jonasbb/serde_with/blob/eb1965a74a3be073ecd13ec05f02a01bc1c44309/serde_with/src/flatten_maybe.rs#L67
 serde = {version = "1.0.122", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "=2.3.1", optional = true}

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -844,8 +844,20 @@ fn test_one_or_many_prefer_one() {
     );
     check_deserialization(S1Vec(vec![1]), r#"1"#);
     check_deserialization(S1Vec(vec![1]), r#"[1]"#);
-    check_error_deserialization::<S1Vec>(r#"{}"#, expect![[r#"a list or single element"#]]);
-    check_error_deserialization::<S1Vec>(r#""xx""#, expect![[r#"a list or single element"#]]);
+    check_error_deserialization::<S1Vec>(
+        r#"{}"#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: map, expected u32
+          Many: invalid type: map, expected a sequence"#]],
+    );
+    check_error_deserialization::<S1Vec>(
+        r#""xx""#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: string "xx", expected u32
+          Many: invalid type: string "xx", expected a sequence"#]],
+    );
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -865,8 +877,20 @@ fn test_one_or_many_prefer_one() {
     );
     check_deserialization(S2Vec(vec![1]), r#""1""#);
     check_deserialization(S2Vec(vec![1]), r#"["1"]"#);
-    check_error_deserialization::<S2Vec>(r#"{}"#, expect![[r#"a list or single element"#]]);
-    check_error_deserialization::<S2Vec>(r#""xx""#, expect![[r#"a list or single element"#]]);
+    check_error_deserialization::<S2Vec>(
+        r#"{}"#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: map, expected a string
+          Many: invalid type: map, expected a sequence"#]],
+    );
+    check_error_deserialization::<S2Vec>(
+        r#""xx""#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid digit found in string
+          Many: invalid type: string "xx", expected a sequence"#]],
+    );
 }
 
 #[test]
@@ -897,8 +921,20 @@ fn test_one_or_many_prefer_many() {
     );
     check_deserialization(S1Vec(vec![1]), r#"1"#);
     check_deserialization(S1Vec(vec![1]), r#"[1]"#);
-    check_error_deserialization::<S1Vec>(r#"{}"#, expect![[r#"a list or single element"#]]);
-    check_error_deserialization::<S1Vec>(r#""xx""#, expect![[r#"a list or single element"#]]);
+    check_error_deserialization::<S1Vec>(
+        r#"{}"#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: map, expected u32
+          Many: invalid type: map, expected a sequence"#]],
+    );
+    check_error_deserialization::<S1Vec>(
+        r#""xx""#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: string "xx", expected u32
+          Many: invalid type: string "xx", expected a sequence"#]],
+    );
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -924,8 +960,20 @@ fn test_one_or_many_prefer_many() {
     );
     check_deserialization(S2Vec(vec![1]), r#""1""#);
     check_deserialization(S2Vec(vec![1]), r#"["1"]"#);
-    check_error_deserialization::<S2Vec>(r#"{}"#, expect![[r#"a list or single element"#]]);
-    check_error_deserialization::<S2Vec>(r#""xx""#, expect![[r#"a list or single element"#]]);
+    check_error_deserialization::<S2Vec>(
+        r#"{}"#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid type: map, expected a string
+          Many: invalid type: map, expected a sequence"#]],
+    );
+    check_error_deserialization::<S2Vec>(
+        r#""xx""#,
+        expect![[r#"
+        OneOrMany could not deserialize any variant:
+          One: invalid digit found in string
+          Many: invalid type: string "xx", expected a sequence"#]],
+    );
 }
 
 /// Test that Cow borrows from the input

--- a/serde_with/tests/serde_as/pickfirst.rs
+++ b/serde_with/tests/serde_as/pickfirst.rs
@@ -14,7 +14,10 @@ fn test_pick_first_two() {
     check_deserialization(S(123), r#""123""#);
     check_error_deserialization::<S>(
         r#""Abc""#,
-        expect![[r#"PickFirst could not deserialize data"#]],
+        expect![[r#"
+            PickFirst could not deserialize any variant:
+              First: invalid type: string "Abc", expected u32
+              Second: invalid digit found in string"#]],
     );
 
     #[serde_as]
@@ -91,7 +94,11 @@ fn test_pick_first_three() {
     check_deserialization(S(vec![1, 2, 3]), r#""1,2,3""#);
     check_error_deserialization::<S>(
         r#""Abc""#,
-        expect![[r#"PickFirst could not deserialize data"#]],
+        expect![[r#"
+            PickFirst could not deserialize any variant:
+              First: invalid type: string "Abc", expected a sequence
+              Second: invalid type: string "Abc", expected a sequence
+              Third: invalid digit found in string"#]],
     );
 
     #[serde_as]
@@ -132,6 +139,11 @@ fn test_pick_first_four() {
     is_equal(S(123), expect![[r#"123"#]]);
     check_error_deserialization::<S>(
         r#""Abc""#,
-        expect![[r#"PickFirst could not deserialize data"#]],
+        expect![[r#"
+            PickFirst could not deserialize any variant:
+              First: invalid type: string "Abc", expected u32
+              Second: invalid type: string "Abc", expected u32
+              Third: invalid type: string "Abc", expected u32
+              Fourth: invalid type: string "Abc", expected u32"#]],
     );
 }


### PR DESCRIPTION
Untagged enums do not provide good error messages and likely never will,
given that there are multiple PRs which are just completely ignored
([serde#2376](https://github.com/serde-rs/serde/pull/2376) and
[serde#1544](https://github.com/serde-rs/serde/pull/1544)).

Instead using `content::de` the untagged enums can be replaced by custom
buffering. The error messages for `OneOrMany` and `PickFirst` now look
like this, including the original failure for each variant.

```text
OneOrMany could not deserialize any variant:
  One: invalid type: map, expected u32
  Many: invalid type: map, expected a sequence
```

```text
PickFirst could not deserialize any variant:
  First: invalid type: string "Abc", expected u32
  Second: invalid digit found in string
```

The implementations of `VecSkipError` and `DefaultOnError` are updated
too, but should not result in any visible changes.