### PR TITLE
Remove allows for non_local_definitions

### DIFF
--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc(test(attr(
-    // Problematic handling for foreign From<T> impls in tests
-    // https://github.com/rust-lang/rust/issues/121621
-    allow(unknown_lints, non_local_definitions),
+    // allow(unknown_lints),
     deny(
         missing_debug_implementations,
         rust_2018_idioms,

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -3,9 +3,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_copy_implementations, missing_debug_implementations)]
 #![doc(test(attr(
-    // Problematic handling for foreign From<T> impls in tests
-    // https://github.com/rust-lang/rust/issues/121621
-    allow(unknown_lints, non_local_definitions),
+    // allow(unknown_lints),
     deny(
         missing_debug_implementations,
         rust_2018_idioms,


### PR DESCRIPTION
The implementation was tweaked such that it no longer triggers on the From implementations