### PR TITLE
makes unwrap_or_skip compatible with references (zero-copy)

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Generalize `serde_with::rust::unwrap_or_skip` to support deserializing references by @beroal (#832)
+
 ## [3.12.0] - 2024-12-25
 
 ### Added

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -149,7 +149,7 @@ pub mod unwrap_or_skip {
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
     where
         D: Deserializer<'de>,
-        T: DeserializeOwned,
+        T: Deserialize<'de>,
     {
         T::deserialize(deserializer).map(Some)
     }


### PR DESCRIPTION
`rust::unwrap_or_skip` was incompatible with references (zero-copy). See examples of this incompatibility in the new tests.