### PR TITLE
fix(serde_conv): allow `clippy::ptr_arg`

### DIFF
--- a/serde_with/src/serde_conv.rs
+++ b/serde_with/src/serde_conv.rs
@@ -112,6 +112,7 @@ macro_rules! serde_conv {
 
         const _:() = {
             impl $m {
+                #[allow(clippy::ptr_arg)]
                 $vis fn serialize<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
                 where
                     S: $crate::serde::Serializer,


### PR DESCRIPTION
This is https://github.com/jonasbb/serde_with/pull/320 again after the `allow` was removed in [`f3892d0`](https://github.com/jonasbb/serde_with/commit/f3892d0ec1b34b5abba3600b502bde8845cd5552#diff-985289ef0daa39bc319206d0b482a423b683c49e55d29480f044fff7ec156d5eL114).

This is the offending code that I have:

```rust
serde_with::serde_conv!(
    pub StringAsHtml,
    String,
    |string: &str| html_escape::encode_text(string).into_owned(),
    |html: String| -> Result<_, Infallible> {
        match html_escape::decode_html_entities(&html) {
            Cow::Owned(string) => Ok(string),
            Cow::Borrowed(_) => Ok(html),
        }
    }
);
```

This results in:

```rustc
warning: writing `&String` instead of `&str` involves a new object where a slice will do
   --> serde_with/serde_with/src/serde_conv.rs:116:41
    |
107 |   macro_rules! serde_conv {
    |   ----------------------- in this expansion of `serde_with::serde_conv!`
...
116 |                   $vis fn serialize<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
    |                                           ^^^
    |
   ::: src/serde.rs:31:1
    |
31  | / serde_with::serde_conv!(
32  | |     pub StringAsHtml,
33  | |     String,
34  | |     |string: &str| html_escape::encode_text(string).into_owned(),
...   |
40  | |     }
41  | | );
    | |_- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default
```

I am not sure if there is a way to resolve the issue on my end.
What do you think?