### PR TITLE
Do not run tarpaulin on serde_with_macros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,9 @@ jobs:
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
         run: |
           cargo install cargo-tarpaulin
-          cargo tarpaulin --out xml --workspace --all-features -- --test-threads=1
+          # Exclude proc-macro crate as this does not work on Rust 1.83
+          # https://github.com/xd009642/tarpaulin/issues/1642#issuecomment-2517795748
+          cargo tarpaulin --exclude serde_with_macros --out xml --workspace --all-features -- --test-threads=1
         env:
           # https://github.com/xd009642/tarpaulin/issues/1499
           CARGO_PROFILE_DEV_DEBUG: 1


### PR DESCRIPTION
There is a problem of testing proc-macro crates with Rust 1.83:
https://github.com/xd009642/tarpaulin/issues/1642#issuecomment-2517795748