### PR TITLE
Decrease minimum serde version to 1.0.152

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,9 +564,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.157"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -585,13 +585,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.157"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -122,7 +122,7 @@ indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-fe
 indexmap_2 = {package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"]}
 # The derive feature is needed for the flattened_maybe macro.
 # https://github.com/jonasbb/serde_with/blob/eb1965a74a3be073ecd13ec05f02a01bc1c44309/serde_with/src/flatten_maybe.rs#L67
-serde = {version = "1.0.157", default-features = false, features = ["derive"] }
+serde = {version = "1.0.152", default-features = false, features = ["derive"] }
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "=3.3.0", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -47,7 +47,7 @@ version = "2.0.0"
 expect-test = "1.4.0"
 pretty_assertions = "1.4.0"
 rustversion = "1.0.0"
-serde = {version = "1.0.157", features = ["derive"]}
+serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.25"
 trybuild = "1.0.80"
 version-sync = "0.9.1"


### PR DESCRIPTION
As far as I can tell, the minimum version of 1.0.157 is unnecessary. The way I've determined that is just from running the build + tests:
```
cargo build --workspace
cargo test --workspace
```

This addresses https://github.com/jonasbb/serde_with/issues/651. For my needs at least 1.0.152 is actually sufficient (rather than 1.0.149), though we could try go lower.
