### PR TITLE
Add support for core::ops::Bound

### DIFF
--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -165,6 +165,24 @@ where
     }
 }
 
+impl<'de, T, U> DeserializeAs<'de, Bound<T>> for Bound<U>
+where
+    U: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<Bound<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(
+            match Bound::<DeserializeAsWrap<T, U>>::deserialize(deserializer)? {
+                Bound::Unbounded => Bound::Unbounded,
+                Bound::Included(v) => Bound::Included(v.into_inner()),
+                Bound::Excluded(v) => Bound::Excluded(v.into_inner()),
+            },
+        )
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<'de, T, U> DeserializeAs<'de, Rc<T>> for Rc<U>
 where

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -403,6 +403,7 @@ pub(crate) mod prelude {
         fmt::{self, Display},
         hash::{BuildHasher, Hash},
         marker::PhantomData,
+        ops::Bound,
         option::Option,
         result::Result,
         str::FromStr,

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -130,6 +130,24 @@ where
     }
 }
 
+impl<T, U> SerializeAs<Bound<T>> for Bound<U>
+where
+    U: SerializeAs<T>,
+    T: Sized,
+{
+    fn serialize_as<S>(source: &Bound<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match source {
+            Bound::Unbounded => Bound::Unbounded,
+            Bound::Included(ref v) => Bound::Included(SerializeAsWrap::<T, U>::new(v)),
+            Bound::Excluded(ref v) => Bound::Excluded(SerializeAsWrap::<T, U>::new(v)),
+        }
+        .serialize(serializer)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<T, U> SerializeAs<Rc<T>> for Rc<U>
 where


### PR DESCRIPTION
I have encountered a case where I would like to use `Bound<Cow<'a, str>>` and borrow the string from the deserialized buffer instead of copying. To use `BorrowStr`, I had to add support for `core::ops::Bound` to `serde_with`.