### PR TITLE
Bump version to 3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "base64 0.21.5",
  "chrono",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "darling",
  "expect-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jonasbb/serde_with/"
 rust-version = "1.65"
-version = "3.6.1"
+version = "3.7.0"
 
 [workspace.metadata.release]
 consolidate-commits = true

--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ Foo::Bytes {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/3.6.1/serde_with/struct.DisplayFromStr.html
-[`with_prefix!`]: https://docs.rs/serde_with/3.6.1/serde_with/macro.with_prefix.html
-[feature flags]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/3.6.1/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/3.6.1/serde_with/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/3.6.1/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/3.7.0/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/3.7.0/serde_with/macro.with_prefix.html
+[feature flags]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/3.7.0/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/3.7.0/serde_with/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/3.7.0/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
-[as-annotation]: https://docs.rs/serde_with/3.6.1/serde_with/guide/serde_as/index.html
+[as-annotation]: https://docs.rs/serde_with/3.7.0/serde_with/guide/serde_as/index.html
 
 ## License
 

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.7.0] - 2024-03-11
+
 ### Added
 
 * Implement `JsonSchemaAs` for `EnumMap` by @swlynch99 (#697)
+* Implement `JsonSchemaAs` for `IfIsHumanReadable` by @swlynch99 (#717)
+* Implement `JsonSchemaAs` for `KeyValueMap` by @swlynch99 (#713)
+* Implement `JsonSchemaAs` for `OneOrMany` by @swlynch99 (#719)
 
 ### Fixed
 

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -133,7 +133,7 @@ schemars_0_8 = {package = "schemars", version = "0.8.16", optional = true, defau
 serde = {version = "1.0.152", default-features = false}
 serde_derive = "1.0.152"
 serde_json = {version = "1.0.45", optional = true, default-features = false}
-serde_with_macros = {path = "../serde_with_macros", version = "=3.6.1", optional = true}
+serde_with_macros = {path = "../serde_with_macros", version = "=3.7.0", optional = true}
 time_0_3 = {package = "time", version = "~0.3.11", optional = true, default-features = false}
 
 [dev-dependencies]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -16,7 +16,7 @@
 )))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/3.6.1/")]
+#![doc(html_root_url = "https://docs.rs/serde_with/3.7.0/")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
@@ -261,14 +261,14 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/3.6.1/serde_with/struct.DisplayFromStr.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/3.6.1/serde_with/macro.with_prefix.html
-//! [feature flags]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/3.6.1/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/3.6.1/serde_with/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/3.6.1/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/3.7.0/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/3.7.0/serde_with/macro.with_prefix.html
+//! [feature flags]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/3.7.0/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/3.7.0/serde_with/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/3.7.0/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
-//! [as-annotation]: https://docs.rs/serde_with/3.6.1/serde_with/guide/serde_as/index.html
+//! [as-annotation]: https://docs.rs/serde_with/3.7.0/serde_with/guide/serde_as/index.html
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -481,7 +481,7 @@ pub use serde_with_macros::*;
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/3.6.1/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/3.7.0/serde_with/attr.serde_as.html
 pub struct As<T: ?Sized>(PhantomData<T>);
 
 /// Adapter to convert from `serde_as` to the serde traits.
@@ -956,7 +956,7 @@ pub struct BytesOrString;
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1088,7 +1088,7 @@ pub struct DurationSeconds<
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1290,7 +1290,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// [`SystemTime`]: std::time::SystemTime
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
-/// [feature flag]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1432,7 +1432,7 @@ pub struct TimestampSeconds<
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
 /// [NaiveDateTime]: ::chrono_0_4::NaiveDateTime
-/// [feature flag]: https://docs.rs/serde_with/3.6.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.7.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.7.0] - 2024-03-11
+
 ### Fixed
 
 * Detect conflicting `schema_with` attributes on fields with `schemars` annotations by @swlynch99 (#715)

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -20,7 +20,7 @@
 )))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/3.6.1/")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/3.7.0/")]
 // Tarpaulin does not work well with proc macros and marks most of the lines as uncovered.
 #![cfg(not(tarpaulin_include))]
 
@@ -589,8 +589,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// It will also work if the relevant derive is behind a `#[cfg_attr]` attribute
 /// and propagate the `#[cfg_attr]` to the various `#[schemars]` field attributes.
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/3.6.1/serde_with/guide/index.html
-/// [re-exporting `serde_as`]: https://docs.rs/serde_with/3.6.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [`serde_as`]: https://docs.rs/serde_with/3.7.0/serde_with/guide/index.html
+/// [re-exporting `serde_as`]: https://docs.rs/serde_with/3.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(FromMeta)]
@@ -1069,7 +1069,7 @@ fn has_type_embedded(type_: &Type, embedded_type: &syn::Ident) -> bool {
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/3.6.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/3.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(DeserializeFromStr, attributes(serde_with))]
 pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
@@ -1189,7 +1189,7 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/3.6.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/3.7.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(SerializeDisplay, attributes(serde_with))]
 pub fn derive_serialize_display(item: TokenStream) -> TokenStream {


### PR DESCRIPTION
This includes many new `JsonSchemaAs` implementations and a fix to the
`serde_as` macro for `schemars` attributes.