### PR TITLE
Implement `JsonSchemaAs` for `EnumMap`

### DIFF
--- a/serde_with/tests/schemars_0_8/snapshots/enum_map.json
+++ b/serde_with/tests/schemars_0_8/snapshots/enum_map.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/EnumMap<Mappable>"
+    }
+  },
+  "definitions": {
+    "EnumMap<Mappable>": {
+      "type": "object",
+      "properties": {
+        "A": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "B": {
+          "type": "string"
+        },
+        "C": {
+          "type": "object",
+          "required": [
+            "c"
+          ],
+          "properties": {
+            "b": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "c": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
It's been a little busy but I'm back with yet another PR :)

This is the first one that really involves a custom deserialize implementation. `EnumMap` involves transforming a list of enums to a map and to generate its schema we end up needing to do the same to the schema.

Basically, we end up transforming
```json
{
  "type": "object",
  "oneOf": [
    { "properties": { "A": "..." } },
    { "properties": { "B": "..." } }
  ]
}       
```
into
```json
{
  "type": "object",
  "properties": {
    "A": "...",
    "B": "..."
  }
}
```

I have also included a number of tests that I think should cover most of the different cases.

## Notes
- If the schema for the inner type doesn't match what would be expected for a rust enum then we'll end up generating an invalid overall schema. I don't think this is an issue since it doesn't appear that `EnumMap` itself works in this case?