### PR TITLE
Allow external crates to add their own `JsonSchema` impls for custom `SerializeAs` and `DeserializeAs` types

### DIFF
--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -331,7 +331,7 @@ pub mod json;
 mod key_value_map;
 pub mod rust;
 #[cfg(feature = "schemars_0_8")]
-mod schemars_0_8;
+pub mod schemars_0_8;
 pub mod ser;
 #[cfg(feature = "std")]
 mod serde_conv;

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -1,6 +1,9 @@
 //! Integration with [schemars v0.8](schemars_0_8).
 //!
 //! This module is only available if using the `schemars_0_8` feature of the crate.
+//!
+//! If you would like to add support for schemars to your own serde_with helpers
+//! see [`JsonSchemaAs`].
 
 use crate::{
     formats::Separator,
@@ -12,6 +15,139 @@ use ::schemars_0_8::{
     JsonSchema,
 };
 use std::borrow::Cow;
+
+//===================================================================
+// Trait Definition
+
+/// A type which can be described as a JSON schema document.
+///
+/// This trait is as [`SerializeAs`] is to [`Serialize`] but for [`JsonSchema`].
+/// You can use it to make your custom [`SerializeAs`] and [`DeserializeAs`]
+/// types also support being described via JSON schemas.
+///
+/// It is used by the [`Schema`][1] type in order to implement [`JsonSchema`]
+/// for the relevant types. [`Schema`][1] is used implicitly by the [`serde_as`]
+/// macro to instruct `schemars` on how to generate JSON schemas for fields
+/// annotated with `#[serde_as(as = "...")]` attributes.
+///
+/// # Examples
+/// Suppose we have our very own `PositiveInt` type. Then we could add support
+/// for generating a schema from it like this
+///
+/// ```
+/// # extern crate schemars_0_8 as schemars;
+/// # use serde::{Serialize, Serializer, Deserialize, Deserializer};
+/// # use serde_with::{SerializeAs, DeserializeAs};
+/// use serde_with::schemars_0_8::JsonSchemaAs;
+/// use schemars::gen::SchemaGenerator;
+/// use schemars::schema::Schema;
+/// use schemars::JsonSchema;
+///
+/// struct PositiveInt;
+///
+/// impl SerializeAs<i32> for PositiveInt {
+///     // ...
+///     # fn serialize_as<S>(&value: &i32, ser: S) -> Result<S::Ok, S::Error>
+///     # where
+///     #    S: Serializer
+///     # {
+///     #    if value < 0 {
+///     #        return Err(serde::ser::Error::custom(
+///     #            "expected a positive integer value, got a negative one"
+///     #        ));
+///     #    }
+///     #
+///     #    value.serialize(ser)
+///     # }
+/// }
+///
+/// impl<'de> DeserializeAs<'de, i32> for PositiveInt {
+///     // ...
+///     # fn deserialize_as<D>(de: D) -> Result<i32, D::Error>
+///     # where
+///     #     D: Deserializer<'de>,
+///     # {
+///     #     match i32::deserialize(de) {
+///     #         Ok(value) if value < 0 => Err(serde::de::Error::custom(
+///     #             "expected a positive integer value, got a negative one"
+///     #         )),
+///     #         value => value
+///     #     }
+///     # }
+/// }
+///
+/// impl JsonSchemaAs<i32> for PositiveInt {
+///     fn schema_name() -> String {
+///         "PositiveInt".into()
+///     }
+///
+///     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+///         let mut schema = <i32 as JsonSchema>::json_schema(gen).into_object();
+///         schema.number().minimum = Some(0.0);
+///         schema.into()
+///     }
+/// }
+/// ```
+///
+/// [0]: crate::serde_as
+/// [1]: crate::Schema
+pub trait JsonSchemaAs<T: ?Sized> {
+    /// Whether JSON Schemas generated for this type should be re-used where possible using the `$ref` keyword.
+    ///
+    /// For trivial types (such as primitives), this should return `false`. For more complex types, it should return `true`.
+    /// For recursive types, this **must** return `true` to prevent infinite cycles when generating schemas.
+    ///
+    /// By default, this returns `true`.
+    fn is_referenceable() -> bool {
+        true
+    }
+
+    /// The name of the generated JSON Schema.
+    ///
+    /// This is used as the title for root schemas, and the key within the root's `definitions` property for subschemas.
+    fn schema_name() -> String;
+
+    /// Returns a string that uniquely identifies the schema produced by this type.
+    ///
+    /// This does not have to be a human-readable string, and the value will not itself be included in generated schemas.
+    /// If two types produce different schemas, then they **must** have different `schema_id()`s,
+    /// but two types that produce identical schemas should *ideally* have the same `schema_id()`.
+    ///
+    /// The default implementation returns the same value as `schema_name()`.
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(Self::schema_name())
+    }
+
+    /// Generates a JSON Schema for this type.
+    ///
+    /// If the returned schema depends on any [referenceable](JsonSchema::is_referenceable) schemas, then this method will
+    /// add them to the [`SchemaGenerator`](gen::SchemaGenerator)'s schema definitions.
+    ///
+    /// This should not return a `$ref` schema.
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema;
+}
+
+impl<T, TA> JsonSchema for WrapSchema<T, TA>
+where
+    T: ?Sized,
+    TA: JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        TA::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        TA::schema_id()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        TA::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        TA::is_referenceable()
+    }
+}
 
 //===================================================================
 // Macro helpers
