### PR TITLE
Implement (De)Serialization for Pinned Smart Pointers

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Implement (De)Serialization for Pinned Smart Pointers by @Astralchroma (#733)
+
 ## [3.7.0] - 2024-03-11
 
 ### Added

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -390,6 +390,7 @@ pub(crate) mod prelude {
         marker::PhantomData,
         ops::Bound,
         option::Option,
+        pin::Pin,
         result::Result,
         str::FromStr,
         time::Duration,

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -45,6 +45,13 @@ fn test_basic_wrappers() {
 
     is_equal(SBox(Box::new(123)), expect![[r#""123""#]]);
 
+    // Deserialization in generally is not possible, only for unpin types
+    #[serde_as]
+    #[derive(Debug, Serialize, PartialEq)]
+    struct SPin<'a>(#[serde_as(as = "Pin<&DisplayFromStr>")] Pin<&'a u32>);
+    let tmp = 123;
+    check_serialization(SPin(Pin::new(&tmp)), expect![[r#""123""#]]);
+
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct SPinBox(#[serde_as(as = "Pin<Box<DisplayFromStr>>")] Pin<Box<u32>>);

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -23,6 +23,7 @@ use alloc::{
 use core::{
     cell::{Cell, RefCell},
     ops::Bound,
+    pin::Pin,
 };
 use expect_test::expect;
 use serde::{Deserialize, Serialize};
@@ -46,9 +47,21 @@ fn test_basic_wrappers() {
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SPinBox(#[serde_as(as = "Pin<Box<DisplayFromStr>>")] Pin<Box<u32>>);
+
+    is_equal(SPinBox(Box::pin(123)), expect![[r#""123""#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct SRc(#[serde_as(as = "Rc<DisplayFromStr>")] Rc<u32>);
 
     is_equal(SRc(Rc::new(123)), expect![[r#""123""#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SPinRc(#[serde_as(as = "Pin<Rc<DisplayFromStr>>")] Pin<Rc<u32>>);
+
+    is_equal(SPinRc(Rc::pin(123)), expect![[r#""123""#]]);
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize)]
@@ -65,6 +78,12 @@ fn test_basic_wrappers() {
     struct SArc(#[serde_as(as = "Arc<DisplayFromStr>")] Arc<u32>);
 
     is_equal(SArc(Arc::new(123)), expect![[r#""123""#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SPinArc(#[serde_as(as = "Pin<Arc<DisplayFromStr>>")] Pin<Arc<u32>>);
+
+    is_equal(SPinArc(Arc::pin(123)), expect![[r#""123""#]]);
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Implements `SerializeAs` and `DeserializeAs` for `Pin<Box<T>>`, `Pin<Rc<T>>`, and `Pin<Arc<T>>`