### PR TITLE
Avoid emitting `with` when there's already a `schema_with` annotation

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Implement `JsonSchemaAs` for `EnumMap` by @swlynch99 (#697)
 
+### Fixed
+
+* Detect conflicting `schema_with` attributes on fields with `schemars` annotations by @swlynch99 (#715)
+    This extends the existing avoidance mechanism to a new variant fixing #712.
+
 ## [3.6.1] - 2024-02-08
 
 ### Changed

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -117,6 +117,41 @@ fn schemars_custom_with() {
     }));
 }
 
+#[test]
+fn schemars_custom_schema_with() {
+    fn custom_int(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Integer.into()),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct Test {
+        #[serde_as(as = "DisplayFromStr")]
+        #[schemars(schema_with = "custom_int")]
+        custom: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(any(), schemars(schema_with = "custom_int"))]
+        with_disabled: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(all(), schemars(schema_with = "custom_int"))]
+        always_enabled: i32,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "custom": 3,
+        "with_disabled": "5",
+        "always_enabled": 7,
+    }));
+}
+
 mod test_std {
     use super::*;
     use std::collections::{BTreeMap, VecDeque};

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Detect conflicting `schema_with` attributes on fields with `schemars` annotations by @swlynch99 (#715)
+    This extends the existing avoidance mechanism to a new variant fixing #712.
+
 ## [3.6.1] - 2024-02-08
 
 No changes.

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -771,7 +771,7 @@ fn serde_as_add_attr_to_field(
         if let Some(cfg) = schemars_config.cfg_expr() {
             let with_cfg = utils::schemars_with_attr_if(
                 &field.attrs,
-                &["with", "serialize_with", "deserialize_with"],
+                &["with", "serialize_with", "deserialize_with", "schema_with"],
             )?;
             let attr_inner_tokens =
                 quote!(#serde_with_crate_path::Schema::<#type_original, #replacement_type>)
@@ -796,8 +796,10 @@ fn serde_as_add_attr_to_field(
         field.attrs.push(attr);
 
         if let Some(cfg) = schemars_config.cfg_expr() {
-            let with_cfg =
-                utils::schemars_with_attr_if(&field.attrs, &["with", "deserialize_with"])?;
+            let with_cfg = utils::schemars_with_attr_if(
+                &field.attrs,
+                &["with", "deserialize_with", "schema_with"],
+            )?;
             let attr_inner_tokens =
                 quote!(#serde_with_crate_path::Schema::<#type_original, #replacement_type>::deserialize)
                     .to_string();
@@ -818,7 +820,10 @@ fn serde_as_add_attr_to_field(
         field.attrs.push(attr);
 
         if let Some(cfg) = schemars_config.cfg_expr() {
-            let with_cfg = utils::schemars_with_attr_if(&field.attrs, &["with", "serialize_with"])?;
+            let with_cfg = utils::schemars_with_attr_if(
+                &field.attrs,
+                &["with", "serialize_with", "schema_with"],
+            )?;
             let attr_inner_tokens =
                 quote!(#serde_with_crate_path::Schema::<#type_original, #replacement_type>::serialize)
                     .to_string();


### PR DESCRIPTION
I spotted #712 and since I had finally gotten around to making another set of PRs I figured I might as well submit a fix.

This treats a `#[schemars(schema_with = "...")]` attribute the same as a `#[schemars(with = "...")]` attribute when deciding whether to emit our own.

There is also a new test case that validates that everything works as expected.

Fixes #712