### PR TITLE
Replace uses of write! with write_str and write_fmt

### DIFF
--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -847,7 +847,7 @@ where
             type Value = S;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a string")
+                formatter.write_str("a string")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -1091,7 +1091,7 @@ where
             type Value = I;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a string")
+                formatter.write_str("a string")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -186,7 +186,7 @@ where
             type Value = Vec<T>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a map of enum values")
+                formatter.write_str("a map of enum values")
             }
 
             fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {

--- a/serde_with/src/key_value_map.rs
+++ b/serde_with/src/key_value_map.rs
@@ -188,7 +188,7 @@ where
             type Value = Vec<T>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a map")
+                formatter.write_str("a map")
             }
 
             fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -390,7 +390,7 @@ impl<'de> DeserializeAs<'de, DurationSigned> for DurationSeconds<String, Strict>
             type Value = DurationSigned;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a string containing a number")
+                formatter.write_str("a string containing a number")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>

--- a/serde_with/tests/derives/serialize_display.rs
+++ b/serde_with/tests/derives/serialize_display.rs
@@ -10,7 +10,7 @@ struct A {
 
 impl fmt::Display for A {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "->{} <> {}<-", self.a, self.b)
+        f.write_fmt(format_args!("->{} <> {}<-", self.a, self.b))
     }
 }
 

--- a/serde_with/tests/serde_as/enum_map.rs
+++ b/serde_with/tests/serde_as/enum_map.rs
@@ -9,7 +9,7 @@ fn bytes_debug_readable(bytes: &[u8]) -> String {
     for &byte in bytes {
         match byte {
             non_printable if !(0x20..0x7f).contains(&non_printable) => {
-                write!(result, "\\x{byte:02x}").unwrap();
+                result.write_fmt(format_args!("\\x{byte:02x}")).unwrap();
             }
             b'\\' => result.push_str("\\\\"),
             _ => {


### PR DESCRIPTION
write! with a single string argument is not properly optimized and using
write_str generates better code:
https://github.com/serde-rs/serde/pull/2697
https://github.com/rust-lang/rust/pull/121001