### PR TITLE
Fix various small typos & grammar

### DIFF
--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the "Get Changelog Entry" step above, referencing its ID to get its outputs object.
+          # This pulls from the "Get Changelog Entry" step above, referencing its ID to get its `outputs` object.
           # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           tag_name: "v${{ steps.changelog_reader.outputs.version }}"
           name: "serde_with v${{ steps.changelog_reader.outputs.version }}"

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -8,7 +8,7 @@ on:
 #  push:
 #    branches: [ master ]
 
-# Declare default permissions as read only.
+# Declare default permissions as read-only.
 permissions: read-all
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,20 +18,21 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 Make sure to include the three major parts of information:
 
 1. Show your code and serialized data.
-    Without them it is almost impossible to understand where the problem arises.
+    Without them, it is almost impossible to understand where the problem arises.
 2. Explain what the expected result and/or expected serialized data is.
-3. If possible prepare a minimal running example.
+3. If possible, prepare a minimal running example.
 
 Security vulnerabilities should be reported privately as [security advisory](https://github.com/jonasbb/serde_with/security).
 Check [SECURITY.md](./SECURITY.md) for details.
 
 ## Submitting a PR
 
-This repository provides a devcontainer setup, which can be used with VS Code or GitHub codespaces to simplify contributions.
+This repository provides a dev container setup, which can be used with VS Code or GitHub Codespaces to simplify contributing.
 
-1. Simply start by opening a PR.
+1. Start by opening a PR.
 2. New features should always be accompanied by tests and documentation.
-    * New transformations should have a documentation using rustdoc. A short descriptions should be added to `serde_as_transformations.md` too.
+    * New transformations should have documentation using rustdoc.
+      A short description should be added to `serde_as_transformations.md` too.
     * Integration tests belong in the `tests` folder.
     * A changelog entry can also be added.
 3. Contributions must pass `cargo clippy` and `cargo fmt`.
@@ -40,7 +41,7 @@ This repository provides a devcontainer setup, which can be used with VS Code or
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall
-be dual licensed as above, without any additional terms or conditions.
+be dual-licensed as above, without any additional terms or conditions.
 
 [user guide]: https://docs.rs/serde_with/latest/serde_with/guide/index.html
 
@@ -55,4 +56,4 @@ A new chrono v0.5 would get the feature name `chrono_0_5` and the v1 release `ch
 
 `serde_with` depends also on further crates to implement the converters, such as `base64` or `hex`.
 Here the feature name should not depend on the crate, but rather describe the added functionality enabled by it.
-For example, additional JSON functionality is behind the `json` feature and it depends on `serde_json` for the implementation.
+For example, additional JSON functionality is behind the `json` feature, and it depends on `serde_json` for the implementation.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][as-annotation]-annotation.
+This crate provides custom de/serialization helpers to use in combination with [serde's `with` annotation][with-annotation] and with the improved [`serde_as`][as-annotation]-annotation.
 Some common use cases are:
 
 * De/Serializing a type using the `Display` and `FromStr` traits, e.g., for `u8`, `url::Url`, or `mime::Mime`.
@@ -25,7 +25,7 @@ Some common use cases are:
 
 **Check out the [user guide][user guide] to find out more tips and tricks about this crate.**
 
-For further help using this crate you can [open a new discussion](https://github.com/jonasbb/serde_with/discussions/new) or ask on [users.rust-lang.org](https://users.rust-lang.org/).
+For further help using this crate, you can [open a new discussion](https://github.com/jonasbb/serde_with/discussions/new) or ask on [users.rust-lang.org](https://users.rust-lang.org/).
 For bugs, please open a [new issue](https://github.com/jonasbb/serde_with/issues/new) on GitHub.
 
 ## Use `serde_with` in your Project
@@ -131,7 +131,7 @@ Foo {a: None, b: None, c: None, d: Some(4), e: None, f: None, g: Some(7)}
 
 ### Advanced `serde_as` usage
 
-This example is mainly supposed to highlight the flexibility of the `serde_as`-annotation compared to [serde's with-annotation][with-annotation].
+This example is mainly supposed to highlight the flexibility of the `serde_as` annotation compared to [serde's `with` annotation][with-annotation].
 More details about `serde_as` can be found in the [user guide].
 
 ```rust
@@ -207,6 +207,6 @@ For detailed contribution instructions please read [`CONTRIBUTING.md`].
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall
-be dual licensed as above, without any additional terms or conditions.
+be dual-licensed as above, without any additional terms or conditions.
 
 [`CONTRIBUTING.md`]: https://github.com/jonasbb/serde_with/blob/master/CONTRIBUTING.md

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Generalize some trait bounds for `DeserializeAs` implementations
 
-    While working on #637 it came to light that some of the macros for generating `DeserializeAs` implementations were not as generic as they could.
+    While working on #637, it came to light that some macros for generating `DeserializeAs` implementations were not as generic as they could.
     This means they didn't work with custom hasher types, but only the default hashers.
     This has now been fixed and custom hashers should work better, as long as they implement `BuildHasher + Default`.
 
@@ -168,9 +168,9 @@ It only affects custom character sets used for base64 of which there are no inst
 
 * Undo the changes to the trait bound for `Seq`. (#570, #571)
     The new implementation caused issues with serialization formats that require the sequence length beforehand.
-    It also caused problems, that certain attributes which worked before no longer worked, due to mismatching number of references.
+    It also caused problems such as that certain attributes which worked before no longer worked, due to a mismatching number of references.
 
-    Thanks to  @stefunctional for reporting and for @stephaneyfx for providing a test case.
+    Thanks to @stefunctional for reporting and for @stephaneyfx for providing a test case.
 
 ## [2.3.0] - 2023-03-09
 
@@ -234,7 +234,7 @@ It only affects custom character sets used for base64 of which there are no inst
 ### Changed
 
 * Pin the `serde_with_macros` dependency to the same version as the main crate.
-    This simplifies publishing and ensures that always a compatible version is picked.
+    This simplifies publishing and ensures a compatible version is always picked.
 
 ### Fixed
 
@@ -317,7 +317,7 @@ However, tools consuming `Cargo.lock` or `cargo metadata` might give wrong resul
 ### Added
 
 * Make `JsonString<T>` smarter by allowing nesting `serde_as` definitions.
-    This allows applying custom serialization logic, before the value gets converted into a JSON string.
+    This allows applying custom serialization logic before the value gets converted into a JSON string.
 
     ```rust
     // Rust
@@ -355,7 +355,7 @@ However, tools consuming `Cargo.lock` or `cargo metadata` might give wrong resul
 
 ### Removed
 
-* Remove old module based conversions.
+* Remove old module-based conversions.
 
     The newer `serde_as` based conversions are preferred.
 
@@ -424,7 +424,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 
 ### Removed
 
-* Remove old module based conversions.
+* Remove old module-based conversions.
 
     The newer `serde_as` based conversions are preferred.
 
@@ -694,7 +694,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
     cow_array: Cow<'a, [u8; 15]>,
     ```
 
-    Note: For borrowed arrays the used Deserializer needs to support Serde's 0-copy deserialization.
+    Note: For borrowed arrays, the used Deserializer needs to support Serde's 0-copy deserialization.
 
 ## [1.9.2] - 2021-06-07
 
@@ -828,7 +828,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 [serde-big-array-copy]: https://github.com/est31/serde-big-array/issues/6
 [serde-big-array-nested]: https://github.com/est31/serde-big-array/issues/7
 
-* Arrays with tuple elements can now be deserialized from  a map. ([#272])
+* Arrays with tuple elements can now be deserialized from a map. ([#272])
     This feature requires Rust 1.51+.
 
     ```rust
@@ -906,7 +906,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 ### Changed
 
 * Release `Sized` trait bound from `As`, `Same`, `SerializeAs`, and `SerializeAsWrap`.
-    Only the serialize part is relaxed.
+    Only the `serialize` part is relaxed.
 
 ## [1.6.0] - 2020-11-22
 
@@ -935,16 +935,16 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 ### Added
 
 * The largest addition to this release is the addition of the `serde_as` de/serialization scheme.
-    It's goal is it to be a more flexible replacement to serde's with-annotation, by being more composable than before.
+    Its goal is to be a more flexible replacement to serde's `with` annotation, by being more composable than before.
     No longer is it a problem to add a custom de/serialization adapter is the type is within an `Option` or a `Vec`.
 
     Thanks to `@markazmierczak` for the design of the trait without whom this wouldn't be possible.
 
     More details about this new scheme can be found in the also new [user guide](https://docs.rs/serde_with/1.5.0/serde_with/guide/index.html)
 * This release also features a detailed user guide.
-    The guide focusses more on how to use this crate by providing examples.
+    The guide focuses more on how to use this crate by providing examples.
     For example, it includes a section about the available feature flags of this crate and how you can migrate to the shiny new `serde_as` scheme.
-* The crate now features de/serialization adaptors for the std and chrono's `Duration` types. #56 #104
+* The crate now features de/serialization adaptors for the std and `chrono` `Duration` types. #56 #104
 * Add a `hex` module, which allows formatting bytes (i.e. `Vec<u8>`) as a hexadecimal string.
     The formatting supports different arguments how the formatting is happening.
 * Add two derive macros, `SerializeDisplay` and `DeserializeFromStr`, which implement the `Serialize`/`Deserialize` traits based on `Display` and `FromStr`.
@@ -956,11 +956,11 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
     The functions simply pass through to the underlying `Serialize` implementation.
     This affects `sets_duplicate_value_is_error`, `maps_duplicate_key_is_error`, `maps_first_key_wins`, `default_on_error`, and `default_on_null`.
 * Added `sets_last_value_wins` as a replacement for `sets_first_value_wins` which is deprecated now.
-    The default behavior of serde is to prefer the first value of a set so the opposite is taking the last value.
+    The default behavior of serde is to prefer the first value of a set, so the opposite is taking the last value.
 * Added `#[serde_as]` compatible conversion methods for serializing durations and timestamps as numbers.
-    The four types `DurationSeconds`, `DurationSecondsWithFrac`, `TimestampSeconds`, `TimestampSecondsWithFrac` provide the serialization conversion with optional subsecond precision.
+    The four types `DurationSeconds`, `DurationSecondsWithFrac`, `TimestampSeconds`, `TimestampSecondsWithFrac` provide the serialization conversion with optional sub-second precision.
     There is support for `std::time::Duration`, `chrono::Duration`, `std::time::SystemTime` and `chrono::DateTime`.
-    Timestamps are serialized as a duration since the UNIX epoch.
+    Timestamps are serialized as durations since the UNIX epoch.
     The serialization can be customized.
     It supports multiple formats, such as `i64`, `f64`, or `String`, and the deserialization can be tweaked if it should be strict or lenient when accepting formats.
 
@@ -1001,16 +1001,16 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 ### Added
 
 * The largest addition to this release is the addition of the `serde_as` de/serialization scheme.
-    It's goal is it to be a more flexible replacement to serde's with-annotation, by being more composable than before.
+    Its goal is to be a more flexible replacement to serde's with annotation, by being more composable than before.
     No longer is it a problem to add a custom de/serialization adapter is the type is within an `Option` or a `Vec`.
 
     Thanks to `@markazmierczak` for the design of the trait without whom this wouldn't be possible.
 
     More details about this new scheme can be found in the also new [user guide](https://docs.rs/serde_with/1.5.0-alpha.1/serde_with/guide/index.html)
 * This release also features a detailed user guide.
-    The guide focusses more on how to use this crate by providing examples.
+    The guide focuses more on how to use this crate by providing examples.
     For example, it includes a section about the available feature flags of this crate and how you can migrate to the shiny new `serde_as` scheme.
-* The crate now features de/serialization adaptors for the std and chrono's `Duration` types. #56 #104
+* The crate now features de/serialization adaptors for the std and `chrono`'s `Duration` types. #56 #104
 
 ### Changed
 
@@ -1033,7 +1033,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 
 * Bump minimal Rust version to 1.36.0
     * Supports Rust Edition 2018
-    * version-sync depends on smallvec which requires 1.36
+    * version-sync depends on smallvec, which requires 1.36
 * Improved CI pipeline by running `cargo audit` and `tarpaulin` in all configurations now.
 
 ## [1.3.1] - 2019-04-09
@@ -1066,7 +1066,7 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 
 ### Added
 
-* Serialize HashMap/BTreeMap as list of tuples
+* Serialize HashMap/BTreeMap as a list of tuples
 
 ## [1.0.0] - 2019-01-17
 
@@ -1107,8 +1107,8 @@ A diff of the lock-file makes it seem that `serde_with` depends on new crates, e
 * Add deserialization helper for sets and maps, inspired by [comment](https://github.com/serde-rs/serde/issues/553#issuecomment-299711855)
     * Create an error if duplicate values for a set are detected
     * Create an error if duplicate keys for a map are detected
-    * Implement a first-value wins strategy for sets/maps. This is different to serde's default
-        which implements a last value wins strategy.
+    * Implement a "first value wins" strategy for sets/maps.
+      This is different to serde's default, which implements a "last value wins" strategy.
 
 ## [0.2.1] - 2018-06-05
 

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -53,8 +53,8 @@ guide = ["dep:doc-comment", "dep:document-features", "macros", "std"]
 
 #! # Features
 #!
-#! The following features enable support for types from other crates or enable additional functionality, that requires further dependencies to be pulled in.
-#! These features are disabled by default to minimize the amount of required dependencies.
+#! The following features enable support for types from other crates or enable additional functionality that requires further dependencies to be pulled in.
+#! These features are disabled by default to minimize the number of required dependencies.
 
 ## The feature enables serializing data in base64 format.
 base64 = ["dep:base64", "alloc"]
@@ -119,7 +119,7 @@ schemars_0_8 = ["dep:schemars_0_8", "std", "serde_with_macros?/schemars_0_8"]
 ## Some functionality is only available when `alloc` or `std` is enabled too.
 time_0_3 = ["dep:time_0_3"]
 
-# When adding new optional dependencies update the documentation in feature-flags.md
+# When adding new optional dependencies, update the documentation in feature-flags.md
 [dependencies]
 base64 = {version = "0.21.0", optional = true, default-features = false}
 chrono_0_4 = {package = "chrono", version = "0.4.20", optional = true, default-features = false, features = ["serde"]}

--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -28,7 +28,7 @@ fn unix_epoch_naive() -> NaiveDateTime {
     NaiveDateTime::from_timestamp_opt(0, 0).unwrap()
 }
 
-/// Deserialize a Unix timestamp with optional subsecond precision into a `DateTime<Utc>`.
+/// Deserialize a Unix timestamp with optional sub-second precision into a `DateTime<Utc>`.
 ///
 /// The `DateTime<Utc>` can be serialized from an integer, a float, or a string representing a number.
 ///

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -145,7 +145,7 @@ where
 impl<T: ?Sized> As<T> {
     /// Deserialize type `T` using [`DeserializeAs`][]
     ///
-    /// The function signature is compatible with [serde's with-annotation][with-annotation].
+    /// The function signature is compatible with [serde's `with` annotation][with-annotation].
     ///
     /// [with-annotation]: https://serde.rs/field-attrs.html#with
     pub fn deserialize<'de, D, I>(deserializer: D) -> Result<I, D::Error>

--- a/serde_with/src/guide.md
+++ b/serde_with/src/guide.md
@@ -8,10 +8,10 @@ For example, you can serialize [a map as a sequence of tuples][crate::guide::ser
 
 The crate offers four types of functionality.
 
-## 1. A more flexible and composable replacement for the with annotation, called `serde_as`
+## 1. A more flexible and composable replacement for the `with` annotation, called `serde_as`
 
-This is an alternative to [serde's with-annotation][with-annotation], which adds flexibility and composability to the scheme.
-The main downside is that it works with fewer types than [with-annotations][with-annotation].
+This is an alternative to [serde's `with` annotation][with-annotation], which adds flexibility and composability to the scheme.
+The main downside is that it works with fewer types than [`with` annotations][with-annotation].
 However, all types from the Rust Standard Library should be supported in all combinations and any missing entry is a bug.
 
 You mirror the type structure of the field you want to de/serialize.

--- a/serde_with/src/guide/serde_as.md
+++ b/serde_with/src/guide/serde_as.md
@@ -1,7 +1,7 @@
 # `serde_as` Annotation
 
-This is an alternative to serde's with-annotation.
-It is more flexible and composable, but work with fewer types.
+This is an alternative to serde's `with` annotation.
+It is more flexible and composable, but works with fewer types.
 
 The scheme is based on two new traits, [`SerializeAs`] and [`DeserializeAs`], which need to be implemented by all types which want to be compatible with `serde_as`.
 The proc-macro attribute [`#[serde_as]`][crate::serde_as] exists as a usability boost for users.
@@ -52,7 +52,7 @@ struct A {
 }
 ```
 
-The main advantage is that you can compose `serde_as` stuff, which is impossible with the with-annotation.
+The main advantage is that you can compose `serde_as` stuff, which is impossible with the `with` annotation.
 For example, the `mime` field from above could be nested in one or more data structures:
 
 ```rust
@@ -106,7 +106,7 @@ Gating `serde_as` behind optional features is possible using the `cfg_eval` attr
 The attribute is available via the [`cfg_eval`-crate](https://docs.rs/cfg_eval) on stable or using the [Rust attribute](https://doc.rust-lang.org/1.70.0/core/prelude/v1/attr.cfg_eval.html) on unstable nightly.
 
 The `cfg_eval` attribute must be placed **before** the struct-level `serde_as` attribute.
-You can combine them together in a single `cfg_attr`, as long as the order is preserved.
+You can combine them in a single `cfg_attr`, as long as the order is preserved.
 
 ```rust,ignore
 #[cfg_attr(feature="serde", cfg_eval::cfg_eval, serde_as)]
@@ -121,8 +121,8 @@ struct Struct {
 
 You can support [`SerializeAs`] / [`DeserializeAs`] on your own types too.
 Most "leaf" types do not need to implement these traits, since they are supported implicitly.
-"Leaf" type refers to types which directly serialize like plain data types.
-[`SerializeAs`] / [`DeserializeAs`] is very important for collection types, like `Vec` or `BTreeMap`, since they need special handling for the key/value de/serialization such that the conversions can be done on the key/values.
+"Leaf" types refer to types which directly serialize, like plain data types.
+[`SerializeAs`] / [`DeserializeAs`] is essential for collection types, like `Vec` or `BTreeMap`, since they need special handling for the key/value de/serialization such that the conversions can be done on the key/values.
 You also find them implemented on the conversion types, such as the [`DisplayFromStr`] type.
 These comprise the bulk of this crate and allow you to perform all the nice conversions to [hex strings], the [bytes to string converter], or [duration to UNIX epoch].
 
@@ -182,8 +182,8 @@ impl<'de> DeserializeAs<'de, RemoteType> for LocalType {
 # }
 ```
 
-This is how the final implementation looks like.
-We assumed we have a module `MODULE` with a `serialize` function already, which we use here to provide the implementation.
+This is what the final implementation looks like.
+We assumed we already have a module `MODULE` with a `serialize` function, which we use here to provide the implementation.
 As can be seen, this is mostly boilerplate, since the most part is encapsulated in `$module::serialize`.
 The final `Data` struct will now look like:
 

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -160,7 +160,7 @@ null => 0
 
 [`VecSkipError`]
 
-For formats with heterogenous-typed sequences, we can collect only the deserializable elements.
+For formats with heterogeneously typed sequences, we can collect only the deserializable elements.
 This is also useful for unknown enum variants.
 
 ```ignore
@@ -212,7 +212,7 @@ value: Duration,
 "value": 86400,
 ```
 
-[`DurationSecondsWithFrac`] supports subsecond precision:
+[`DurationSecondsWithFrac`] supports sub-second precision:
 
 ```ignore
 // Rust
@@ -382,7 +382,7 @@ value: Vec<String>,
 [`SetLastValueWins`]
 
 serdes default behavior for sets is to take the first value, when multiple "equal" values are inserted into a set.
-This changes the logic, to prefer the last value.
+This changes the logic to prefer the last value.
 
 ## Pick first successful deserialization
 
@@ -405,7 +405,7 @@ value: u32,
 
 [`MapFirstKeyWins`]
 
-serdes default behavior is to take the last key and value combination, if multiple "equal" keys exist.
+Serde's default behavior is to take the last key-value combination, if multiple "equal" keys exist.
 This changes the logic to instead prefer the first found key-value combination.
 
 ## Prevent duplicate map keys
@@ -466,7 +466,7 @@ value: SystemTime,
 "value": 86400,
 ```
 
-[`TimestampSecondsWithFrac`] supports subsecond precision:
+[`TimestampSecondsWithFrac`] supports sub-second precision:
 
 ```ignore
 // Rust

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ---
 //!
-//! This crate provides custom de/serialization helpers to use in combination with [serde's with-annotation][with-annotation] and with the improved [`serde_as`][as-annotation]-annotation.
+//! This crate provides custom de/serialization helpers to use in combination with [serde's `with` annotation][with-annotation] and with the improved [`serde_as`][as-annotation]-annotation.
 //! Some common use cases are:
 //!
 //! * De/Serializing a type using the `Display` and `FromStr` traits, e.g., for `u8`, `url::Url`, or `mime::Mime`.
@@ -187,7 +187,7 @@
 //!
 //! ## Advanced `serde_as` usage
 //!
-//! This example is mainly supposed to highlight the flexibility of the `serde_as`-annotation compared to [serde's with-annotation][with-annotation].
+//! This example is mainly supposed to highlight the flexibility of the `serde_as` annotation compared to [serde's `with` annotation][with-annotation].
 //! More details about `serde_as` can be found in the [user guide].
 //!
 //! ```rust
@@ -439,8 +439,8 @@ pub use serde_with_macros::*;
 
 /// Adapter to convert from `serde_as` to the serde traits.
 ///
-/// The `As` type adapter allows using types which implement [`DeserializeAs`] or [`SerializeAs`] in place of serde's with-annotation.
-/// The with-annotation allows running custom code when de/serializing, however it is quite inflexible.
+/// The `As` type adapter allows using types which implement [`DeserializeAs`] or [`SerializeAs`] in place of serde's `with` annotation.
+/// The `with` annotation allows running custom code when de/serializing, however it is quite inflexible.
 /// The traits [`DeserializeAs`]/[`SerializeAs`] are more flexible, as they allow composition and nesting of types to create more complex de/serialization behavior.
 /// However, they are not directly compatible with serde, as they are not provided by serde.
 /// The `As` type adapter makes them compatible, by forwarding the function calls to `serialize`/`deserialize` to the corresponding functions `serialize_as` and `deserialize_as`.
@@ -817,8 +817,8 @@ pub struct BytesOrString;
 
 /// De/Serialize Durations as number of seconds.
 ///
-/// De/serialize durations as number of seconds with subsecond precision.
-/// Subsecond precision is *only* supported for [`DurationSecondsWithFrac`], but not for [`DurationSeconds`].
+/// De/serialize durations as number of seconds with sub-second precision.
+/// Sub-second precision is *only* supported for [`DurationSecondsWithFrac`], but not for [`DurationSeconds`].
 /// You can configure the serialization format between integers, floats, and stringified numbers with the `FORMAT` specifier and configure the deserialization with the `STRICTNESS` specifier.
 ///
 /// The `STRICTNESS` specifier can either be [`formats::Strict`] or [`formats::Flexible`] and defaults to [`formats::Strict`].
@@ -1490,7 +1490,7 @@ pub struct TimestampNanoSecondsWithFrac<
 /// Serialization of byte sequences like `&[u8]` or `Vec<u8>` is quite inefficient since each value will be serialized individually.
 /// This converter type optimizes the serialization and deserialization.
 ///
-/// This is a port of the [`serde_bytes`] crate making it compatible with the `serde_as`-annotation, which allows it to be used in more cases than provided by [`serde_bytes`].
+/// This is a port of the [`serde_bytes`] crate making it compatible with the `serde_as` annotation, which allows it to be used in more cases than provided by [`serde_bytes`].
 ///
 /// The type provides de/serialization for these types:
 ///

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -107,7 +107,7 @@ pub trait JsonSchemaAs<T: ?Sized> {
 
     /// The name of the generated JSON Schema.
     ///
-    /// This is used as the title for root schemas, and the key within the root's `definitions` property for subschemas.
+    /// This is used as the title for root schemas, and the key within the root's `definitions` property for sub-schemas.
     fn schema_name() -> String;
 
     /// Returns a string that uniquely identifies the schema produced by this type.
@@ -530,7 +530,7 @@ where
         std::format!("serde_with::EnumMap<{}>", T::schema_id()).into()
     }
 
-    // We generate the shcema here by going through all the variants of the
+    // We generate the schema here by going through all the variants of the
     // enum (the oneOf property) and sticking all their properties onto an
     // object.
     //

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -159,7 +159,7 @@ where
 impl<T: ?Sized> As<T> {
     /// Serialize type `T` using [`SerializeAs`][]
     ///
-    /// The function signature is compatible with [serde's with-annotation][with-annotation].
+    /// The function signature is compatible with [serde's `with` annotation][with-annotation].
     ///
     /// [with-annotation]: https://serde.rs/field-attrs.html#with
     pub fn serialize<S, I>(value: &I, serializer: S) -> Result<S::Ok, S::Error>

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -320,7 +320,7 @@ where
     Ok(unix_epoch_primitive() + duration_from_duration_signed::<D>(dur)?)
 }
 
-// No subsecond precision
+// No sub-second precision
 use_duration_signed_de!(
     DurationSeconds DurationSeconds,
     DurationMilliSeconds DurationMilliSeconds,

--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -43,7 +43,7 @@ fn json_datetime_from_any_to_string_deserialization() {
         ]"#,
     );
 
-    // floats, shows precision errors in subsecond part
+    // floats, shows precision errors in sub-second part
     check_deserialization(
         vec![
             S(new_datetime(1_478_563_200, 122_999_906)),

--- a/serde_with/tests/serde_as/map_tuple_list.rs
+++ b/serde_with/tests/serde_as/map_tuple_list.rs
@@ -320,7 +320,7 @@ fn test_tuple_array_as_map() {
     );
 }
 
-// Test that the `Seq` conversion works when the inner type is explicity specified.
+// Test that the `Seq` conversion works when the inner type is explicitly specified.
 #[test]
 fn test_map_as_tuple_with_nested_complex_type() {
     #[serde_as]

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -98,7 +98,7 @@ No changes.
     }
     ```
 
-    The `apply` attribute will expand into this, applying the attributs to the matching fields:
+    The `apply` attribute will expand into this, applying the attributes to the matching fields:
 
     ```rust
     #[derive(serde::Serialize)]
@@ -155,7 +155,7 @@ No changes compared to v2.0.0-rc.0.
     * `core::option::Option`, with or without leading `::`
 
     If an existing `default` attribute is detected, the attribute is not applied again.
-    This behavior can be supressed by using `#[serde_as(no_default)]` or `#[serde_as(as = "Option<S>", no_default)]`.
+    This behavior can be suppressed by using `#[serde_as(no_default)]` or `#[serde_as(as = "Option<S>", no_default)]`.
 
 ### Fixed
 
@@ -178,7 +178,7 @@ No changes compared to v2.0.0-rc.0.
     * `core::option::Option`, with or without leading `::`
 
     If an existing `default` attribute is detected, the attribute is not applied again.
-    This behavior can be supressed by using `#[serde_as(no_default)]` or `#[serde_as(as = "Option<S>", no_default)]`.
+    This behavior can be suppressed by using `#[serde_as(no_default)]` or `#[serde_as(as = "Option<S>", no_default)]`.
 
 ### Fixed
 
@@ -235,7 +235,7 @@ No changes compared to v2.0.0-rc.0.
 
     This should have no effect on the generated code and on the runtime behavior.
     It eases integration of third-party crates with `serde_with`, since they can now process the `#[serde_as(...)]` field attributes reliably.
-    Before this was impossible for derive macros and lead to awkward ordering constraints on the attribute macros.
+    Before this, it was impossible for derive macros and lead to awkward ordering constraints on the attribute macros.
 
     Thanks to @Lehona for reporting this problem and to @dtolnay for suggesting the dummy derive macro.
 
@@ -267,7 +267,7 @@ No changes compared to v2.0.0-rc.0.
     This solves conflicts with `Result` if `Result` is not `std::result::Result`, e.g., a type alias.
     Additionally, the code assumed that `FromStr` was in scope, which is now also not required.
 
-    Thanks goes to @adwhit for reporting and fixing the problem in #186.
+    Thanks to @adwhit for reporting and fixing the problem in #186.
 
 ## [1.2.0] - 2020-10-01
 
@@ -275,7 +275,7 @@ No changes compared to v2.0.0-rc.0.
 
 * Add `serde_as` macro. Refer to the `serde_with` crate for details.
 * Add two derive macros, `SerializeDisplay` and `DeserializeFromStr`, which implement the `Serialize`/`Deserialize` traits based on `Display` and `FromStr`.
-    This is in addition to the already existing methods like `DisplayFromStr`, which act locally, whereas the derive macros provide the traits expected by the rest of the ecosystem.
+  This is in addition to the pre-existing methods like `DisplayFromStr`, which act locally, whereas the derive macros provide the traits expected by the rest of the ecosystem.
 
 ### Changed
 
@@ -290,7 +290,7 @@ No changes compared to v2.0.0-rc.0.
 ### Added
 
 * Add two derive macros, `SerializeDisplay` and `DeserializeFromStr`, which implement the `Serialize`/`Deserialize` traits based on `Display` and `FromStr`.
-    This is in addition to the already existing methods like `DisplayFromStr`, which act locally, whereas the derive macros provide the traits expected by the rest of the ecosystem.
+  This is in addition to the pre-existing methods like `DisplayFromStr`, which act locally, whereas the derive macros provide the traits expected by the rest of the ecosystem.
 
 ## [1.2.0-alpha.2] - 2020-08-08
 

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1,4 +1,4 @@
-// Cleanup when workspace lints can be overriden
+// Cleanup when workspace lints can be overridden
 // https://github.com/rust-lang/cargo/issues/13157
 #![forbid(unsafe_code)]
 #![warn(missing_copy_implementations, missing_debug_implementations)]
@@ -447,7 +447,7 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 
 /// Convenience macro to use the [`serde_as`] system.
 ///
-/// The [`serde_as`] system is designed as a more flexible alternative to serde's with-annotation.
+/// The [`serde_as`] system is designed as a more flexible alternative to serde's `with` annotation.
 /// The `#[serde_as]` attribute must be placed *before* the `#[derive]` attribute.
 /// Each field of a struct or enum can be annotated with `#[serde_as(...)]` to specify which
 /// transformations should be applied. `serde_as` is *not* supported on enum variants.

--- a/serde_with_macros/tests/compile-fail/serde_as.rs
+++ b/serde_with_macros/tests/compile-fail/serde_as.rs
@@ -13,7 +13,7 @@ struct ConflictingAsAnnotations {
     c: u32,
 }
 
-/// Test error message for conflicts with serde's with-annotation
+/// Test error message for conflicts with serde's `with` annotation
 #[serde_as]
 #[derive(Serialize)]
 struct ConflictingWithAnnotations {


### PR DESCRIPTION
This PR just fixes a bunch of small typos and grammatical issues – no functional changes. Thank you for the work on this library!