### PR TITLE
Tweak the coverage configuration

### DIFF
--- a/serde_with/src/content/mod.rs
+++ b/serde_with/src/content/mod.rs
@@ -2,5 +2,7 @@
 //!
 //! <https://github.com/serde-rs/serde/blob/55a7cedd737278a9d75a2efd038c6f38b8c38bd6/serde/src/private/ser.rs#L338-L997>
 
+#![cfg(not(tarpaulin_include))]
+
 pub(crate) mod de;
 pub(crate) mod ser;

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -31,6 +31,8 @@
 #![allow(renamed_and_removed_lints)]
 // Necessary for nightly clippy lints
 #![allow(clippy::unknown_clippy_lints)]
+// Tarpaulin does not work well with proc macros and marks most of the lines as uncovered.
+#![cfg(not(tarpaulin_include))]
 
 //! proc-macro extensions for [`serde_with`].
 //!


### PR DESCRIPTION
proc-macros are badly supported by tarpaulin, leading to mostly
uncovered lines, so we exclude them from the reporting.
The `content` module is copied from `serde` but without extensive tests.

bors r+