@@ -39,100 +175,100 @@ macro_rules! forward_schema {
 //===================================================================
 // Common definitions for various std types
 
-impl<'a, T: 'a, TA: 'a> JsonSchema for WrapSchema<&'a T, &'a TA>
+impl<'a, T: 'a, TA: 'a> JsonSchemaAs<&'a T> for &'a TA
 where
     T: ?Sized,
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(&'a WrapSchema<T, TA>);
 }
 
-impl<'a, T: 'a, TA: 'a> JsonSchema for WrapSchema<&'a mut T, &'a mut TA>
+impl<'a, T: 'a, TA: 'a> JsonSchemaAs<&'a mut T> for &'a mut TA
 where
     T: ?Sized,
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(&'a mut WrapSchema<T, TA>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Option<T>, Option<TA>>
+impl<T, TA> JsonSchemaAs<Option<T>> for Option<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Option<WrapSchema<T, TA>>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Box<T>, Box<TA>>
+impl<T, TA> JsonSchemaAs<Box<T>> for Box<TA>
 where
     T: ?Sized,
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Box<WrapSchema<T, TA>>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Rc<T>, Rc<TA>>
+impl<T, TA> JsonSchemaAs<Rc<T>> for Rc<TA>
 where
     T: ?Sized,
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Rc<WrapSchema<T, TA>>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Arc<T>, Arc<TA>>
+impl<T, TA> JsonSchemaAs<Arc<T>> for Arc<TA>
 where
     T: ?Sized,
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Arc<WrapSchema<T, TA>>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Vec<T>, Vec<TA>>
+impl<T, TA> JsonSchemaAs<Vec<T>> for Vec<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Vec<WrapSchema<T, TA>>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<VecDeque<T>, VecDeque<TA>>
+impl<T, TA> JsonSchemaAs<VecDeque<T>> for VecDeque<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(VecDeque<WrapSchema<T, TA>>);
 }
 
 // schemars only requires that V implement JsonSchema for BTreeMap<K, V>
-impl<K, V, KA, VA> JsonSchema for WrapSchema<BTreeMap<K, V>, BTreeMap<KA, VA>>
+impl<K, V, KA, VA> JsonSchemaAs<BTreeMap<K, V>> for BTreeMap<KA, VA>
 where
-    WrapSchema<V, VA>: JsonSchema,
+    VA: JsonSchemaAs<V>,
 {
     forward_schema!(BTreeMap<WrapSchema<K, KA>, WrapSchema<V, VA>>);
 }
 
 // schemars only requires that V implement JsonSchema for HashMap<K, V>
-impl<K, V, S, KA, VA> JsonSchema for WrapSchema<HashMap<K, V, S>, HashMap<KA, VA, S>>
+impl<K, V, S, KA, VA> JsonSchemaAs<HashMap<K, V, S>> for HashMap<KA, VA, S>
 where
-    WrapSchema<V, VA>: JsonSchema,
+    VA: JsonSchemaAs<V>,
 {
     forward_schema!(HashMap<WrapSchema<K, KA>, WrapSchema<V, VA>, S>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<BTreeSet<T>, BTreeSet<TA>>
+impl<T, TA> JsonSchemaAs<BTreeSet<T>> for BTreeSet<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(BTreeSet<WrapSchema<T, TA>>);
 }
 
-impl<T, TA, H> JsonSchema for WrapSchema<HashSet<T, H>, HashSet<TA, H>>
+impl<T, TA, S> JsonSchemaAs<T> for HashSet<TA, S>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
-    forward_schema!(HashSet<WrapSchema<T, TA>, H>);
+    forward_schema!(HashSet<WrapSchema<T, TA>, S>);
 }
 
-impl<T, TA, const N: usize> JsonSchema for WrapSchema<[T; N], [TA; N]>
+impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     fn schema_name() -> String {
         std::format!("[{}; {}]", <WrapSchema<T, TA>>::schema_name(), N)
@@ -171,16 +307,16 @@ macro_rules! schema_for_tuple {
         ( $( $ts:ident )+ )
         ( $( $as:ident )+ )
     ) => {
-        impl<$($ts,)+ $($as,)+> JsonSchema for WrapSchema<($($ts,)+), ($($as,)+)>
+        impl<$($ts,)+ $($as,)+> JsonSchemaAs<($($ts,)+)> for ($($as,)+)
         where
-            $( WrapSchema<$ts, $as>: JsonSchema, )+
+            $( $as: JsonSchemaAs<$ts>, )+
         {
             forward_schema!(( $( WrapSchema<$ts, $as>, )+ ));
         }
     }
 }
 
-impl JsonSchema for WrapSchema<(), ()> {
+impl JsonSchemaAs<()> for () {
     forward_schema!(());
 }
 
@@ -218,15 +354,15 @@ schema_for_tuple!(
 //===================================================================
 // Impls for serde_with types.
 
-impl<T: JsonSchema> JsonSchema for WrapSchema<T, Same> {
+impl<T: JsonSchema> JsonSchemaAs<T> for Same {
     forward_schema!(T);
 }
 
-impl<T> JsonSchema for WrapSchema<T, DisplayFromStr> {
+impl<T> JsonSchemaAs<T> for DisplayFromStr {
     forward_schema!(String);
 }
 
-impl<'a, T: 'a> JsonSchema for WrapSchema<Cow<'a, T>, BorrowCow>
+impl<'a, T: 'a> JsonSchemaAs<Cow<'a, T>> for BorrowCow
 where
     T: ?Sized + ToOwned,
     Cow<'a, T>: JsonSchema,
@@ -234,45 +370,45 @@ where
     forward_schema!(Cow<'a, T>);
 }
 
-impl<T> JsonSchema for WrapSchema<T, Bytes> {
+impl<T> JsonSchemaAs<T> for Bytes {
     forward_schema!(Vec<u8>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<T, DefaultOnError<TA>>
+impl<T, TA> JsonSchemaAs<T> for DefaultOnError<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(WrapSchema<T, TA>);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<T, DefaultOnNull<TA>>
+impl<T, TA> JsonSchemaAs<T> for DefaultOnNull<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Option<WrapSchema<T, TA>>);
 }
 
-impl<O, T: JsonSchema> JsonSchema for WrapSchema<O, FromInto<T>> {
+impl<O, T: JsonSchema> JsonSchemaAs<O> for FromInto<T> {
     forward_schema!(T);
 }
 
-impl<O, T: JsonSchema> JsonSchema for WrapSchema<O, FromIntoRef<T>> {
+impl<O, T: JsonSchema> JsonSchemaAs<O> for FromIntoRef<T> {
     forward_schema!(T);
 }
 
-impl<T, U: JsonSchema> JsonSchema for WrapSchema<T, TryFromInto<U>> {
+impl<T, U: JsonSchema> JsonSchemaAs<T> for TryFromInto<U> {
     forward_schema!(U);
 }
 
-impl<T, U: JsonSchema> JsonSchema for WrapSchema<T, TryFromIntoRef<U>> {
+impl<T, U: JsonSchema> JsonSchemaAs<T> for TryFromIntoRef<U> {
     forward_schema!(U);
 }
 
 macro_rules! schema_for_map {
     ($type:ty) => {
-        impl<K, V, KA, VA> JsonSchema for WrapSchema<$type, Map<KA, VA>>
+        impl<K, V, KA, VA> JsonSchemaAs<$type> for Map<KA, VA>
         where
-            WrapSchema<V, VA>: JsonSchema,
+            VA: JsonSchemaAs<V>,
         {
             forward_schema!(WrapSchema<BTreeMap<K, V>, BTreeMap<KA, VA>>);
         }
@@ -287,32 +423,32 @@ schema_for_map!(LinkedList<(K, V)>);
 schema_for_map!(Vec<(K, V)>);
 schema_for_map!(VecDeque<(K, V)>);
 
-impl<K, V, S, KA, VA> JsonSchema for WrapSchema<HashSet<(K, V), S>, Map<KA, VA>>
+impl<K, V, S, KA, VA> JsonSchemaAs<HashSet<(K, V), S>> for Map<KA, VA>
 where
-    WrapSchema<V, VA>: JsonSchema,
+    VA: JsonSchemaAs<V>,
 {
     forward_schema!(WrapSchema<BTreeMap<K, V>, BTreeMap<KA, VA>>);
 }
 
-impl<K, V, KA, VA, const N: usize> JsonSchema for WrapSchema<[(K, V); N], Map<KA, VA>>
+impl<K, V, KA, VA, const N: usize> JsonSchemaAs<[(K, V); N]> for Map<KA, VA>
 where
-    WrapSchema<V, VA>: JsonSchema,
+    VA: JsonSchemaAs<V>,
 {
     forward_schema!(WrapSchema<BTreeMap<K, V>, BTreeMap<KA, VA>>);
 }
 
 macro_rules! map_first_last_wins_schema {
     ($(=> $extra:ident)? $type:ty) => {
-        impl<K, V, $($extra,)? KA, VA> JsonSchema for WrapSchema<$type, MapFirstKeyWins<KA, VA>>
+        impl<K, V, $($extra,)? KA, VA> JsonSchemaAs<$type> for MapFirstKeyWins<KA, VA>
         where
-            WrapSchema<V, VA>: JsonSchema
+            VA: JsonSchemaAs<V>,
         {
             forward_schema!(BTreeMap<WrapSchema<K, KA>, WrapSchema<V, VA>>);
         }
 
-        impl<K, V, $($extra,)? KA, VA> JsonSchema for WrapSchema<$type, MapPreventDuplicates<KA, VA>>
+        impl<K, V, $($extra,)? KA, VA> JsonSchemaAs<$type> for MapPreventDuplicates<KA, VA>
         where
-            WrapSchema<V, VA>: JsonSchema
+            VA: JsonSchemaAs<V>,
         {
             forward_schema!(BTreeMap<WrapSchema<K, KA>, WrapSchema<V, VA>>);
         }
@@ -328,9 +464,9 @@ map_first_last_wins_schema!(=> S indexmap_1::IndexMap<K, V, S>);
 #[cfg(feature = "indexmap_2")]
 map_first_last_wins_schema!(=> S indexmap_2::IndexMap<K, V, S>);
 
-impl<T, TA> JsonSchema for WrapSchema<T, SetLastValueWins<TA>>
+impl<T, TA> JsonSchemaAs<T> for SetLastValueWins<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     fn schema_id() -> Cow<'static, str> {
         std::format!(
@@ -365,23 +501,23 @@ where
     }
 }
 
-impl<T, TA> JsonSchema for WrapSchema<T, SetPreventDuplicates<TA>>
+impl<T, TA> JsonSchemaAs<T> for SetPreventDuplicates<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(WrapSchema<T, TA>);
 }
 
-impl<SEP, T, TA> JsonSchema for WrapSchema<T, StringWithSeparator<SEP, TA>>
+impl<SEP, T, TA> JsonSchemaAs<T> for StringWithSeparator<SEP, TA>
 where
     SEP: Separator,
 {
     forward_schema!(String);
 }
 
-impl<T, TA> JsonSchema for WrapSchema<Vec<T>, VecSkipError<TA>>
+impl<T, TA> JsonSchemaAs<Vec<T>> for VecSkipError<TA>
 where
-    WrapSchema<T, TA>: JsonSchema,
+    TA: JsonSchemaAs<T>,
 {
     forward_schema!(Vec<WrapSchema<T, TA>>);
 }


### PR DESCRIPTION
This is written on top of #676.

---

Implementing `JsonSchema` directly on `serde_with::Schema<T, TA>` works fine when within `serde_with`. Once you are outside the crate, however, the orphan rules prevent you from adding impls of the form
```rust
impl JsonSchema for Schema<T, MyCustomType> { ... }
```
We would like users to be able to make that impl (or something equivalent) so we need to find a way to make it work. We make this work by adding a new layer of trait indirection.

This PR introduces a new `JsonSchemaAs<T>` trait, adds a blanket
```rust
impl<T, TA> JsonSchema for Schema<T, TA> where TA: JsonSchemaAs<T>
```
and then changes all the existing impls to be for `JsonSchemaAs<T>` instead of on `Schema<T, TA>`.

Now, when a user wants to add json schema support for their own type they can implement `JsonSchemaAs<T>` for their custom type and the orphan rules will allow it.

As a bonus, this seems to have made the extraordinarily confusing ["reached recursion limit"](https://github.com/rust-lang/rust/issues/119839) errors that I have been encountering disappear. Which is nice.