### PR TITLE
Update ahash to 0.8.7 to accommodate stdsimd change in nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",


### PR DESCRIPTION
CI is impacted by https://github.com/tkaitchuck/aHash/issues/200, which is fixed in ahash 0.8.7. I see the following in the jobs that ran on https://github.com/jonasbb/serde_with/pull/694:

```console
error[E0635]: unknown feature `stdsimd`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.6/src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^
```