### PR TITLE
Small fixes

### DIFF
--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -36,7 +36,7 @@ quote = "1.0.0"
 
 [dependencies.syn]
 features = [
-    # "extra-traits", # Only for debugging
+    "extra-traits",
     "full",
     "parsing",
 ]

--- a/serde_with_macros/src/apply.rs
+++ b/serde_with_macros/src/apply.rs
@@ -135,7 +135,6 @@ fn ty_pattern_matches_ty(ty_pattern: &Type, ty: &Type) -> bool {
             Type::Array(TypeArray { elem: ty, len, .. }),
         ) => {
             let ty_match = ty_pattern_matches_ty(ty_pattern, ty);
-            dbg!(len_pattern);
             let len_match = len_pattern == len || len_pattern.to_token_stream().to_string() == "_";
             ty_match && len_match
         }


### PR DESCRIPTION
Remove stray dbg!.
Enable extra-traits for syn. This is already enabled transitively via darling. But the apply macro makes use of Eq and potentially other traits.

bors r+