### PR TITLE
Fix tests with serde >= 1.0.196

### DIFF
--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -456,9 +456,9 @@ fn test_chrono_timestamp_seconds() {
         ]],
     );
     check_error_deserialization::<StructStringStrict>(
-        r#"0.0"#,
+        r#"0.1"#,
         expect![[
-            r#"invalid type: floating point `0`, expected a string containing a number at line 1 column 3"#
+            r#"invalid type: floating point `0.1`, expected a string containing a number at line 1 column 3"#
         ]],
     );
 
@@ -547,8 +547,8 @@ fn test_chrono_timestamp_seconds_with_frac() {
         expect![[r#"invalid type: integer `1`, expected a string at line 1 column 1"#]],
     );
     check_error_deserialization::<StructStringStrict>(
-        r#"0.0"#,
-        expect![[r#"invalid type: floating point `0`, expected a string at line 1 column 3"#]],
+        r#"0.1"#,
+        expect![[r#"invalid type: floating point `0.1`, expected a string at line 1 column 3"#]],
     );
 
     #[serde_as]

--- a/serde_with/tests/serde_as/time.rs
+++ b/serde_with/tests/serde_as/time.rs
@@ -324,9 +324,9 @@ fn test_timestamp_seconds_systemtime() {
         ]],
     );
     check_error_deserialization::<StructStringStrict>(
-        r#"0.0"#,
+        r#"0.1"#,
         expect![[
-            r#"invalid type: floating point `0`, expected a string containing a number at line 1 column 3"#
+            r#"invalid type: floating point `0.1`, expected a string containing a number at line 1 column 3"#
         ]],
     );
 
@@ -423,8 +423,8 @@ fn test_timestamp_seconds_with_frac_systemtime() {
         expect![[r#"invalid type: integer `1`, expected a string at line 1 column 1"#]],
     );
     check_error_deserialization::<StructStringStrict>(
-        r#"0.0"#,
-        expect![[r#"invalid type: floating point `0`, expected a string at line 1 column 3"#]],
+        r#"0.1"#,
+        expect![[r#"invalid type: floating point `0.1`, expected a string at line 1 column 3"#]],
     );
 
     #[serde_as]


### PR DESCRIPTION
In serde 1.0.196, the "invalid type" error message for floats started
adding a trailing ".0" if no decimal point was already part of the
formatted float, causing tests to fail like:

    ---- test_chrono_timestamp_seconds_with_frac stdout ----

    error: expect test failed
       --> serde_with/tests/chrono_0_4.rs:551:9

    Expect:
    ----
    invalid type: floating point `0`, expected a string at line 1 column 3
    ----

    Actual:
    ----
    invalid type: floating point `0.0`, expected a string at line 1 column 3
    ----

Change the tests to use a test value of 0.1, so the test will work both
pre- and post-serde 1.0.196.