### PR TITLE
feat: add optional support for hasbrown Map & Set

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: "Check no_std+alloc (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }})"
         run: cargo check --package serde_with --no-default-features --features=alloc --target thumbv7em-none-eabihf
       - name: "Check no_std+alloc+optional (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }})"
-        run: cargo check --package serde_with --no-default-features --features=alloc,base64,chrono_0_4,hex,indexmap_1,indexmap_2,json,time_0_3 --target thumbv7em-none-eabihf
+        run: cargo check --package serde_with --no-default-features --features=alloc,base64,chrono_0_4,hashbrown_0_14,hex,indexmap_1,indexmap_2,json,time_0_3 --target thumbv7em-none-eabihf
 
       # The tests are split into build and run steps, to see the time impact of each
       # cargo test --all-targets does NOT run doctests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
  "ahash",
- "allocator-api2",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +263,6 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +21,12 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android_system_properties"
@@ -262,6 +279,11 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hex"
@@ -607,6 +629,7 @@ dependencies = [
  "expect-test",
  "fnv",
  "glob",
+ "hashbrown 0.14.0",
  "hex",
  "indexmap 1.9.2",
  "indexmap 2.0.0",

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -54,6 +54,7 @@ chrono = ["chrono_0_4"]
 chrono_0_4 = ["dep:chrono_0_4"]
 guide = ["dep:doc-comment", "macros", "std"]
 hex = ["dep:hex", "alloc"]
+hashbrown_0_14 = ["dep:hashbrown_0_14", "alloc"]
 indexmap = ["indexmap_1"]
 indexmap_1 = ["dep:indexmap_1", "alloc"]
 indexmap_2 = ["dep:indexmap_2", "alloc"]
@@ -66,7 +67,7 @@ time_0_3 = ["dep:time_0_3"]
 base64 = {version = "0.21.0", optional = true, default-features = false}
 chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
-hashbrown = {version = "0.14.0", optional = true, features = ["serde"]}
+hashbrown_0_14 = {package = "hashbrown", version = "0.14.0", optional = true, default-features = false, features = ["ahash", "serde"]}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 indexmap_2 = {package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"]}
@@ -114,9 +115,9 @@ path = "tests/hex.rs"
 required-features = ["hex", "macros"]
 
 [[test]]
-name = "hashbrown"
-path = "tests/hashbrown.rs"
-required-features = ["hashbrown", "macros"]
+name = "hashbrown_0_14"
+path = "tests/hashbrown_0_14.rs"
+required-features = ["hashbrown_0_14", "macros"]
 
 [[test]]
 name = "indexmap_1"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -66,6 +66,7 @@ time_0_3 = ["dep:time_0_3"]
 base64 = {version = "0.21.0", optional = true, default-features = false}
 chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
+hashbrown = {version = "0.14.0", optional = true, features = ["serde"]}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 indexmap_2 = {package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"]}
@@ -111,6 +112,11 @@ required-features = ["chrono_0_4", "macros"]
 name = "hex"
 path = "tests/hex.rs"
 required-features = ["hex", "macros"]
+
+[[test]]
+name = "hashbrown"
+path = "tests/hashbrown.rs"
+required-features = ["hashbrown", "macros"]
 
 [[test]]
 name = "indexmap_1"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -67,7 +67,7 @@ time_0_3 = ["dep:time_0_3"]
 base64 = {version = "0.21.0", optional = true, default-features = false}
 chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-features = false, features = ["serde"]}
 doc-comment = {version = "0.3.3", optional = true}
-hashbrown_0_14 = {package = "hashbrown", version = "0.14.0", optional = true, default-features = false, features = ["ahash", "serde"]}
+hashbrown_0_14 = {package = "hashbrown", version = "0.14.0", optional = true, default-features = false, features = ["serde"]}
 hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 indexmap_2 = {package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"]}

--- a/serde_with/src/de/duplicates.rs
+++ b/serde_with/src/de/duplicates.rs
@@ -1,4 +1,4 @@
-use super::impls::{foreach_map, foreach_set_create};
+use super::impls::{foreach_map, foreach_set};
 use crate::{
     duplicate_key_impls::{
         DuplicateInsertsFirstWinsMap, DuplicateInsertsLastWinsSet, PreventDuplicateInsertsMap,
@@ -111,7 +111,7 @@ macro_rules! set_impl {
         }
     }
 }
-foreach_set_create!(set_impl);
+foreach_set!(set_impl);
 
 struct MapPreventDuplicatesVisitor<MAP, K, KAs, V, VAs>(PhantomData<(MAP, K, KAs, V, VAs)>);
 

--- a/serde_with/src/de/duplicates.rs
+++ b/serde_with/src/de/duplicates.rs
@@ -7,8 +7,8 @@ use crate::{
     prelude::*,
     MapFirstKeyWins, MapPreventDuplicates, SetLastValueWins, SetPreventDuplicates,
 };
-#[cfg(feature = "hashbrown")]
-use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
+#[cfg(feature = "hashbrown_0_14")]
+use hashbrown_0_14::{HashMap as HashbrownMap014, HashSet as HashbrownSet014};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]

--- a/serde_with/src/de/duplicates.rs
+++ b/serde_with/src/de/duplicates.rs
@@ -7,6 +7,8 @@ use crate::{
     prelude::*,
     MapFirstKeyWins, MapPreventDuplicates, SetLastValueWins, SetPreventDuplicates,
 };
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]

--- a/serde_with/src/de/duplicates.rs
+++ b/serde_with/src/de/duplicates.rs
@@ -1,4 +1,4 @@
-use super::impls::{foreach_map_create, foreach_set_create};
+use super::impls::{foreach_map, foreach_set_create};
 use crate::{
     duplicate_key_impls::{
         DuplicateInsertsFirstWinsMap, DuplicateInsertsLastWinsSet, PreventDuplicateInsertsMap,
@@ -75,14 +75,14 @@ where
 #[cfg(feature = "alloc")]
 macro_rules! set_impl {
     (
-        $ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)* $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)* )* >,
+        $ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)? $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)* )* >,
         $with_capacity:expr,
         $append:ident
     ) => {
         impl<'de, T, TAs $(, $typaram)*> DeserializeAs<'de, $ty<T $(, $typaram)*>> for SetPreventDuplicates<TAs>
         where
             TAs: DeserializeAs<'de, T>,
-            $(T: $tbound1 $(+ $tbound2)*,)*
+            $(T: $tbound1 $(+ $tbound2)*,)?
             $($typaram: $bound1 $(+ $bound2)*),*
         {
             fn deserialize_as<D>(deserializer: D) -> Result<$ty<T $(, $typaram)*>, D::Error>
@@ -98,7 +98,7 @@ macro_rules! set_impl {
         impl<'de, T, TAs $(, $typaram)*> DeserializeAs<'de, $ty<T $(, $typaram)*>> for SetLastValueWins<TAs>
         where
             TAs: DeserializeAs<'de, T>,
-            $(T: $tbound1 $(+ $tbound2)*,)*
+            $(T: $tbound1 $(+ $tbound2)*,)?
             $($typaram: $bound1 $(+ $bound2)*),*
         {
             fn deserialize_as<D>(deserializer: D) -> Result<$ty<T $(, $typaram)*>, D::Error>
@@ -180,7 +180,7 @@ where
 #[cfg(feature = "alloc")]
 macro_rules! map_impl {
     (
-        $ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)*)* >,
+        $ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)?, V $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)*)* >,
         $with_capacity:expr
     ) => {
         impl<'de, K, V, KAs, VAs $(, $typaram)*> DeserializeAs<'de, $ty<K, V $(, $typaram)*>>
@@ -188,7 +188,7 @@ macro_rules! map_impl {
         where
             KAs: DeserializeAs<'de, K>,
             VAs: DeserializeAs<'de, V>,
-            $(K: $kbound1 $(+ $kbound2)*,)*
+            $(K: $kbound1 $(+ $kbound2)*,)?
             $($typaram: $bound1 $(+ $bound2)*),*
         {
             fn deserialize_as<D>(deserializer: D) -> Result<$ty<K, V $(, $typaram)*>, D::Error>
@@ -210,7 +210,7 @@ macro_rules! map_impl {
         where
             KAs: DeserializeAs<'de, K>,
             VAs: DeserializeAs<'de, V>,
-            $(K: $kbound1 $(+ $kbound2)*,)*
+            $(K: $kbound1 $(+ $kbound2)*,)?
             $($typaram: $bound1 $(+ $bound2)*),*
         {
             fn deserialize_as<D>(deserializer: D) -> Result<$ty<K, V $(, $typaram)*>, D::Error>
@@ -224,4 +224,4 @@ macro_rules! map_impl {
         }
     };
 }
-foreach_map_create!(map_impl);
+foreach_map!(map_impl);

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,4 +1,6 @@
 use crate::{formats::*, prelude::*};
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]
@@ -16,6 +18,8 @@ macro_rules! foreach_map {
         $m!(BTreeMap<K: Ord, V>);
         #[cfg(feature = "std")]
         $m!(HashMap<K: Eq + Hash, V, H: Sized>);
+        #[cfg(all(feature = "std", feature = "hashbrown"))]
+        $m!(HashbrownMap<K: Eq + Hash, V, H: Sized>);
         #[cfg(all(feature = "std", feature = "indexmap_1"))]
         $m!(IndexMap<K: Eq + Hash, V, H: Sized>);
         #[cfg(all(feature = "std", feature = "indexmap_2"))]
@@ -32,6 +36,11 @@ macro_rules! foreach_map_create {
         $m!(
             HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
             (|size| HashMap::with_capacity_and_hasher(size, Default::default()))
+        );
+        #[cfg(feature = "hashbrown")]
+        $m!(
+            HashbrownMap<K: Eq + Hash, V, S: BuildHasher + Default>,
+            (|size| HashbrownMap::with_capacity_and_hasher(size, Default::default()))
         );
         #[cfg(feature = "indexmap_1")]
         $m!(
@@ -53,6 +62,8 @@ macro_rules! foreach_set {
         $m!(BTreeSet<(K, V): Ord>);
         #[cfg(feature = "std")]
         $m!(HashSet<(K, V): Eq + Hash>);
+        #[cfg(all(feature = "std", feature = "hashbrown"))]
+        $m!(HashbrownSet<(K, V): Eq + Hash>);
         #[cfg(all(feature = "std", feature = "indexmap_1"))]
         $m!(IndexSet<(K, V): Eq + Hash>);
         #[cfg(all(feature = "std", feature = "indexmap_2"))]
@@ -69,6 +80,12 @@ macro_rules! foreach_set_create {
         $m!(
             HashSet<T: Eq + Hash, S: BuildHasher + Default>,
             (|size| HashSet::with_capacity_and_hasher(size, S::default())),
+            insert
+        );
+        #[cfg(feature = "hashbrown")]
+        $m!(
+            HashbrownSet<T: Eq + Hash, S: BuildHasher + Default>,
+            (|size| HashbrownSet::with_capacity_and_hasher(size, S::default())),
             insert
         );
         #[cfg(feature = "indexmap_1")]

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1,6 +1,6 @@
 use crate::{formats::*, prelude::*};
-#[cfg(feature = "hashbrown")]
-use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
+#[cfg(feature = "hashbrown_0_14")]
+use hashbrown_0_14::{HashMap as HashbrownMap014, HashSet as HashbrownSet014};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]
@@ -18,8 +18,8 @@ macro_rules! foreach_map {
         $m!(BTreeMap<K: Ord, V>);
         #[cfg(feature = "std")]
         $m!(HashMap<K: Eq + Hash, V, H: Sized>);
-        #[cfg(all(feature = "std", feature = "hashbrown"))]
-        $m!(HashbrownMap<K: Eq + Hash, V, H: Sized>);
+        #[cfg(all(feature = "std", feature = "hashbrown_0_14"))]
+        $m!(HashbrownMap014<K: Eq + Hash, V, H: Sized>);
         #[cfg(all(feature = "std", feature = "indexmap_1"))]
         $m!(IndexMap<K: Eq + Hash, V, H: Sized>);
         #[cfg(all(feature = "std", feature = "indexmap_2"))]
@@ -37,10 +37,10 @@ macro_rules! foreach_map_create {
             HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
             (|size| HashMap::with_capacity_and_hasher(size, Default::default()))
         );
-        #[cfg(feature = "hashbrown")]
+        #[cfg(feature = "hashbrown_0_14")]
         $m!(
-            HashbrownMap<K: Eq + Hash, V, S: BuildHasher + Default>,
-            (|size| HashbrownMap::with_capacity_and_hasher(size, Default::default()))
+            HashbrownMap014<K: Eq + Hash, V, S: BuildHasher + Default>,
+            (|size| HashbrownMap014::with_capacity_and_hasher(size, Default::default()))
         );
         #[cfg(feature = "indexmap_1")]
         $m!(
@@ -62,8 +62,8 @@ macro_rules! foreach_set {
         $m!(BTreeSet<(K, V): Ord>);
         #[cfg(feature = "std")]
         $m!(HashSet<(K, V): Eq + Hash>);
-        #[cfg(all(feature = "std", feature = "hashbrown"))]
-        $m!(HashbrownSet<(K, V): Eq + Hash>);
+        #[cfg(all(feature = "std", feature = "hashbrown_0_14"))]
+        $m!(HashbrownSet014<(K, V): Eq + Hash>);
         #[cfg(all(feature = "std", feature = "indexmap_1"))]
         $m!(IndexSet<(K, V): Eq + Hash>);
         #[cfg(all(feature = "std", feature = "indexmap_2"))]
@@ -82,10 +82,10 @@ macro_rules! foreach_set_create {
             (|size| HashSet::with_capacity_and_hasher(size, S::default())),
             insert
         );
-        #[cfg(feature = "hashbrown")]
+        #[cfg(feature = "hashbrown_0_14")]
         $m!(
-            HashbrownSet<T: Eq + Hash, S: BuildHasher + Default>,
-            (|size| HashbrownSet::with_capacity_and_hasher(size, S::default())),
+            HashbrownSet014<T: Eq + Hash, S: BuildHasher + Default>,
+            (|size| HashbrownSet014::with_capacity_and_hasher(size, S::default())),
             insert
         );
         #[cfg(feature = "indexmap_1")]

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -34,6 +34,26 @@ where
     }
 }
 
+#[cfg(feature = "hashbrown")]
+impl<T, S> PreventDuplicateInsertsSet<T> for hashbrown::HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn insert(&mut self, value: T) -> bool {
+        self.insert(value)
+    }
+}
+
 #[cfg(feature = "indexmap_1")]
 impl<T, S> PreventDuplicateInsertsSet<T> for indexmap_1::IndexSet<T, S>
 where
@@ -91,6 +111,26 @@ where
 
 #[cfg(feature = "std")]
 impl<K, V, S> PreventDuplicateInsertsMap<K, V> for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn insert(&mut self, key: K, value: V) -> bool {
+        self.insert(key, value).is_none()
+    }
+}
+
+#[cfg(feature = "hashbrown")]
+impl<K, V, S> PreventDuplicateInsertsMap<K, V> for hashbrown::HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -34,8 +34,8 @@ where
     }
 }
 
-#[cfg(feature = "hashbrown")]
-impl<T, S> PreventDuplicateInsertsSet<T> for hashbrown::HashSet<T, S>
+#[cfg(feature = "hashbrown_0_14")]
+impl<T, S> PreventDuplicateInsertsSet<T> for hashbrown_0_14::HashSet<T, S>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,
@@ -129,8 +129,8 @@ where
     }
 }
 
-#[cfg(feature = "hashbrown")]
-impl<K, V, S> PreventDuplicateInsertsMap<K, V> for hashbrown::HashMap<K, V, S>
+#[cfg(feature = "hashbrown_0_14")]
+impl<K, V, S> PreventDuplicateInsertsMap<K, V> for hashbrown_0_14::HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -35,8 +35,8 @@ where
     }
 }
 
