### PR TITLE
Add `JsonSchemaAs` impl for `IfIsHumanReadable`

### DIFF
--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -492,6 +492,15 @@ impl<T, U: JsonSchema> JsonSchemaAs<T> for TryFromIntoRef<U> {
     forward_schema!(U);
 }
 
+impl<T, TA, FA> JsonSchemaAs<T> for IfIsHumanReadable<TA, FA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    // serde_json always has `is_human_readable` set to true so we just use the
+    // schema for the human readable variant.
+    forward_schema!(WrapSchema<T, TA>);
+}
+
 macro_rules! schema_for_map {
     ($type:ty) => {
         impl<K, V, KA, VA> JsonSchemaAs<$type> for Map<KA, VA>

--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -706,6 +706,19 @@ fn test_map() {
 }
 
 #[test]
+fn test_if_is_human_readable() {
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "IfIsHumanReadable<DisplayFromStr>")]
+        data: i32,
+    }
+
+    check_valid_json_schema(&Test { data: 5 });
+    check_matches_schema::<Test>(&json!({ "data": "5" }));
+}
+
+#[test]
 fn test_set_last_value_wins_with_duplicates() {
     #[serde_as]
     #[derive(Serialize, JsonSchema)]


### PR DESCRIPTION
It looks like `IfIsHumanReadable` was added after I wrote all the existing impls so here's a bonus PR!

This one is straightforward. `serde_json` always has `is_human_readable` set to true so we use the schema for the human readable variant. I have also included a test to that effect.