### PR TITLE
Implement JsonSchemaAs for KeyValueMap

### DIFF
--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -1,6 +1,6 @@
 use crate::utils::{check_matches_schema, check_valid_json_schema};
-use ::schemars_0_8::JsonSchema;
 use expect_test::expect_file;
+use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
 use serde_with::*;
@@ -222,6 +222,33 @@ mod snapshots {
         C { c: i32, b: Option<u64> },
     }
 
+    #[derive(JsonSchema, Serialize)]
+    struct KvMapData {
+        #[serde(rename = "$key$")]
+        key: String,
+
+        a: u32,
+        b: String,
+        c: f32,
+        d: bool,
+    }
+
+    #[allow(dead_code, variant_size_differences)]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(tag = "$key$")]
+    enum KvMapEnum {
+        TypeA { a: u32 },
+        TypeB { b: String },
+        TypeC { c: bool },
+    }
+
+    #[derive(JsonSchema, Serialize)]
+    struct KvMapFlatten {
+        #[serde(flatten)]
+        data: KvMapEnum,
+        extra: bool,
+    }
+
     declare_snapshot_test! {
         bytes {
             struct Test {
@@ -302,6 +329,27 @@ mod snapshots {
             struct Test {
                 #[serde_as(as = "EnumMap")]
                 data: Vec<Mappable>,
+            }
+        }
+
+        key_value_map {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapData>,
+            }
+        }
+
+        key_value_map_enum {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapEnum>,
+            }
+        }
+
+        key_value_map_flatten {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapFlatten>,
             }
         }
     }
@@ -732,4 +780,80 @@ fn test_set_prevent_duplicates_with_duplicates() {
     check_matches_schema::<Test>(&json!({
         "set": [ 1, 1 ]
     }));
+}
+
+mod key_value_map {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[serde_as]
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct KVMap<E>(
+        #[serde_as(as = "KeyValueMap<_>")]
+        #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+        Vec<E>,
+    );
+
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(untagged)]
+    enum UntaggedEnum {
+        A {
+            #[serde(rename = "$key$")]
+            key: String,
+            field1: String,
+        },
+        B(String, i32),
+    }
+
+    #[test]
+    fn test_untagged_enum() {
+        let value = KVMap(vec![
+            UntaggedEnum::A {
+                key: "v1".into(),
+                field1: "field".into(),
+            },
+            UntaggedEnum::B("v2".into(), 7),
+        ]);
+
+        check_valid_json_schema(&value);
+    }
+
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(untagged)]
+    enum UntaggedNestedEnum {
+        Nested(UntaggedEnum),
+        C {
+            #[serde(rename = "$key$")]
+            key: String,
+            field2: i32,
+        },
+    }
+
+    #[test]
+    fn test_untagged_nested_enum() {
+        let value = KVMap(vec![
+            UntaggedNestedEnum::Nested(UntaggedEnum::A {
+                key: "v1".into(),
+                field1: "field".into(),
+            }),
+            UntaggedNestedEnum::Nested(UntaggedEnum::B("v2".into(), 7)),
+            UntaggedNestedEnum::C {
+                key: "v2".into(),
+                field2: 222,
+            },
+        ]);
+
+        check_valid_json_schema(&value);
+    }
+
+    #[test]
+    fn test_btreemap() {
+        let value = KVMap(vec![
+            BTreeMap::from_iter([("$key$", "a"), ("value", "b")]),
+            BTreeMap::from_iter([("$key$", "b"), ("value", "d")]),
+        ]);
+
+        check_valid_json_schema(&value);
+    }
 }

--- a/serde_with/tests/schemars_0_8/snapshots/key_value_map.json
+++ b/serde_with/tests/schemars_0_8/snapshots/key_value_map.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/KeyValueMap<KvMapData>"
+    }
+  },
+  "definitions": {
+    "KeyValueMap<KvMapData>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ],
+        "properties": {
+          "a": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "b": {
+            "type": "string"
+          },
+          "c": {
+            "type": "number",
+            "format": "float"
+          },
+          "d": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_8/snapshots/key_value_map_enum.json
+++ b/serde_with/tests/schemars_0_8/snapshots/key_value_map_enum.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/KeyValueMap<KvMapEnum>"
+    }
+  },
+  "definitions": {
+    "KeyValueMap<KvMapEnum>": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "a"
+            ],
+            "properties": {
+              "a": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "b"
+            ],
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "c"
+            ],
+            "properties": {
+              "c": {
+                "type": "boolean"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_8/snapshots/key_value_map_flatten.json
+++ b/serde_with/tests/schemars_0_8/snapshots/key_value_map_flatten.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/KeyValueMap<KvMapFlatten>"
+    }
+  },
+  "definitions": {
+    "KeyValueMap<KvMapFlatten>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "a"
+            ],
+            "properties": {
+              "a": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "b"
+            ],
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "c"
+            ],
+            "properties": {
+              "c": {
+                "type": "boolean"
+              }
+            }
+          }
+        ],
+        "required": [
+          "extra"
+        ],
+        "properties": {
+          "extra": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm back with yet another PR! This time we're doing `KeyValueMap`.

I think this one is probably the most complicated conversion that needs to be done to make the schema work. We need to convert a schema that looks like this
```json
{
  "type": "object",
  "properties": {
    "$key$": "...",
    "a": "...",
  },
  "required": ["$key$", "a"]
}
```
into this
```json
{
  "type": "object",
  "additionalProperties": {
    "type": "object",
    "required": ["a"],
    "properties": { "a": "..." }
  }
}
```

On its own that is not to bad but it gets more complicated since we also have to deal subschemas which can be generated from types that make use of `#[serde(untagged)]` and `#[serde(flatten)]`. See the doc comment on `kvmap_transform_schema` for more details.

# Notes
- I'm not entirely sure this is correct in the presence of an [`anyOf`](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.2) subschema that makes use of `minProperties` and `maxProperties` (normal ones where they have a `$key$` field should work fine). I'm not entirely sure there is one correct behaviour in the case either but to me this seems like a edge case that is pretty far out there so it should be fine.
- It also isn't correct if the `$key$` property ends up being defined in some external schema (i.e. `$ref` points to some random document on the internet). This seems like an edge case and I don't think there's any reasonable behaviour here anyway.