-#[cfg(feature = "hashbrown")]
-impl<K, V, S> DuplicateInsertsFirstWinsMap<K, V> for hashbrown::HashMap<K, V, S>
+#[cfg(feature = "hashbrown_0_14")]
+impl<K, V, S> DuplicateInsertsFirstWinsMap<K, V> for hashbrown_0_14::HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
@@ -51,7 +51,7 @@ where
 
     #[inline]
     fn insert(&mut self, key: K, value: V) {
-        use hashbrown::hash_map::Entry;
+        use hashbrown_0_14::hash_map::Entry;
 
         match self.entry(key) {
             // we want to keep the first value, so do nothing

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -28,6 +28,27 @@ where
     }
 }
 
+#[cfg(feature = "hashbrown")]
+impl<T, S> DuplicateInsertsLastWinsSet<T> for hashbrown::HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    #[inline]
+    fn new(size_hint: Option<usize>) -> Self {
+        match size_hint {
+            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
+            None => Self::with_hasher(S::default()),
+        }
+    }
+
+    #[inline]
+    fn replace(&mut self, value: T) {
+        // Hashset already fulfils the contract
+        self.replace(value);
+    }
+}
+
 #[cfg(feature = "indexmap_1")]
 impl<T, S> DuplicateInsertsLastWinsSet<T> for indexmap_1::IndexSet<T, S>
 where

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -28,8 +28,8 @@ where
     }
 }
 
