### PR TITLE
Eliminate dependency on serde's "derive" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde-xml-rs",
+ "serde_derive",
  "serde_json",
  "serde_test",
  "serde_with_macros",

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -130,9 +130,8 @@ hex = {version = "0.4.3", optional = true, default-features = false}
 indexmap_1 = {package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"]}
 indexmap_2 = {package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"]}
 schemars_0_8 = {package = "schemars", version = "0.8.16", optional = true, default-features = false}
-# The derive feature is needed for the flattened_maybe macro.
-# https://github.com/jonasbb/serde_with/blob/eb1965a74a3be073ecd13ec05f02a01bc1c44309/serde_with/src/flatten_maybe.rs#L67
-serde = {version = "1.0.152", default-features = false, features = ["derive"] }
+serde = {version = "1.0.152", default-features = false}
+serde_derive = "1.0.152"
 serde_json = {version = "1.0.45", optional = true, default-features = false}
 serde_with_macros = {path = "../serde_with_macros", version = "=3.6.0", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}
@@ -149,6 +148,7 @@ rmp-serde = "1.1.0"
 ron = "0.8"
 rustversion = "1.0.0"
 schemars_0_8 = {package = "schemars", version = "0.8.16"}
+serde = {version = "1.0.152", default-features = false, features = ["derive"]}
 serde_json = {version = "1.0.25", features = ["preserve_order"]}
 serde_test = "1.0.124"
 serde_yaml = "0.9.2"

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -64,7 +64,7 @@ macro_rules! flattened_maybe {
                 serde,
             };
 
-            #[derive($crate::serde::Deserialize)]
+            #[derive($crate::serde_derive::Deserialize)]
             #[serde(crate = "serde")]
             pub struct Both<T> {
                 #[serde(flatten)]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -296,6 +296,8 @@ extern crate alloc;
 pub extern crate core;
 #[doc(hidden)]
 pub extern crate serde;
+#[doc(hidden)]
+pub extern crate serde_derive;
 #[cfg(feature = "std")]
 extern crate std;
 


### PR DESCRIPTION
This allows serde, and other crates downstream of it like serde_json, to compile in parallel with serde_derive. Without this PR, in any dependency graph that pulls in serde_with, first serde_derive would need to compile, then serde would need to compile, then serde_json would need to compile.

https://github.com/sharkdp/bat/pull/2815 has a diagram of the impact of this change.