### PR TITLE
Pin xml-rs dev-dependency to 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "serde_yaml",
  "time",
  "version-sync",
+ "xml-rs",
 ]
 
 [[package]]

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -88,6 +88,11 @@ serde_yaml = "0.9.2"
 serde-xml-rs = "0.6.0"
 version-sync = "0.9.1"
 
+# There is a change that breaks some tests, starting with 0.8.9.
+# Newer xml-rs versions are not compatible with the current MSRV.
+# https://github.com/netvl/xml-rs/issues/223
+xml-rs = "=0.8.4"
+
 [[test]]
 name = "base64"
 path = "tests/base64.rs"

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -23,15 +23,18 @@ pub(crate) use foreach_map;
 macro_rules! foreach_map_create {
     ($m:ident) => {
         #[cfg(feature = "alloc")]
-        $m!(BTreeMap<K: Ord, V>,
-            (|_size| BTreeMap::new()));
+        $m!(BTreeMap<K: Ord, V>, (|_size| BTreeMap::new()));
         #[cfg(feature = "std")]
-        $m!(HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
-            (|size| HashMap::with_capacity_and_hasher(size, Default::default())));
+        $m!(
+            HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
+            (|size| HashMap::with_capacity_and_hasher(size, Default::default()))
+        );
         #[cfg(feature = "indexmap_1")]
-        $m!(IndexMap<K: Eq + Hash, V, S: BuildHasher + Default>,
-            (|size| IndexMap::with_capacity_and_hasher(size, Default::default())));
-    }
+        $m!(
+            IndexMap<K: Eq + Hash, V, S: BuildHasher + Default>,
+            (|size| IndexMap::with_capacity_and_hasher(size, Default::default()))
+        );
+    };
 }
 pub(crate) use foreach_map_create;
 
@@ -63,7 +66,7 @@ macro_rules! foreach_set_create {
             (|size| IndexSet::with_capacity_and_hasher(size, S::default())),
             insert
         );
-    }
+    };
 }
 pub(crate) use foreach_set_create;
 


### PR DESCRIPTION
There is a breaking change in 0.8.9
https://github.com/netvl/xml-rs/issues/223

bors r+