-#[cfg(feature = "hashbrown")]
-impl<T, S> DuplicateInsertsLastWinsSet<T> for hashbrown::HashSet<T, S>
+#[cfg(feature = "hashbrown_0_14")]
+impl<T, S> DuplicateInsertsLastWinsSet<T> for hashbrown_0_14::HashSet<T, S>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -6,19 +6,18 @@ Each entry will explain the feature in more detail.
 `serde_with` is fully `no_std` compatible.
 Using it in a `no_std` environment requires using `default-features = false`, since `std` is enabled by default.
 
-- [Available Feature Flags](#available-feature-flags)
-  - [`alloc`](#alloc)
-  - [`std` (default)](#std-default)
-  - [`base64`](#base64)
-  - [`chrono_0_4`](#chrono_0_4)
-  - [`guide`](#guide)
-  - [`hashbrown`](#hashbrown)
-  - [`hex`](#hex)
-  - [`indexmap_1`](#indexmap_1)
-  - [`indexmap_2`](#indexmap_2)
-  - [`json`](#json)
-  - [`macros` (default)](#macros-default)
-  - [`time_0_3`](#time_0_3)
+1. [`alloc`](#alloc)
+2. [`std` (default)](#std-default)
+3. [`base64`](#base64)
+4. [`chrono_0_4`](#chrono_0_4)
+5. [`guide`](#guide)
+6. [`hashbrown_0_14`](#hashbrown_0_14)
+7. [`hex`](#hex)
+8. [`indexmap_1`](#indexmap_1)
+9. [`indexmap_2`](#indexmap_2)
+10. [`json`](#json)
+11. [`macros` (default)](#macros-default)
+12. [`time_0_3`](#time_0_3)
 
 ## `alloc`
 
@@ -51,11 +50,11 @@ This pulls in `chrono` v0.4 as a dependency.
 The `guide` feature enables inclusion of this user guide.
 The feature only changes the rustdoc output and enables no other effects.
 
-## `hashbrown`
+## `hashbrown_0_14`
 
-The `hashbrown` feature enables `hashbown::{HashMap, HashSet}` as supported containers.
+The `hashbrown_0_14` feature enables `hashbown::{HashMap, HashSet}` as supported containers.
 
-This pulls in `hashbrown` as a dependency.
+This pulls in `hashbrown` v0.14 as a dependency.
 It enables the `alloc` feature.
 Some functionality is only available when `std` is enabled too.
 

--- a/serde_with/src/guide/feature_flags.md
+++ b/serde_with/src/guide/feature_flags.md
@@ -6,17 +6,19 @@ Each entry will explain the feature in more detail.
 `serde_with` is fully `no_std` compatible.
 Using it in a `no_std` environment requires using `default-features = false`, since `std` is enabled by default.
 
-1. [`alloc`](#alloc)
-2. [`std` (default)](#std-default)
-3. [`base64`](#base64)
-4. [`chrono_0_4`](#chrono_0_4)
-5. [`guide`](#guide)
-6. [`hex`](#hex)
-7. [`indexmap_1`](#indexmap_1)
-8. [`indexmap_2`](#indexmap_2)
-9. [`json`](#json)
-10. [`macros` (default)](#macros-default)
-11. [`time_0_3`](#time_0_3)
+- [Available Feature Flags](#available-feature-flags)
+  - [`alloc`](#alloc)
+  - [`std` (default)](#std-default)
+  - [`base64`](#base64)
+  - [`chrono_0_4`](#chrono_0_4)
+  - [`guide`](#guide)
+  - [`hashbrown`](#hashbrown)
+  - [`hex`](#hex)
+  - [`indexmap_1`](#indexmap_1)
+  - [`indexmap_2`](#indexmap_2)
+  - [`json`](#json)
+  - [`macros` (default)](#macros-default)
+  - [`time_0_3`](#time_0_3)
 
 ## `alloc`
 
@@ -48,6 +50,14 @@ This pulls in `chrono` v0.4 as a dependency.
 
 The `guide` feature enables inclusion of this user guide.
 The feature only changes the rustdoc output and enables no other effects.
+
+## `hashbrown`
+
+The `hashbrown` feature enables `hashbown::{HashMap, HashSet}` as supported containers.
+
+This pulls in `hashbrown` as a dependency.
+It enables the `alloc` feature.
+Some functionality is only available when `std` is enabled too.
 
 ## `hex`
 

--- a/serde_with/src/ser/duplicates.rs
+++ b/serde_with/src/ser/duplicates.rs
@@ -2,8 +2,8 @@ use super::impls::{foreach_map, foreach_set};
 use crate::{
     prelude::*, MapFirstKeyWins, MapPreventDuplicates, SetLastValueWins, SetPreventDuplicates,
 };
-#[cfg(feature = "hashbrown")]
-use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
+#[cfg(feature = "hashbrown_0_14")]
+use hashbrown_0_14::{HashMap as HashbrownMap014, HashSet as HashbrownSet014};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]

--- a/serde_with/src/ser/duplicates.rs
+++ b/serde_with/src/ser/duplicates.rs
@@ -2,6 +2,8 @@ use super::impls::{foreach_map, foreach_set};
 use crate::{
     prelude::*, MapFirstKeyWins, MapPreventDuplicates, SetLastValueWins, SetPreventDuplicates,
 };
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1,4 +1,6 @@
 use crate::{formats, formats::Strictness, prelude::*};
+#[cfg(feature = "hashbrown")]
+use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]
@@ -17,9 +19,11 @@ macro_rules! foreach_map {
         $m!(BTreeMap<K, V>);
         #[cfg(feature = "std")]
         $m!(HashMap<K, V, H: Sized>);
-        #[cfg(all(feature = "indexmap_1"))]
+        #[cfg(feature = "hashbrown")]
+        $m!(HashbrownMap<K, V, H: Sized>);
+        #[cfg(feature = "indexmap_1")]
         $m!(IndexMap<K, V, H: Sized>);
-        #[cfg(all(feature = "indexmap_2"))]
+        #[cfg(feature = "indexmap_2")]
         $m!(IndexMap2<K, V, H: Sized>);
     };
 }
@@ -31,9 +35,11 @@ macro_rules! foreach_set {
         $m!(BTreeSet<$T>);
         #[cfg(feature = "std")]
         $m!(HashSet<$T, H: Sized>);
-        #[cfg(all(feature = "indexmap_1"))]
+        #[cfg(feature = "hashbrown")]
+        $m!(HashbrownSet<$T, H: Sized>);
+        #[cfg(feature = "indexmap_1")]
         $m!(IndexSet<$T, H: Sized>);
-        #[cfg(all(feature = "indexmap_2"))]
+        #[cfg(feature = "indexmap_2")]
         $m!(IndexSet2<$T, H: Sized>);
     };
     ($m:ident) => {

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1,6 +1,6 @@
 use crate::{formats, formats::Strictness, prelude::*};
-#[cfg(feature = "hashbrown")]
-use hashbrown::{HashMap as HashbrownMap, HashSet as HashbrownSet};
+#[cfg(feature = "hashbrown_0_14")]
+use hashbrown_0_14::{HashMap as HashbrownMap014, HashSet as HashbrownSet014};
 #[cfg(feature = "indexmap_1")]
 use indexmap_1::{IndexMap, IndexSet};
 #[cfg(feature = "indexmap_2")]
@@ -19,8 +19,8 @@ macro_rules! foreach_map {
         $m!(BTreeMap<K, V>);
         #[cfg(feature = "std")]
         $m!(HashMap<K, V, H: Sized>);
-        #[cfg(feature = "hashbrown")]
-        $m!(HashbrownMap<K, V, H: Sized>);
+        #[cfg(feature = "hashbrown_0_14")]
+        $m!(HashbrownMap014<K, V, H: Sized>);
         #[cfg(feature = "indexmap_1")]
         $m!(IndexMap<K, V, H: Sized>);
         #[cfg(feature = "indexmap_2")]
@@ -35,8 +35,8 @@ macro_rules! foreach_set {
         $m!(BTreeSet<$T>);
         #[cfg(feature = "std")]
         $m!(HashSet<$T, H: Sized>);
-        #[cfg(feature = "hashbrown")]
-        $m!(HashbrownSet<$T, H: Sized>);
+        #[cfg(feature = "hashbrown_0_14")]
+        $m!(HashbrownSet014<$T, H: Sized>);
         #[cfg(feature = "indexmap_1")]
         $m!(IndexSet<$T, H: Sized>);
         #[cfg(feature = "indexmap_2")]

--- a/serde_with/tests/hashbrown.rs
+++ b/serde_with/tests/hashbrown.rs
@@ -1,0 +1,262 @@
+#![allow(
+  // clippy is broken and shows wrong warnings
+  // clippy on stable does not know yet about the lint name
+  unknown_lints,
+  // https://github.com/rust-lang/rust-clippy/issues/8867
+  clippy::derive_partial_eq_without_eq,
+)]
+
+mod utils;
+
+use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
+use core::iter::FromIterator;
+use expect_test::expect;
+use hashbrown::{HashMap, HashSet};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr, Same};
+use std::net::IpAddr;
+
+#[test]
+fn test_hashmap() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")] HashMap<u8, u32>);
+
+    // Normal
+    is_equal(
+        S([(1, 1), (3, 3), (111, 111)].iter().cloned().collect()),
+        expect![[r#"
+            {
+              "1": "1",
+              "111": "111",
+              "3": "3"
+            }"#]],
+    );
+    is_equal(S(HashMap::default()), expect![[r#"{}"#]]);
+}
+
+#[test]
+fn test_hashset() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "HashSet<DisplayFromStr>")] HashSet<u32>);
+
+    // Normal
+    is_equal(
+        S([1, 2, 3, 4, 5].iter().cloned().collect()),
+        expect![[r#"
+            [
+              "1",
+              "5",
+              "4",
+              "3",
+              "2"
+            ]"#]],
+    );
+    is_equal(S(HashSet::default()), expect![[r#"[]"#]]);
+}
+
+#[test]
+fn test_map_as_tuple_list() {
+    let ip = "1.2.3.4".parse().unwrap();
+    let ip2 = "255.255.255.255".parse().unwrap();
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI(#[serde_as(as = "Vec<(DisplayFromStr, DisplayFromStr)>")] HashMap<u32, IpAddr>);
+
+    let map: HashMap<_, _> = vec![(1, ip), (10, ip), (200, ip2)].into_iter().collect();
+    is_equal(
+        SI(map.clone()),
+        expect![[r#"
+            [
+              [
+                "1",
+                "1.2.3.4"
+              ],
+              [
+                "200",
+                "255.255.255.255"
+              ],
+              [
+                "10",
+                "1.2.3.4"
+              ]
+            ]"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI2(#[serde_as(as = "Vec<(Same, DisplayFromStr)>")] HashMap<u32, IpAddr>);
+
+    is_equal(
+        SI2(map),
+        expect![[r#"
+            [
+              [
+                1,
+                "1.2.3.4"
+              ],
+              [
+                200,
+                "255.255.255.255"
+              ],
+              [
+                10,
+                "1.2.3.4"
+              ]
+            ]"#]],
+    );
+}
+
+#[test]
+fn duplicate_key_first_wins_hashmap() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::maps_first_key_wins")] HashMap<usize, usize>);
+
+    // Different value and key always works
+    is_equal(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
+
+    // Same value for different keys is ok
+    is_equal(
+        S(HashMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
+
+    // Duplicate keys, the first one is used
+    check_deserialization(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2)])),
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+    );
+}
+
+#[test]
+fn prohibit_duplicate_key_hashmap() {
+    #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+    struct S(
+        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")] HashMap<usize, usize>,
+    );
+
+    // Different value and key always works
+    is_equal(
+        S(HashMap::from_iter(vec![(1, 1), (2, 2), (3, 3)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 2,
+              "3": 3
+            }"#]],
+    );
+
+    // Same value for different keys is ok
+    is_equal(
+        S(HashMap::from_iter(vec![(1, 1), (2, 1), (3, 1)])),
+        expect![[r#"
+            {
+              "1": 1,
+              "2": 1,
+              "3": 1
+            }"#]],
+    );
+
+    // Duplicate keys are an error
+    check_error_deserialization::<S>(
+        r#"{"1": 1, "2": 2, "1": 3}"#,
+        expect![[r#"invalid entry: found duplicate key at line 1 column 24"#]],
+    );
+}
+
+#[test]
+fn duplicate_value_last_wins_hashset() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_last_value_wins")] HashSet<W>);
+
+    #[derive(Debug, Eq, Deserialize, Serialize)]
+    struct W(i32, bool);
+    impl PartialEq for W {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+    impl std::hash::Hash for W {
+        fn hash<H>(&self, state: &mut H)
+        where
+            H: std::hash::Hasher,
+        {
+            self.0.hash(state)
+        }
+    }
+
+    // Different values always work
+    is_equal(
+        S(HashSet::from_iter(vec![
+            W(1, true),
+            W(2, false),
+            W(3, true),
+        ])),
+        expect![[r#"
+            [
+              [
+                1,
+                true
+              ],
+              [
+                2,
+                false
+              ],
+              [
+                3,
+                true
+              ]
+            ]"#]],
+    );
+
+    let value: S = serde_json::from_str(
+        r#"[
+        [1, false],
+        [1, true],
+        [2, true],
+        [2, false]
+    ]"#,
+    )
+    .unwrap();
+    let entries: Vec<_> = value.0.into_iter().collect();
+    assert_eq!(1, entries[0].0);
+    assert!(entries[0].1);
+    assert_eq!(2, entries[1].0);
+    assert!(!entries[1].1);
+}
+
+#[test]
+fn prohibit_duplicate_value_hashset() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct S(#[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] HashSet<usize>);
+
+    is_equal(
+        S(HashSet::from_iter(vec![1, 2, 3, 4])),
+        expect![[r#"
+            [
+              1,
+              4,
+              3,
+              2
+            ]"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"[1, 2, 3, 4, 1]"#,
+        expect![[r#"invalid entry: found duplicate value at line 1 column 15"#]],
+    );
+}

--- a/serde_with/tests/hashbrown_0_14.rs
+++ b/serde_with/tests/hashbrown_0_14.rs
@@ -11,7 +11,7 @@ mod utils;
 use crate::utils::{check_deserialization, check_error_deserialization, is_equal};
 use core::iter::FromIterator;
 use expect_test::expect;
-use hashbrown::{HashMap, HashSet};
+use hashbrown_0_14::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Same};
 use std::net::IpAddr;


### PR DESCRIPTION
This PR is not yet ready to merge as I've never setup a `#[no_std]` friendly crate before. Looking for guidance for how to properly setup the Cargo.toml to support this (and perhaps validate this holds true).