### PR TITLE
Implement `JsonSchemaAs` for `OneOrMany`

### DIFF
--- a/serde_with/tests/schemars_0_8/snapshots/one_or_many_prefer_one.json
+++ b/serde_with/tests/schemars_0_8/snapshots/one_or_many_prefer_one.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OneOrMany<int32, PreferOne>",
+  "anyOf": [
+    {
+      "type": "integer",
+      "format": "int32"
+    },
+    {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Here's the next type. This one implements `JsonSchemaAs` for `OneOrMany`. It is fortunately much simpler than `KeyValueMap`.

For `OneOrMany` the transformation we want to do is basically to take this schema
```json
{ "$ref": "..." }
```

and transform it into
```json
{
  "anyOf": [
    { "$ref": "..." },
    {
      "type": "array",
      "items": { "$ref": "..." }
    }
  ]
}
```

that is, we change it so it can take either an array or a single value. The only difference between the `PreferOne` and the `PreferMany` variants is that the inner object is marked as `writeOnly: true`.

I have also included some tests that should cover pretty much everything.
