### PR TITLE
feat(serde_with_macros): proper handling of `cfg_attr` and `schemars`

### DIFF
--- a/serde_with/tests/schemars_0_8.rs
+++ b/serde_with/tests/schemars_0_8.rs
@@ -95,6 +95,22 @@ fn schemars_basic() {
 }
 
 #[test]
+fn schemars_other_cfg_attrs() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct Test {
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(any(), arbitrary("some" |weird| syntax::<bool, 2>()))]
+        #[cfg_attr(any(), schemars(with = "i32"))]
+        custom: i32,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "custom": "23",
+    }));
+}
+
+#[test]
 fn schemars_custom_with() {
     #[serde_as]
     #[derive(JsonSchema, Serialize)]

--- a/serde_with_macros/src/lazy_bool.rs
+++ b/serde_with_macros/src/lazy_bool.rs
@@ -1,0 +1,139 @@
+use core::{
+    mem,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
+};
+
+/// Not-yet evaluated boolean value.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum LazyBool<T> {
+    /// Like `false`.
+    ///
+    /// This is this type’s default.
+    #[default]
+    False,
+
+    /// Like `true`.
+    True,
+
+    /// Not-yet decided.
+    Lazy(T),
+}
+
+impl<T> From<bool> for LazyBool<T> {
+    fn from(value: bool) -> Self {
+        match value {
+            false => Self::False,
+            true => Self::True,
+        }
+    }
+}
+
+/// Helper to implement various binary operations on [`LazyBool`].
+macro_rules! impl_op {
+    (
+        <
+            $trait:ident::$method:ident,
+            $assign_trait:ident::$assign_method:ident
+        >($matching:pat_param) {
+            $($pattern:pat => $body:expr),+ $(,)?
+        }
+        $(where $($bound:tt)+)?
+    ) => {
+        impl<L, R, T> $trait<LazyBool<R>> for LazyBool<L>
+        where
+            L: $trait<R, Output = T>,
+            LazyBool<L>: Into<LazyBool<T>>,
+            LazyBool<R>: Into<LazyBool<T>>,
+            $($($bound)+)?
+        {
+            type Output = LazyBool<T>;
+
+            fn $method(self, rhs: LazyBool<R>) -> Self::Output {
+                match (self, rhs) {
+                    (LazyBool::Lazy(lhs), LazyBool::Lazy(rhs)) => LazyBool::Lazy(lhs.$method(rhs)),
+                    ($matching, rhs) => rhs.into(),
+                    (lhs, $matching) => lhs.into(),
+                    $($pattern => $body),+
+                }
+            }
+        }
+
+        impl<'a, L, R, T> $trait<&'a LazyBool<R>> for LazyBool<L>
+        where
+            L: $trait<&'a R, Output = T>,
+            LazyBool<L>: Into<LazyBool<T>>,
+            LazyBool<R>: Into<LazyBool<T>> + Clone,
+            $($($bound)+)?
+        {
+            type Output = LazyBool<T>;
+
+            fn $method(self, rhs: &'a LazyBool<R>) -> Self::Output {
+                match (self, rhs) {
+                    (LazyBool::Lazy(lhs), LazyBool::Lazy(rhs)) => LazyBool::Lazy(lhs.$method(rhs)),
+                    ($matching, rhs) => rhs.clone().into(),
+                    (lhs, $matching) => lhs.into(),
+                    $($pattern => $body),+
+                }
+            }
+        }
+
+        impl<'a, L, R, T> $trait<LazyBool<R>> for &'a LazyBool<L>
+        where
+            LazyBool<R>: $trait<&'a LazyBool<L>, Output = LazyBool<T>>,
+        {
+            type Output = LazyBool<T>;
+
+            fn $method(self, rhs: LazyBool<R>) -> Self::Output {
+                rhs.$method(self)
+            }
+        }
+
+        impl<L, R> $assign_trait<LazyBool<R>> for LazyBool<L>
+        where
+            LazyBool<L>: $trait<LazyBool<R>, Output = LazyBool<L>>,
+        {
+            fn $assign_method(&mut self, rhs: LazyBool<R>) {
+                let lhs = mem::take(self);
+                *self = lhs.$method(rhs);
+            }
+        }
+    };
+}
+
+impl_op! { <BitAnd::bitand, BitAndAssign::bitand_assign>(LazyBool::True){ _ => LazyBool::False } }
+impl_op! { <BitOr::bitor, BitOrAssign::bitor_assign>(LazyBool::False) { _ => LazyBool::True } }
+impl_op! {
+    <BitXor::bitxor, BitXorAssign::bitxor_assign>(LazyBool::False) {
+        (LazyBool::True, rhs) => (!rhs).into(),
+        (lhs, LazyBool::True) => (!lhs).into(),
+    }
+    where
+        LazyBool<L>: Not<Output = LazyBool<L>>,
+        LazyBool<R>: Not<Output = LazyBool<R>>,
+}
+
+impl<T> Not for LazyBool<T>
+where
+    T: Not<Output = T>,
+{
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Self::False => Self::True,
+            Self::True => Self::False,
+            Self::Lazy(this) => Self::Lazy(!this),
+        }
+    }
+}
+
+impl<T> Not for &LazyBool<T>
+where
+    LazyBool<T>: Not<Output = LazyBool<T>> + Clone,
+{
+    type Output = LazyBool<T>;
+
+    fn not(self) -> Self::Output {
+        !self.clone()
+    }
+}


### PR DESCRIPTION
With this commit, `cfg_attr` will be handled properly. The current implementation does not accept e.g.:

```rust
#[serde_as]
#[derive(JsonSchema, Serialize)]
struct Test {
    #[serde_as(as = "DisplayFromStr")]
    #[cfg_attr(any(), arbitrary("some" |weird| syntax::<bool, 2>()))]
    #[cfg_attr(any(), schemars(rename = "foo"), schemars(range(min = 0)))]
    custom: i32,
}
```

Because due to https://github.com/jonasbb/serde_with/blob/master/serde_with_macros/src/utils.rs#L91, the parser does not accept `cfg_attr` with multiple arguments, which is allowed, see e.g. https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute. Another issue I’ve found with `arbitrary` where some unexpected errors due to this custom parser: https://github.com/jonasbb/serde_with/blob/master/serde_with_macros/src/utils.rs#L191-L218 in combination with this line: https://github.com/jonasbb/serde_with/blob/master/serde_with_macros/src/utils.rs#L240.

Line 240 will only `continue`, if the outer-most meta if neither `cfg_attr` or `schemars`. If however the attribute is `cfg_attr`, the code after the `match`-block is reached and the parser will just assume, that the inner meta is `schemars` and thus fail to parse any meta with some weird syntax.

Even `#[schemars(length(min = 1.0))]` will fail, because the parser expects all `schemars`-attributes to be a list of key-value-pairs (`foo = bar`), thus failing for `length(min = 1.0)`, even though this is perfectly legal (https://graham.cool/schemars/deriving/attributes/#length).

I introduced the type `LazyBool` to simplify dealing with various conditions.