### PR TITLE
feat(serde_with): make `BytesOrString` adjustable

### DIFF
--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -994,7 +994,10 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
+impl<'de, PREFERENCE> DeserializeAs<'de, Vec<u8>> for BytesOrString<PREFERENCE>
+where
+    PREFERENCE: formats::TypePreference,
+{
     fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
         D: Deserializer<'de>,

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -811,9 +811,23 @@ pub struct DefaultOnNull<T = Same>(PhantomData<T>);
 /// assert_eq!("✨Works!".as_bytes(), &*a.bytes_or_string);
 /// # }
 /// ```
+///
+/// Often it is prefered to serialize these bytes as string again,
+///   but `BytesOrString` will always return an array of integers in the range of `0–255`.
+/// This can be adjusted using its generic type parameter,
+///   which can be either [`PreferBytes`] (default), [`PreferAsciiString`] or [`PreferString`].
+/// The latter two will try to convert arbitrary bytes to a `&str` first and will fallback to
+///   serializing as array of bytes only if these bytes would form an invalid string.
+/// `PreferAsciiString` will serialize strings containing non-ASCII characters as array as well.
+///
 /// [`String`]: std::string::String
+/// [`PreferBytes`]: formats::PreferBytes
+/// [`PreferAsciiString`]: formats::PreferString
+/// [`PreferString`]: formats::PreferString
 #[cfg(feature = "alloc")]
-pub struct BytesOrString;
+pub struct BytesOrString<PREFERENCE: formats::TypePreference = formats::PreferBytes>(
+    PhantomData<PREFERENCE>,
+);
 
 /// De/Serialize Durations as number of seconds.
 ///

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -430,7 +430,10 @@ impl<T> JsonSchemaAs<T> for Bytes {
     forward_schema!(Vec<u8>);
 }
 
-impl JsonSchemaAs<Vec<u8>> for BytesOrString {
+impl<PREFERENCE> JsonSchemaAs<Vec<u8>> for BytesOrString<PREFERENCE>
+where
+    PREFERENCE: formats::TypePreference,
+{
     fn schema_name() -> String {
         "BytesOrString".into()
     }

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -595,12 +595,15 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl SerializeAs<Vec<u8>> for BytesOrString {
+impl<PREFERENCE> SerializeAs<Vec<u8>> for BytesOrString<PREFERENCE>
+where
+    PREFERENCE: formats::TypePreference,
+{
     fn serialize_as<S>(source: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        source.serialize(serializer)
+        PREFERENCE::serialize_as(source.as_slice(), serializer)
     }
 }
 


### PR DESCRIPTION
At the moment, any `Vec<u8>` annotated with `#[serde(as = "BytesOrString")]` will always be serialised as an array of integers in the range `0–255`. However, often these bytes are valid strings, the internal representation as `Vec<u8>` is often just an implementation detail. This PR adds a generic type parameter `PREFERENCE`, which must implement the new trait `TypePreference`, which is a subtrait of `SerializeAs<[u8]>`. This parameter defaults to the new marker-strut `PreferBytes`, which serialises `Vec<u8>` as an array like before. Two additional marker-structs are `PreferString`, which tries to convert `&[u8]` to `&str` first and will fallback to serialising as array only if the bytes do not represent a valid string, as well as `PreferAsciiString`, which additionally checks that all characters of the string are valid ASCII-characters, otherwise falling back to the array as well.