### PR TITLE
Add `JsonSchema` impls for `BytesOrString` and `BoolFromInt`

### DIFF
--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -401,24 +401,9 @@ impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
         "serde_with::BoolFromInt<Flexible>".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
         SchemaObject {
             instance_type: Some(InstanceType::Integer.into()),
-            subschemas: Some(Box::new(SubschemaValidation {
-                any_of: Some(std::vec![
-                    gen.subschema_for::<WrapSchema<bool, BoolFromInt<Strict>>>(),
-                    SchemaObject {
-                        instance_type: Some(InstanceType::Integer.into()),
-                        metadata: Some(Box::new(Metadata {
-                            write_only: true,
-                            ..Default::default()
-                        })),
-                        ..Default::default()
-                    }
-                    .into()
-                ]),
-                ..Default::default()
-            })),
             ..Default::default()
         }
         .into()

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -441,6 +441,42 @@ impl<T> JsonSchemaAs<T> for Bytes {
     forward_schema!(Vec<u8>);
 }
 
+impl JsonSchemaAs<Vec<u8>> for BytesOrString {
+    fn schema_name() -> String {
+        "BytesOrString".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::BytesOrString".into()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                any_of: Some(std::vec![
+                    gen.subschema_for::<Vec<u8>>(),
+                    SchemaObject {
+                        instance_type: Some(InstanceType::String.into()),
+                        metadata: Some(Box::new(Metadata {
+                            write_only: true,
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    }
+                    .into()
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
 impl<T, TA> JsonSchemaAs<T> for DefaultOnError<TA>
 where
     TA: JsonSchemaAs<T>,

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -379,7 +379,7 @@ impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
             instance_type: Some(InstanceType::Integer.into()),
             number: Some(Box::new(NumberValidation {
                 minimum: Some(0.0),
-                maximum: Some(0.0),
+                maximum: Some(1.0),
                 ..Default::default()
             })),
             ..Default::default()

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -300,6 +300,46 @@ mod array {
     }
 }
 
+mod bytes_or_string {
+    use super::*;
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "BytesOrString")]
+        bytes: Vec<u8>,
+    }
+
+    #[test]
+    fn test_serialized_is_valid() {
+        check_valid_json_schema(&Test {
+            bytes: b"test".to_vec(),
+        });
+    }
+
+    #[test]
+    fn test_string_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": "test string"
+        }));
+    }
+
+    #[test]
+    fn test_bytes_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": [1, 2, 3, 4]
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_int_not_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": 5
+        }));
+    }
+}
+
 #[test]
 fn test_borrow_cow() {
     use std::borrow::Cow;

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -356,6 +356,22 @@ mod bool_from_int {
             "value": "seven"
         }));
     }
+
+    #[test]
+    #[should_panic]
+    fn test_fractional_value_strict() {
+        check_matches_schema::<BoolStrict>(&json!({
+            "value": 0.5
+        }))
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_fractional_value_flexible() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": 0.5
+        }))
+    }
 }
 
 mod bytes_or_string {

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -300,6 +300,64 @@ mod array {
     }
 }
 
+mod bool_from_int {
+    use super::*;
+    use serde_with::formats::{Flexible, Strict};
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct BoolStrict {
+        #[serde_as(as = "BoolFromInt<Strict>")]
+        value: bool,
+    }
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct BoolFlexible {
+        #[serde_as(as = "BoolFromInt<Flexible>")]
+        value: bool,
+    }
+
+    #[test]
+    fn test_serialized_strict_is_valid() {
+        check_valid_json_schema(&vec![
+            BoolStrict { value: true },
+            BoolStrict { value: false },
+        ]);
+    }
+
+    #[test]
+    fn test_serialized_flexible_is_valid() {
+        check_valid_json_schema(&vec![
+            BoolFlexible { value: true },
+            BoolFlexible { value: false },
+        ]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn strict_out_of_range() {
+        check_matches_schema::<BoolStrict>(&json!({
+            "value": 5
+        }));
+    }
+
+    #[test]
+    fn flexible_out_of_range() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": 5
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn flexible_wrong_type() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": "seven"
+        }));
+    }
+}
+
 mod bytes_or_string {
     use super::*;
 


### PR DESCRIPTION
This PR continues where #679 left off. Since the impls get more complicated as we go on I will be chunking them up into smaller PRs so that reviewing them stays manageable. I also don't plan on doing more than 1 or maybe 2 PRs concurrently. I just considered #682 important enough that it should jump the queue. 

## Details
- `JsonSchemaFor` impls for both `BytesOrString` and `BoolFromInt`
- Tests for both of the above

## Notes
- `BytesOrString`'s schema is represented as an enum that can be either a string or an array of bytes. The one difference is that the string representation is marked as "writeOnly" as it is never emitted.
- I originally also did something similar for `BoolFromInt<Flexible>` but I didn't think that this was useful compared to the extra confusion when reading the schema. I have changed it so it's schema is just that of an integer.