### PR TITLE
Add `#[doc(cfg(..))]` annotation to the schemars_0_8 module

### DIFF
--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -313,6 +313,7 @@ pub mod json;
 mod key_value_map;
 pub mod rust;
 #[cfg(feature = "schemars_0_8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "schemars_0_8")))]
 pub mod schemars_0_8;
 pub mod ser;
 #[cfg(feature = "std")]


### PR DESCRIPTION
It looks like I missed this during my first PR. Since the other modules already have this it is confusing that it is missing.