### PR TITLE
Fix serialization for `Duration*` and `Timestamp*` types for very large values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ explicit_auto_deref = "allow"
 manual-unwrap-or-default = "allow"
 
 # alloc_instead_of_core = "warn"
+# as_conversions = "warn"
+# arithmetic_side_effects = "warn"
 # Checks for usage of `cloned()` on an `Iterator` or `Option` where `copied()` could be used instead.
 cloned_instead_of_copied = "warn"
 # Checks for literal calls to `Default::default()`.

--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -127,12 +127,13 @@ pub mod datetime_utc_ts_seconds_from_any {
                     }
                     [seconds, subseconds] => {
                         if let Ok(seconds) = seconds.parse() {
-                            let subseclen = subseconds.chars().count() as u32;
-                            if subseclen > 9 {
-                                return Err(DeError::custom(format_args!(
+                            let subseclen =
+                            match u32::try_from(subseconds.chars().count()) {
+                                Ok(subseclen) if subseclen <= 9 => subseclen,
+                                _ =>    return Err(DeError::custom(format_args!(
                                     "DateTimes only support nanosecond precision but '{value}' has more than 9 digits."
-                                )));
-                            }
+                                ))),
+                            };
 
                             if let Ok(mut subseconds) = subseconds.parse() {
                                 // convert subseconds to nanoseconds (10^-9), require 9 places for nanoseconds

--- a/serde_with/src/content/de.rs
+++ b/serde_with/src/content/de.rs
@@ -62,17 +62,19 @@ impl<'de> Content<'de> {
     fn unexpected(&self) -> Unexpected<'_> {
         match *self {
             Content::Bool(b) => Unexpected::Bool(b),
-            Content::U8(n) => Unexpected::Unsigned(n as u64),
-            Content::U16(n) => Unexpected::Unsigned(n as u64),
-            Content::U32(n) => Unexpected::Unsigned(n as u64),
+            Content::U8(n) => Unexpected::Unsigned(u64::from(n)),
+            Content::U16(n) => Unexpected::Unsigned(u64::from(n)),
+            Content::U32(n) => Unexpected::Unsigned(u64::from(n)),
             Content::U64(n) => Unexpected::Unsigned(n),
+            // TODO generate better unexpected error
             Content::U128(_) => Unexpected::Other("u128"),
-            Content::I8(n) => Unexpected::Signed(n as i64),
-            Content::I16(n) => Unexpected::Signed(n as i64),
-            Content::I32(n) => Unexpected::Signed(n as i64),
+            Content::I8(n) => Unexpected::Signed(i64::from(n)),
+            Content::I16(n) => Unexpected::Signed(i64::from(n)),
+            Content::I32(n) => Unexpected::Signed(i64::from(n)),
             Content::I64(n) => Unexpected::Signed(n),
+            // TODO generate better unexpected error
             Content::I128(_) => Unexpected::Other("i128"),
-            Content::F32(f) => Unexpected::Float(f as f64),
+            Content::F32(f) => Unexpected::Float(f64::from(f)),
             Content::F64(f) => Unexpected::Float(f),
             Content::Char(c) => Unexpected::Char(c),
             Content::String(ref s) => Unexpected::Str(s),

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1826,7 +1826,7 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                     0 => Ok(false),
                     1 => Ok(true),
                     unexp => Err(DeError::invalid_value(
-                        Unexpected::Unsigned(unexp as u64),
+                        Unexpected::Unsigned(u64::from(unexp)),
                         &"0 or 1",
                     )),
                 }
@@ -1840,7 +1840,7 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                     0 => Ok(false),
                     1 => Ok(true),
                     unexp => Err(DeError::invalid_value(
-                        Unexpected::Signed(unexp as i64),
+                        Unexpected::Signed(i64::from(unexp)),
                         &"0 or 1",
                     )),
                 }

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1018,7 +1018,7 @@ impl<STRICTNESS: Strictness> SerializeAs<bool> for BoolFromInt<STRICTNESS> {
     where
         S: Serializer,
     {
-        serializer.serialize_u8(*source as u8)
+        serializer.serialize_u8(u8::from(*source))
     }
 }
 

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -34,11 +34,13 @@ where
     _size_hint_from_bounds(iter.size_hint())
 }
 
-pub(crate) const NANOS_PER_SEC: u32 = 1_000_000_000;
+pub(crate) const NANOS_PER_SEC: u128 = 1_000_000_000;
+pub(crate) const NANOS_PER_SEC_F64: f64 = 1_000_000_000.0;
 // pub(crate) const NANOS_PER_MILLI: u32 = 1_000_000;
 // pub(crate) const NANOS_PER_MICRO: u32 = 1_000;
 // pub(crate) const MILLIS_PER_SEC: u64 = 1_000;
 // pub(crate) const MICROS_PER_SEC: u64 = 1_000_000;
+pub(crate) const U64_MAX: u128 = u64::MAX as u128;
 
 pub(crate) struct MapIter<'de, A, K, V> {
     pub(crate) access: A,
@@ -114,10 +116,10 @@ where
 }
 
 pub(crate) fn duration_signed_from_secs_f64(secs: f64) -> Result<DurationSigned, &'static str> {
-    const MAX_NANOS_F64: f64 = ((u64::MAX as u128 + 1) * (NANOS_PER_SEC as u128)) as f64;
+    const MAX_NANOS_F64: f64 = ((U64_MAX + 1) * NANOS_PER_SEC) as f64;
     // TODO why are the seconds converted to nanoseconds first?
     // Does it make sense to just truncate the value?
-    let mut nanos = secs * (NANOS_PER_SEC as f64);
+    let mut nanos = secs * NANOS_PER_SEC_F64;
     if !nanos.is_finite() {
         return Err("got non-finite value when converting float to duration");
     }
@@ -132,8 +134,8 @@ pub(crate) fn duration_signed_from_secs_f64(secs: f64) -> Result<DurationSigned,
     let nanos = nanos as u128;
     Ok(DurationSigned::new(
         sign,
-        (nanos / (NANOS_PER_SEC as u128)) as u64,
-        (nanos % (NANOS_PER_SEC as u128)) as u32,
+        (nanos / NANOS_PER_SEC) as u64,
+        (nanos % NANOS_PER_SEC) as u32,
     ))
 }
 

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -307,11 +307,12 @@ impl<'de> Visitor<'de> for DurationVisitorFlexible {
     where
         E: DeError,
     {
-        if value >= 0 {
-            Ok(DurationSigned::new(Sign::Positive, value as u64, 0))
+        let sign = if value >= 0 {
+            Sign::Positive
         } else {
-            Ok(DurationSigned::new(Sign::Negative, (-value) as u64, 0))
-        }
+            Sign::Negative
+        };
+        Ok(DurationSigned::new(sign, value.unsigned_abs(), 0))
     }
 
     fn visit_u64<E>(self, secs: u64) -> Result<Self::Value, E>

--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -3,7 +3,8 @@ extern crate alloc;
 mod utils;
 
 use crate::utils::{
-    check_deserialization, check_error_deserialization, check_serialization, is_equal,
+    check_deserialization, check_error_deserialization, check_error_serialization,
+    check_serialization, is_equal,
 };
 use alloc::collections::BTreeMap;
 use chrono_0_4::{DateTime, Duration, Local, NaiveDateTime, Utc};
@@ -740,4 +741,56 @@ fn test_naive_datetime_smoketest() {
         NaiveDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         NaiveDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
     };
+}
+
+#[test]
+fn bug771_extreme_nanoseconds() {
+    #[serde_as]
+    #[derive(Debug, Serialize)]
+    struct S(#[serde_as(as = "serde_with::TimestampNanoSeconds")] DateTime<Utc>);
+
+    check_error_serialization(
+        S(DateTime::<Utc>::MIN_UTC),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("1385-06-12T00:25:26.290448384Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("1385-06-12T00:25:26.290448385Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("1677-09-21T00:12:43.145224191Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("1677-09-21T00:12:43.145224192Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_serialization(
+        S("1677-09-21T00:12:43.145224193Z".parse().unwrap()),
+        expect!["-9223372036854775807"],
+    );
+    check_serialization(
+        S("2262-04-11T23:47:16.854775807Z".parse().unwrap()),
+        expect!["9223372036854775807"],
+    );
+    check_error_serialization(
+        S("2262-04-11T23:47:16.854775808Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("2554-07-21T23:34:33.709551615Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S("2554-07-21T23:34:33.709551616Z".parse().unwrap()),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
+    check_error_serialization(
+        S(DateTime::<Utc>::MAX_UTC),
+        expect!["Failed to serialize value as the value cannot be represented."],
+    );
 }

--- a/serde_with/tests/serde_as/enum_map.rs
+++ b/serde_with/tests/serde_as/enum_map.rs
@@ -13,7 +13,7 @@ fn bytes_debug_readable(bytes: &[u8]) -> String {
             }
             b'\\' => result.push_str("\\\\"),
             _ => {
-                result.push(byte as char);
+                result.push(char::from(byte));
             }
         }
     }


### PR DESCRIPTION
Closes #771