### PR TITLE
Fix documentation of `NoneAsEmptyString` to specify `Display` instead of `AsRef<str>`.

### DIFF
--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -555,7 +555,7 @@ pub struct DisplayFromStr;
 
 /// De/Serialize a [`Option<String>`] type while transforming the empty string to [`None`]
 ///
-/// Convert an [`Option<T>`] from/to string using [`FromStr`] and [`AsRef<str>`] implementations.
+/// Convert an [`Option<T>`] from/to string using [`FromStr`] and [`Display`] implementations.
 /// An empty string is deserialized as [`None`] and a [`None`] vice versa.
 ///
 /// # Examples


### PR DESCRIPTION
As part of #605 the investigation revealed that the documentation of
`NoneAsEmptyString` was wrong. It specified `AsRef<str>` instead of
`Display` as the trait.

bors r+