### PR TITLE
Add JsonSchemaAs impls for all Duration and Timestamp adaptors

### DIFF
--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -613,48 +613,76 @@ where
 mod timespan {
     use super::*;
 
+    // #[non_exhaustive] is not actually necessary here but it should
+    // help avoid warnings about semver breakage if this ever changes.
+    #[non_exhaustive]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum TimespanTargetType {
+        String,
+        F64,
+        U64,
+        I64,
+    }
+
+    impl TimespanTargetType {
+        pub const fn is_signed(self) -> bool {
+            !matches!(self, Self::U64)
+        }
+    }
+
     /// Internal helper trait used to constrain which types we implement
     /// `JsonSchemaAs<T>` for.
     pub trait TimespanSchemaTarget<F> {
-        /// Whether F is signed.
-        const SIGNED: bool = true;
+        /// The underlying type.
+        ///
+        /// This is mainly used to decide which variant of the resulting schema
+        /// should be marked as `write_only: true`.
+        const TYPE: TimespanTargetType;
 
-        /// Whether F is String
-        const STRING: bool;
+        /// Whether the target type is signed.
+        ///
+        /// This is only true for `std::time::Duration`.
+        const SIGNED: bool = true;
     }
 
-    macro_rules! is_string {
+    macro_rules! timespan_type_of {
         (String) => {
-            true
+            TimespanTargetType::String
         };
-        ($name:ty) => {
-            false
+        (f64) => {
+            TimespanTargetType::F64
+        };
+        (i64) => {
+            TimespanTargetType::I64
+        };
+        (u64) => {
+            TimespanTargetType::U64
         };
     }
 
     macro_rules! declare_timespan_target {
-        ( $target:ty { $($format:ty),* $(,)? } )=> {
+        ( $target:ty { $($format:ident),* $(,)? } ) => {
             $(
                 impl TimespanSchemaTarget<$format> for $target {
-                    const STRING: bool = is_string!($format);
+                    const TYPE: TimespanTargetType = timespan_type_of!($format);
                 }
             )*
         }
     }
 
     impl TimespanSchemaTarget<u64> for Duration {
+        const TYPE: TimespanTargetType = TimespanTargetType::U64;
         const SIGNED: bool = false;
-        const STRING: bool = false;
     }
 
     impl TimespanSchemaTarget<f64> for Duration {
+        const TYPE: TimespanTargetType = TimespanTargetType::F64;
         const SIGNED: bool = false;
-        const STRING: bool = false;
     }
 
     impl TimespanSchemaTarget<String> for Duration {
+        const TYPE: TimespanTargetType = TimespanTargetType::String;
         const SIGNED: bool = false;
-        const STRING: bool = true;
     }
 
     declare_timespan_target!(SystemTime { i64, f64, String });
@@ -676,7 +704,7 @@ mod timespan {
     declare_timespan_target!(::time_0_3::PrimitiveDateTime { i64, f64, String });
 }
 
-use self::timespan::TimespanSchemaTarget;
+use self::timespan::{TimespanSchemaTarget, TimespanTargetType};
 
 /// Internal type used for the base impls on DurationXXX and TimestampYYY types.
 ///
@@ -692,37 +720,61 @@ where
     forward_schema!(F);
 }
 
-fn flexible_timespan_schema(signed: bool, is_string: bool) -> Schema {
-    let mut number = SchemaObject {
-        instance_type: Some(InstanceType::Number.into()),
-        number: (!signed).then(|| {
-            Box::new(NumberValidation {
-                minimum: Some(0.0),
-                ..Default::default()
-            })
-        }),
-        ..Default::default()
-    };
+impl TimespanTargetType {
+    pub(crate) fn to_flexible_schema(self, signed: bool) -> Schema {
+        use ::schemars_0_8::schema::StringValidation;
 
-    let mut string = SchemaObject {
-        instance_type: Some(InstanceType::String.into()),
-        ..Default::default()
-    };
-
-    if is_string {
-        number.metadata().write_only = true;
-    } else {
-        string.metadata().write_only = true;
-    }
-
-    SchemaObject {
-        subschemas: Some(Box::new(SubschemaValidation {
-            one_of: Some(std::vec![number.into(), string.into()]),
+        let mut number = SchemaObject {
+            instance_type: Some(InstanceType::Number.into()),
+            number: (!signed).then(|| {
+                Box::new(NumberValidation {
+                    minimum: Some(0.0),
+                    ..Default::default()
+                })
+            }),
             ..Default::default()
-        })),
-        ..Default::default()
+        };
+
+        // This is a more lenient version of the regex used to determine
+        // whether JSON numbers are valid. Specifically, it allows multiple
+        // leading zeroes whereas that is illegal in JSON.
+        let regex = r#"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?"#;
+        let mut string = SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some(match signed {
+                    true => std::format!("^-?{regex}$"),
+                    false => std::format!("^{regex}$"),
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        if self == Self::String {
+            number.metadata().write_only = true;
+        } else {
+            string.metadata().write_only = true;
+        }
+
+        SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(std::vec![number.into(), string.into()]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
     }
-    .into()
+
+    pub(crate) fn schema_id(self) -> &'static str {
+        match self {
+            Self::String => "serde_with::FlexibleStringTimespan",
+            Self::F64 => "serde_with::FlexibleF64Timespan",
+            Self::U64 => "serde_with::FlexibleU64Timespan",
+            Self::I64 => "serde_with::FlexibleI64Timespan",
+        }
+    }
 }
 
 impl<T, F> JsonSchemaAs<T> for Timespan<F, Flexible>
@@ -731,24 +783,20 @@ where
     F: Format + JsonSchema,
 {
     fn schema_name() -> String {
-        match <T as TimespanSchemaTarget<F>>::STRING {
-            true => "FlexibleStringTimespan".into(),
-            false => "FlexibleTimespan".into(),
-        }
+        <T as TimespanSchemaTarget<F>>::TYPE
+            .schema_id()
+            .strip_prefix("serde_with::")
+            .expect("schema id did not start with `serde_with::` - this is a bug")
+            .into()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        match <T as TimespanSchemaTarget<F>>::STRING {
-            true => "serde_with::FlexibleStringTimespan".into(),
-            false => "serde_with::FlexibleTimespan".into(),
-        }
+        <T as TimespanSchemaTarget<F>>::TYPE.schema_id().into()
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
-        flexible_timespan_schema(
-            <T as TimespanSchemaTarget<F>>::SIGNED,
-            <T as TimespanSchemaTarget<F>>::STRING,
-        )
+        <T as TimespanSchemaTarget<F>>::TYPE
+            .to_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
     }
 
     fn is_referenceable() -> bool {

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -248,6 +248,9 @@ mod snapshots {
                 #[serde_as(as = "DurationSecondsWithFrac<f64, Flexible>")]
                 frac: std::time::Duration,
 
+                #[serde_as(as = "DurationSeconds<String, Flexible>")]
+                flexible_string: std::time::Duration,
+
                 #[serde_as(as = "DurationSeconds<u64, Strict>")]
                 seconds_u64_strict: std::time::Duration,
 

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -180,7 +180,7 @@ mod test_std {
 
 mod snapshots {
     use super::*;
-    use serde_with::formats::CommaSeparator;
+    use serde_with::formats::*;
     use std::collections::BTreeSet;
 
     declare_snapshot_test! {
@@ -237,6 +237,22 @@ mod snapshots {
             struct Test {
                 #[serde_as(as = "SetPreventDuplicates<_>")]
                 data: BTreeSet<u32>,
+            }
+        }
+
+        duration {
+            struct Test {
+                #[serde_as(as = "DurationSeconds<u64, Flexible>")]
+                seconds: std::time::Duration,
+
+                #[serde_as(as = "DurationSecondsWithFrac<f64, Flexible>")]
+                frac: std::time::Duration,
+
+                #[serde_as(as = "DurationSeconds<u64, Strict>")]
+                seconds_u64_strict: std::time::Duration,
+
+                #[serde_as(as = "TimestampSeconds<i64, Flexible>")]
+                time_i64: std::time::SystemTime,
             }
         }
     }
@@ -436,6 +452,110 @@ mod bytes_or_string {
         check_matches_schema::<Test>(&json!({
             "bytes": 5
         }));
+    }
+}
+
+mod duration {
+    use super::*;
+    use serde_with::formats::{Flexible, Strict};
+    use std::time::{Duration, SystemTime};
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct DurationTest {
+        #[serde_as(as = "DurationSeconds<u64, Strict>")]
+        strict_u64: Duration,
+
+        #[serde_as(as = "DurationSeconds<String, Strict>")]
+        strict_str: Duration,
+
+        #[serde_as(as = "DurationSecondsWithFrac<f64, Strict>")]
+        strict_f64: Duration,
+
+        #[serde_as(as = "DurationSeconds<u64, Flexible>")]
+        flexible_u64: Duration,
+
+        #[serde_as(as = "DurationSeconds<f64, Flexible>")]
+        flexible_f64: Duration,
+
+        #[serde_as(as = "DurationSeconds<String, Flexible>")]
+        flexible_str: Duration,
+    }
+
+    #[test]
+    fn test_serialized_is_valid() {
+        check_valid_json_schema(&DurationTest {
+            strict_u64: Duration::from_millis(2500),
+            strict_str: Duration::from_millis(2500),
+            strict_f64: Duration::from_millis(2500),
+            flexible_u64: Duration::from_millis(2500),
+            flexible_f64: Duration::from_millis(2500),
+            flexible_str: Duration::from_millis(2500),
+        });
+    }
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleU64Duration(#[serde_as(as = "DurationSeconds<u64, Flexible>")] Duration);
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleStringDuration(#[serde_as(as = "DurationSeconds<String, Flexible>")] Duration);
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleTimestamp(#[serde_as(as = "TimestampSeconds<i64, Flexible>")] SystemTime);
+
+    #[test]
+    fn test_string_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!("32"));
+    }
+
+    #[test]
+    fn test_integer_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(16));
+    }
+
+    #[test]
+    fn test_number_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(54.1));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_negative_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(-5));
+    }
+
+    #[test]
+    fn test_string_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!("32"));
+    }
+
+    #[test]
+    fn test_integer_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(16));
+    }
+
+    #[test]
+    fn test_number_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(54.1));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_negative_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(-5));
+    }
+
+    #[test]
+    fn test_negative_as_flexible_timestamp() {
+        check_matches_schema::<FlexibleTimestamp>(&json!(-50000));
+    }
+
+    #[test]
+    fn test_negative_string_as_flexible_timestamp() {
+        check_matches_schema::<FlexibleTimestamp>(&json!("-50000"));
     }
 }
 

