### PR TITLE
Implement `JsonSchemaAs` for `PickFirst`

### DIFF
--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -360,6 +360,14 @@ mod snapshots {
                 data: Vec<i32>,
             }
         }
+
+        pickfirst {
+            #[serde(transparent)]
+            struct Test {
+                #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+                value: u32
+            }
+        }
     }
 }
 
@@ -377,6 +385,7 @@ mod derive {
     #[serde_as]
     #[derive(Serialize)]
     #[cfg_attr(any(), derive(JsonSchema))]
+    #[allow(dead_code)]
     struct Disabled {
         // If we are incorrectly adding `#[schemars(with = ...)]` attributes
         // then we should get an error on this field.
@@ -940,4 +949,15 @@ mod one_or_many {
     fn test_prefer_many_no_invalid_type_many() {
         check_matches_schema::<WithPreferMany>(&json!(["test", 1]));
     }
+}
+
+#[test]
+fn test_pickfirst() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct IntOrDisplay(#[serde_as(as = "PickFirst<(_, DisplayFromStr)>")] u32);
+
+    check_matches_schema::<IntOrDisplay>(&json!(7));
+    check_matches_schema::<IntOrDisplay>(&json!("17"));
 }

--- a/serde_with/tests/schemars_0_8/snapshots/pickfirst.json
+++ b/serde_with/tests/schemars_0_8/snapshots/pickfirst.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PickFirst<(uint32String)>",
+  "anyOf": [
+    {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    {
+      "writeOnly": true,
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is the second-to-last type that I've got an implementation queued up for. The only one left after this is `Seq`.

This one is pretty straightforward: we put the involved schemas in an `anyOf` subschema. All the schemas except the first are annotated with `writeOnly: true` to indicate that they are only accepted when deserializing and not emitted when serializing. The one extra detail is that I've used an internal `allOf` in each element so that setting `writeOnly: true` works even if the schema of the type is a reference to an external schema.

I have also included tests and a snapshot test to show that everything works.