### PR TITLE
Implement DeserializeAs for DurationSeconds without std feature

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Generalize `serde_with::rust::unwrap_or_skip` to support deserializing references by @beroal (#832)
 * Bump MSRV to 1.71, since that is required for the `jsonschema` dev-dependency.
 
+### Fixed
+
+* Make the `DurationSeconds` types and other variants more accessible even without `std` (#845)
+
 ## [3.12.0] - 2024-12-25
 
 ### Added

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1082,7 +1082,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 macro_rules! use_signed_duration {
     (
         $main_trait:ident $internal_trait:ident =>
@@ -1116,7 +1115,6 @@ macro_rules! use_signed_duration {
     };
 }
 
-#[cfg(feature = "std")]
 use_signed_duration!(
     DurationSeconds DurationSeconds,
     DurationMilliSeconds DurationMilliSeconds,
@@ -1125,12 +1123,32 @@ use_signed_duration!(
     => {
         Duration; to_std_duration =>
         {u64, Strict =>}
-        {f64, Strict =>}
-        {String, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
     }
 );
+#[cfg(feature = "alloc")]
+use_signed_duration!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration; to_std_duration =>
+        {String, Strict =>}
+    }
+);
 #[cfg(feature = "std")]
+use_signed_duration!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration; to_std_duration =>
+        // round() only works on std
+        {f64, Strict =>}
+    }
+);
 use_signed_duration!(
     DurationSecondsWithFrac DurationSecondsWithFrac,
     DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
@@ -1139,8 +1157,18 @@ use_signed_duration!(
     => {
         Duration; to_std_duration =>
         {f64, Strict =>}
-        {String, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_signed_duration!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Duration; to_std_duration =>
+        {String, Strict =>}
     }
 );
 

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -84,7 +84,6 @@ impl DurationSigned {
         .ok_or_else(|| DeError::custom("timestamp is outside the range for std::time::SystemTime"))
     }
 
-    #[cfg(feature = "std")]
     pub(crate) fn to_std_duration<'de, D>(self) -> Result<Duration, D::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
This includes the other fractionless variants as well, such as
DurationMilliSeconds, DurationMicroSeconds, and DurationNanoSeconds.