--- a/serde_with/tests/schemars_0_8/snapshots/duration.json
+++ b/serde_with/tests/schemars_0_8/snapshots/duration.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test",
+  "type": "object",
+  "required": [
+    "frac",
+    "seconds",
+    "seconds_u64_strict",
+    "time_i64"
+  ],
+  "properties": {
+    "frac": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "writeOnly": true,
+          "type": "string"
+        }
+      ]
+    },
+    "seconds": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "writeOnly": true,
+          "type": "string"
+        }
+      ]
+    },
+    "seconds_u64_strict": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "time_i64": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "writeOnly": true,
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_8/snapshots/duration.json
+++ b/serde_with/tests/schemars_0_8/snapshots/duration.json
@@ -3,12 +3,26 @@
   "title": "Test",
   "type": "object",
   "required": [
+    "flexible_string",
     "frac",
     "seconds",
     "seconds_u64_strict",
     "time_i64"
   ],
   "properties": {
+    "flexible_string": {
+      "oneOf": [
+        {
+          "writeOnly": true,
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$"
+        }
+      ]
+    },
     "frac": {
       "oneOf": [
         {
@@ -17,7 +31,8 @@
         },
         {
           "writeOnly": true,
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$"
         }
       ]
     },
@@ -29,7 +44,8 @@
         },
         {
           "writeOnly": true,
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$"
         }
       ]
     },
@@ -45,7 +61,8 @@
         },
         {
           "writeOnly": true,
-          "type": "string"
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$"
         }
       ]
     }


### PR DESCRIPTION
This PR picks up from where #683 left off.

---
Since there are quite a few different Duration and Timestamp adaptors most of this PR is just macro-driven copy paste. In earlier iterations it was much worse but with the help of an internal trait I was able to reduce it down to something manageable.

# Details
This PR includes:
- `JsonSchemaAs` impls for all `DurationXXX` and `TimestampYYY` adaptors for all formats and supported library types.
- Tests for the above

# Notes
- Modelling `Strict` versions is easy. Their schema is just that of the underlying format.
- `Flexible` adaptors required some judgement calls:
  - I have decided not to distinguish between integers and numbers - everything is typed as `"instanceType": "number"`. I think this is more likely to be useful in practice than trying to make a distinction between "reads any number" and "emits only integers" - something that many consumers of the schema might not even consider a meaningful distinction.

