### PR TITLE
Require serde 1.0.139

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -67,7 +67,7 @@ hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 # The derive feature is needed for the flattened_maybe macro.
 # https://github.com/jonasbb/serde_with/blob/eb1965a74a3be073ecd13ec05f02a01bc1c44309/serde_with/src/flatten_maybe.rs#L67
-serde = {version = "1.0.122", default-features = false, features = ["derive"]}
+serde = {version = "1.0.139", default-features = false, features = ["derive"] }
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "=2.3.1", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}


### PR DESCRIPTION
`serde::de::value::StringDeserializer::new` was introduced in 1.0.139.