### PR TITLE
Move shared metadata to workspace definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/jonasbb/serde_with/"
+rust-version = "1.64"
+version = "3.2.0"
+
 [workspace.metadata.release]
 consolidate-commits = true
 pre-release-commit-message = "Bump version to v{{version}}"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -5,17 +5,18 @@ authors = [
     "Marcin Kaźmierczak",
 ]
 name = "serde_with"
-rust-version = "1.64"
-version = "3.2.0"
 
 categories = ["encoding", "no-std", "no-std::no-alloc"]
 description = "Custom de/serialization functions for Rust's serde"
 documentation = "https://docs.rs/serde_with/"
-edition = "2021"
 keywords = ["serde", "utilities", "serialization", "deserialization"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/jonasbb/serde_with"
+
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 include = ["src/**/*", "tests/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 

--- a/serde_with/tests/version_numbers.rs
+++ b/serde_with/tests/version_numbers.rs
@@ -20,10 +20,7 @@ fn test_serde_with_macros_dependency() {
         "../serde_with/Cargo.toml",
         r#"^serde_with_macros = .*? version = "={version}""#
     );
-    version_sync::assert_contains_regex!(
-        "../serde_with_macros/Cargo.toml",
-        r#"^version = "{version}""#
-    );
+    version_sync::assert_contains_regex!("../Cargo.toml", r#"^version = "{version}""#);
 }
 
 /// Check that all docs.rs links point to the current version

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 authors = ["Jonas Bushart"]
 name = "serde_with_macros"
-rust-version = "1.64"
-version = "3.2.0"
 
 categories = ["encoding"]
 description = "proc-macro library for serde_with"
 documentation = "https://docs.rs/serde_with_macros/"
-edition = "2021"
 keywords = ["serde", "utilities", "serialization", "deserialization"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/jonasbb/serde_with/"
+
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 include = [
     "src/**/*",

--- a/serde_with_test/Cargo.toml
+++ b/serde_with_test/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
-edition = "2021"
 name = "serde_with_test"
 publish = false
 version = "0.0.0"
-rust-version = "1.64"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Move shared metadata, like license, repository, or edition to the
workspace, such that all crates use the single definition.