### PR TITLE
Add support for schemars v0.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
         # It is good to test more than the MSRV and stable since sometimes
         # breakage occurs in intermediate versions.
         # IMPORTANT: Synchronize the MSRV with the Cargo.toml values.
-        rust: ["1.71", "1.75", "1.80", "1.85", "stable", "beta", "nightly"]
+        rust: ["1.74", "1.75", "1.80", "1.85", "stable", "beta", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f55c82c700538496bdc329bb4918a81f87cc8888811bd123cf325a0f2f8d309"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.17",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 0.9.0",
  "serde",
  "serde_json",
 ]
@@ -952,6 +965,18 @@ name = "schemars_derive"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83263746fe5e32097f06356968a077f96089739c927a61450efa069905eec108"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1016,12 +1041,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1066,7 +1092,8 @@ dependencies = [
  "rmp-serde",
  "ron",
  "rustversion",
- "schemars",
+ "schemars 0.8.17",
+ "schemars 0.9.0",
  "serde",
  "serde-xml-rs",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jonasbb/serde_with/"
-rust-version = "1.71"
+rust-version = "1.74"
 version = "3.12.0"
 
 [workspace.metadata.release]

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -12,10 +12,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Generalize `serde_with::rust::unwrap_or_skip` to support deserializing references by @beroal (#832)
 * Bump MSRV to 1.71, since that is required for the `jsonschema` dev-dependency.
 * Make `serde_conv` available without the `std` feature by @arilou (#839)
+* Bump MSRV to 1.74, since that is required for `schemars` v0.9.0 by @swlynch99 (#849)
 
 ### Fixed
 
 * Make the `DurationSeconds` types and other variants more accessible even without `std` (#845)
+
+### Added
+
+* Added support for `schemars` v0.9.0 under the `schemars_0_9` feature flag by @swlynch99 (#849)
 
 ## [3.12.0] - 2024-12-25
 

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -41,7 +41,7 @@ alloc = ["serde/alloc", "base64?/alloc", "chrono_0_4?/alloc", "hex?/alloc", "ser
 ## Enables support for various types from the std library.
 ## This will enable `std` support in all dependencies too.
 ## The feature enabled by default and also enables `alloc`.
-std = ["alloc", "serde/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "time_0_3?/serde-well-known", "time_0_3?/std"]
+std = ["alloc", "serde/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "time_0_3?/serde-well-known", "time_0_3?/std", "schemars_0_9?/std"]
 
 #! # Documentation
 #!
@@ -118,6 +118,13 @@ macros = ["dep:serde_with_macros"]
 ## This pulls in `schemars` v0.8 as a dependency. It will also implicitly enable
 ## the `std` feature as `schemars` is not `#[no_std]`.
 schemars_0_8 = ["dep:schemars_0_8", "std", "serde_with_macros?/schemars_0_8"]
+## This feature enables integration with `schemars` 0.9
+## This makes `#[derive(JsonSchema)]` pick up the correct schema for the type
+## used within `#[serde_as(as = ...)]`.
+##
+## This pulls in `schemars` v0.9 as a dependency. It will also implicitly enable
+## the `alloc` feature.
+schemars_0_9 = ["dep:schemars_0_9", "alloc", "serde_with_macros?/schemars_0_9", "dep:serde_json"]
 ## The feature enables integration of `time` v0.3 specific conversions.
 ## This includes support for the timestamp and duration types.
 ##
@@ -136,6 +143,7 @@ hex = { version = "0.4.3", optional = true, default-features = false }
 indexmap_1 = { package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"] }
 indexmap_2 = { package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"] }
 schemars_0_8 = { package = "schemars", version = "0.8.16", optional = true, default-features = false }
+schemars_0_9 = { package = "schemars", version = "0.9.0", optional = true, default-features = false }
 serde = { version = "1.0.152", default-features = false }
 serde_derive = "1.0.152"
 serde_json = { version = "1.0.45", optional = true, default-features = false }
@@ -154,6 +162,7 @@ rmp-serde = "1.3.0"
 ron = "0.10"
 rustversion = "1.0.0"
 schemars_0_8 = { package = "schemars", version = "0.8.16" }
+schemars_0_9 = { package = "schemars", version = "0.9.0" }
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.25", features = ["preserve_order"] }
 serde_test = "1.0.124"
@@ -230,6 +239,11 @@ required-features = ["alloc"]
 name = "schemars_0_8"
 path = "tests/schemars_0_8.rs"
 required-features = ["schemars_0_8"]
+
+[[test]]
+name = "schemars_0_9"
+path = "tests/schemars_0_9/main.rs"
+required-features = ["schemars_0_9", "std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -312,6 +312,9 @@ pub mod rust;
 #[cfg(feature = "schemars_0_8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "schemars_0_8")))]
 pub mod schemars_0_8;
+#[cfg(feature = "schemars_0_9")]
+#[cfg_attr(docsrs, doc(cfg(feature = "schemars_0_9")))]
+pub mod schemars_0_9;
 pub mod ser;
 mod serde_conv;
 #[cfg(feature = "time_0_3")]
@@ -2595,5 +2598,5 @@ pub struct SetLastValueWins<T>(PhantomData<T>);
 /// feature is enabled.
 ///
 /// [`JsonSchema`]: ::schemars_0_8::JsonSchema
-#[cfg(feature = "schemars_0_8")]
+#[cfg(any(feature = "schemars_0_8", feature = "schemars_0_9"))]
 pub struct Schema<T: ?Sized, TA>(PhantomData<T>, PhantomData<TA>);

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -46,7 +46,8 @@ use serde_json::Value;
 /// # use serde::{Serialize, Serializer, Deserialize, Deserializer};
 /// # use serde_with::{SerializeAs, DeserializeAs};
 /// use serde_with::schemars_0_9::JsonSchemaAs;
-/// use schemars::{json_schema, SchemaGenerator, Schema, JsonSchema};
+/// use schemars::{json_schema, SchemaGenerator, Schema};
+/// use std::borrow::Cow;
 ///
 /// # #[allow(dead_code)]
 /// struct PositiveInt;
@@ -87,7 +88,7 @@ use serde_json::Value;
 ///         "PositiveInt".into()
 ///     }
 ///
-///     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+///     fn json_schema(_: &mut SchemaGenerator) -> Schema {
 ///         json_schema!({
 ///             "type": "integer",
 ///             "minimum": 0

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -688,7 +688,7 @@ where
                 *max = max.saturating_sub(1);
             }
 
-            if let Some(Value::Number(min)) = schema.get_mut("maxProperties") {
+            if let Some(Value::Number(min)) = schema.get_mut("minProperties") {
                 *min = min.saturating_sub(1);
             }
         }

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -544,7 +544,7 @@ where
 
         let one_of = match inner.get_mut("oneOf") {
             Some(Value::Array(one_of)) => one_of,
-            _ => return inner_schema.into(),
+            _ => return inner_schema,
         };
 
         let mut properties = serde_json::Map::new();
@@ -680,7 +680,7 @@ where
                         done = true;
                         false
                     }
-                    _ => return true,
+                    _ => true,
                 });
             }
 

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -1,0 +1,1038 @@
+//! Test Cases
+
+use crate::utils::{check_matches_schema, check_valid_json_schema};
+use expect_test::expect_file;
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_json::json;
+use serde_with::*;
+use std::collections::BTreeSet;
+
+// This avoids us having to add `#[schemars(crate = "::schemars_0_9")]` all
+// over the place. We're not testing that and it is inconvenient.
+extern crate schemars_0_9 as schemars;
+
+mod utils;
+
+/// Declare a snapshot tests for a struct.
+///
+/// The snapshot files are stored under the `schemars_0_9` folder alongside
+/// this test file.
+macro_rules! declare_snapshot_test {
+    {$(
+        $( #[$tattr:meta] )*
+        $test:ident {
+            $( #[$stattr:meta] )*
+            struct $name:ident {
+                $(
+                    $( #[ $fattr:meta ] )*
+                    $field:ident : $ty:ty
+                ),*
+                $(,)?
+            }
+        }
+    )*} => {$(
+        #[test]
+        $(#[$tattr])*
+        fn $test() {
+            #[serde_as]
+            #[derive(JsonSchema, Serialize)]
+            $( #[$stattr] )*
+            struct $name {
+                $(
+                    $( #[$fattr] )*
+                    $field: $ty,
+                )*
+            }
+
+            let schema = schemars::schema_for!($name);
+            let _ = jsonschema::Validator::new(
+                &serde_json::to_value(&schema).expect("generated schema is not valid json"),
+            )
+            .expect("generated schema is not valid");
+
+            let mut schema = serde_json::to_string_pretty(&schema)
+                .expect("schema could not be serialized");
+            schema.push('\n');
+
+            let filename = concat!("./", module_path!(), "::", stringify!($test), ".json")
+                .replace("::", "/")
+                .replace("schemars_0_9/", "");
+
+            let expected = expect_file![filename];
+            expected.assert_eq(&schema);
+        }
+    )*}
+}
+
+#[test]
+fn schemars_basic() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[schemars(crate = "::schemars_0_9")]
+    struct Basic {
+        /// Basic field, no attribute
+        bare_field: u32,
+
+        /// Field that directly uses DisplayFromStr
+        #[serde_as(as = "DisplayFromStr")]
+        display_from_str: u32,
+
+        /// Same does not implement JsonSchema directly so this checks that the
+        /// correct schemars attribute was injected.
+        #[serde_as(as = "Same")]
+        same: u32,
+
+        /// This checks that Same still works when wrapped in a box.
+        #[serde_as(as = "Box<Same>")]
+        box_same: Box<u32>,
+
+        /// Same thing, but with a Vec this time.
+        #[serde_as(as = "Vec<_>")]
+        vec_same: Vec<u32>,
+    }
+
+    let schema = schemars::schema_for!(Basic);
+    let mut schema = serde_json::to_string_pretty(&schema).expect("schema could not be serialized");
+    schema.push('\n');
+
+    let expected = expect_file!["./schemars_basic.json"];
+    expected.assert_eq(&schema);
+}
+
+#[test]
+fn schemars_other_cfg_attrs() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct Test {
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(any(), arbitrary("some" |weird| syntax::<bool, 2>()))]
+        #[cfg_attr(any(), schemars(with = "i32"))]
+        custom: i32,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "custom": "23",
+    }));
+}
+
+#[test]
+fn schemars_custom_with() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct Test {
+        #[serde_as(as = "DisplayFromStr")]
+        #[schemars(with = "i32")]
+        custom: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(any(), schemars(with = "i32"))]
+        with_disabled: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(all(), schemars(with = "i32"))]
+        always_enabled: i32,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "custom": 3,
+        "with_disabled": "5",
+        "always_enabled": 7,
+    }));
+}
+
+#[test]
+fn schemars_deserialize_only_bug_735() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[schemars(crate = "::schemars_0_9")]
+    struct Basic {
+        /// Basic field, no attribute
+        bare_field: u32,
+
+        /// Will emit matching schemars attribute
+        #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+        both: u32,
+
+        /// Can emit schemars with serialize_as, but it will be ignored
+        #[serde_as(serialize_as = "PickFirst<(_, DisplayFromStr)>")]
+        serialize_only: u32,
+
+        /// schemars doesn't support deserialize_as
+        #[serde_as(deserialize_as = "PickFirst<(_, DisplayFromStr)>")]
+        deserialize_only: u32,
+
+        /// Can emit schemars with serialize_as, but it will be ignored
+        /// schemars doesn't support deserialize_as
+        #[serde_as(
+            serialize_as = "PickFirst<(_, DisplayFromStr)>",
+            deserialize_as = "PickFirst<(_, DisplayFromStr)>"
+        )]
+        serialize_and_deserialize: u32,
+    }
+
+    let schema = schemars::schema_for!(Basic);
+    let mut schema = serde_json::to_string_pretty(&schema).expect("schema could not be serialized");
+    schema.push('\n');
+
+    let expected = expect_file!["./schemars_deserialize_only_bug_735.json"];
+    expected.assert_eq(&schema);
+}
+
+#[test]
+fn schemars_custom_schema_with() {
+    fn custom_int(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        use schemars::json_schema;
+
+        json_schema!({
+            "type": "integer"
+        })
+    }
+
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct Test {
+        #[serde_as(as = "DisplayFromStr")]
+        #[schemars(schema_with = "custom_int")]
+        custom: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(any(), schemars(schema_with = "custom_int"))]
+        with_disabled: i32,
+
+        #[serde_as(as = "DisplayFromStr")]
+        #[cfg_attr(all(), schemars(schema_with = "custom_int"))]
+        always_enabled: i32,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "custom": 3,
+        "with_disabled": "5",
+        "always_enabled": 7,
+    }));
+}
+
+mod test_std {
+    use super::*;
+    use std::collections::{BTreeMap, VecDeque};
+
+    declare_snapshot_test! {
+        option {
+            struct Test {
+                #[serde_with(as = "Option<_>")]
+                optional: Option<i32>,
+            }
+        }
+
+        vec {
+            struct Test {
+                #[serde_with(as = "Vec<_>")]
+                vec: Vec<String>
+            }
+        }
+
+        vec_deque {
+            struct Test {
+                #[serde_with(as = "VecDeque<_>")]
+                vec_deque: VecDeque<String>
+            }
+        }
+
+        map {
+            struct Test {
+                #[serde_with(as = "BTreeMap<_, _>")]
+                map: BTreeMap<String, i32>
+            }
+        }
+
+        set {
+            struct Test {
+                #[serde_with(as = "BTreeSet<_>")]
+                map: BTreeSet<String>,
+            }
+        }
+
+        tuples {
+            struct Test {
+                #[serde_with(as = "()")]
+                tuple0: (),
+
+                #[serde_with(as = "(_ ,)")]
+                tuple1: (i32,),
+
+                #[serde_with(as = "(_, _)")]
+                tuple2: (i32, i32),
+
+                #[serde_with(as = "(_, _, _)")]
+                tuple3: (i32, i32, String)
+            }
+        }
+    }
+}
+
+mod snapshots {
+    use super::*;
+    use serde_with::formats::*;
+
+    #[allow(dead_code)]
+    #[derive(JsonSchema, Serialize)]
+    enum Mappable {
+        A(i32),
+        B(String),
+        C { c: i32, b: Option<u64> },
+    }
+
+    #[derive(JsonSchema, Serialize)]
+    struct KvMapData {
+        #[serde(rename = "$key$")]
+        key: String,
+
+        a: u32,
+        b: String,
+        c: f32,
+        d: bool,
+    }
+
+    #[allow(dead_code, variant_size_differences)]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(tag = "$key$")]
+    enum KvMapEnum {
+        TypeA { a: u32 },
+        TypeB { b: String },
+        TypeC { c: bool },
+    }
+
+    #[derive(JsonSchema, Serialize)]
+    struct KvMapFlatten {
+        #[serde(flatten)]
+        data: KvMapEnum,
+        extra: bool,
+    }
+
+    declare_snapshot_test! {
+        bytes {
+            struct Test {
+                #[serde_as(as = "Bytes")]
+                bytes: Vec<u8>,
+            }
+        }
+
+        default_on_null {
+            struct Test {
+                #[serde_as(as = "DefaultOnNull<_>")]
+                data: String,
+            }
+        }
+
+        string_with_separator {
+            struct Test {
+                #[serde_as(as = "StringWithSeparator<CommaSeparator, String>")]
+                data: Vec<String>,
+            }
+        }
+
+        from_into {
+            struct Test {
+                #[serde_as(as = "FromInto<u64>")]
+                data: u32,
+            }
+        }
+
+        map {
+            struct Test {
+                #[serde_as(as = "Map<_, _>")]
+                data: Vec<(String, u32)>,
+            }
+        }
+
+        map_fixed {
+            struct Test {
+                #[serde_as(as = "Map<_, _>")]
+                data: [(String, u32); 4],
+            }
+        }
+
+        set_last_value_wins {
+            struct Test {
+                #[serde_as(as = "SetLastValueWins<_>")]
+                data: BTreeSet<u32>,
+            }
+        }
+
+        set_prevent_duplicates {
+            struct Test {
+                #[serde_as(as = "SetPreventDuplicates<_>")]
+                data: BTreeSet<u32>,
+            }
+        }
+
+        duration {
+            struct Test {
+                #[serde_as(as = "DurationSeconds<u64, Flexible>")]
+                seconds: std::time::Duration,
+
+                #[serde_as(as = "DurationSecondsWithFrac<f64, Flexible>")]
+                frac: std::time::Duration,
+
+                #[serde_as(as = "DurationSeconds<String, Flexible>")]
+                flexible_string: std::time::Duration,
+
+                #[serde_as(as = "DurationSeconds<u64, Strict>")]
+                seconds_u64_strict: std::time::Duration,
+
+                #[serde_as(as = "TimestampSeconds<i64, Flexible>")]
+                time_i64: std::time::SystemTime,
+            }
+        }
+
+        enum_map {
+            struct Test {
+                #[serde_as(as = "EnumMap")]
+                data: Vec<Mappable>,
+            }
+        }
+
+        key_value_map {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapData>,
+            }
+        }
+
+        key_value_map_enum {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapEnum>,
+            }
+        }
+
+        key_value_map_flatten {
+            struct Test {
+                #[serde_as(as = "KeyValueMap<_>")]
+                data: Vec<KvMapFlatten>,
+            }
+        }
+
+        one_or_many_prefer_one {
+            #[serde(transparent)]
+            struct Test {
+                #[serde_as(as = "OneOrMany<_, PreferOne>")]
+                data: Vec<i32>,
+            }
+        }
+
+        pickfirst {
+            #[serde(transparent)]
+            struct Test {
+                #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+                value: u32
+            }
+        }
+
+        pickfirst_nested {
+            #[serde(transparent)]
+            struct Test {
+                #[serde_as(as = "OneOrMany<PickFirst<(_, DisplayFromStr)>>")]
+                optional_value: Vec<u32>
+            }
+        }
+
+        one_or_many_nested {
+            struct Test {
+                #[serde_as(as = "Option<OneOrMany<_>>")]
+                optional_many: Option<Vec<String>>,
+            }
+        }
+    }
+}
+
+mod derive {
+    use super::*;
+
+    #[serde_as]
+    #[derive(Serialize)]
+    #[cfg_attr(all(), derive(JsonSchema))]
+    struct Enabled {
+        #[serde_as(as = "DisplayFromStr")]
+        field: u32,
+    }
+
+    #[allow(dead_code)]
+    #[serde_as]
+    #[derive(Serialize)]
+    #[cfg_attr(any(), derive(JsonSchema))]
+    struct Disabled {
+        // If we are incorrectly adding `#[schemars(with = ...)]` attributes
+        // then we should get an error on this field.
+        #[serde_as(as = "DisplayFromStr")]
+        field: u32,
+    }
+
+    #[test]
+    fn test_enabled_has_correct_schema() {
+        check_valid_json_schema(&Enabled { field: 77 });
+    }
+}
+
+mod array {
+    use super::*;
+
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    struct FixedArray {
+        #[serde_as(as = "[_; 3]")]
+        array: [u32; 3],
+    }
+
+    #[test]
+    fn test_serialized_is_valid() {
+        let array = FixedArray { array: [1, 2, 3] };
+
+        check_valid_json_schema(&array);
+    }
+
+    #[test]
+    fn test_valid_json() {
+        let value = json!({ "array": [1, 2, 3] });
+        check_matches_schema::<FixedArray>(&value);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_too_short() {
+        check_matches_schema::<FixedArray>(&json!({
+            "array": [1],
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_too_long() {
+        check_matches_schema::<FixedArray>(&json!({
+            "array": [1, 2, 3, 4]
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_wrong_item_type() {
+        check_matches_schema::<FixedArray>(&json!({
+            "array": ["1", "2", "3"]
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_oob_item() {
+        check_matches_schema::<FixedArray>(&json!({
+            "array": [-1, 0x1_0000_0000i64, 32]
+        }));
+    }
+}
+
+mod bool_from_int {
+    use super::*;
+    use serde_with::formats::{Flexible, Strict};
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct BoolStrict {
+        #[serde_as(as = "BoolFromInt<Strict>")]
+        value: bool,
+    }
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct BoolFlexible {
+        #[serde_as(as = "BoolFromInt<Flexible>")]
+        value: bool,
+    }
+
+    #[test]
+    fn test_serialized_strict_is_valid() {
+        check_valid_json_schema(&vec![
+            BoolStrict { value: true },
+            BoolStrict { value: false },
+        ]);
+    }
+
+    #[test]
+    fn test_serialized_flexible_is_valid() {
+        check_valid_json_schema(&vec![
+            BoolFlexible { value: true },
+            BoolFlexible { value: false },
+        ]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn strict_out_of_range() {
+        check_matches_schema::<BoolStrict>(&json!({
+            "value": 5
+        }));
+    }
+
+    #[test]
+    fn flexible_out_of_range() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": 5
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn flexible_wrong_type() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": "seven"
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_fractional_value_strict() {
+        check_matches_schema::<BoolStrict>(&json!({
+            "value": 0.5
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_fractional_value_flexible() {
+        check_matches_schema::<BoolFlexible>(&json!({
+            "value": 0.5
+        }));
+    }
+}
+
+mod bytes_or_string {
+    use super::*;
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "BytesOrString")]
+        bytes: Vec<u8>,
+    }
+
+    #[test]
+    fn test_serialized_is_valid() {
+        check_valid_json_schema(&Test {
+            bytes: b"test".to_vec(),
+        });
+    }
+
+    #[test]
+    fn test_string_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": "test string"
+        }));
+    }
+
+    #[test]
+    fn test_bytes_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": [1, 2, 3, 4]
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_int_not_valid_json() {
+        check_matches_schema::<Test>(&json!({
+            "bytes": 5
+        }));
+    }
+}
+
+mod enum_map {
+    use super::*;
+
+    #[derive(Serialize, JsonSchema)]
+    struct InnerStruct {
+        c: String,
+        d: f64,
+    }
+
+    #[derive(Serialize, JsonSchema)]
+    enum Inner {
+        A(i32),
+        B(String),
+        C(InnerStruct),
+    }
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    #[serde(transparent)]
+    struct Outer(#[serde_as(as = "EnumMap")] Vec<Inner>);
+
+    #[test]
+    fn test_serialized_is_valid() {
+        check_valid_json_schema(&Outer(vec![
+            Inner::A(5),
+            Inner::B("test".into()),
+            Inner::C(InnerStruct {
+                c: "c".into(),
+                d: -34.0,
+            }),
+        ]));
+    }
+
+    #[test]
+    fn test_matches_expected() {
+        check_matches_schema::<Outer>(&json!({
+            "A": 75,
+            "B": "BBBBBB",
+            "C": {
+                "c": "inner C",
+                "d": 777
+            }
+        }));
+    }
+
+    #[test]
+    fn test_no_fields_required() {
+        check_matches_schema::<Outer>(&json!({}));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mixed_up_schemas() {
+        check_matches_schema::<Outer>(&json!({
+            "A": "b",
+            "B": 5
+        }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_key() {
+        check_matches_schema::<Outer>(&json!({
+            "invalid": 4
+        }));
+    }
+}
+
+mod duration {
+    use super::*;
+    use serde_with::formats::{Flexible, Strict};
+    use std::time::{Duration, SystemTime};
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct DurationTest {
+        #[serde_as(as = "DurationSeconds<u64, Strict>")]
+        strict_u64: Duration,
+
+        #[serde_as(as = "DurationSeconds<String, Strict>")]
+        strict_str: Duration,
+
+        #[serde_as(as = "DurationSecondsWithFrac<f64, Strict>")]
+        strict_f64: Duration,
+
+        #[serde_as(as = "DurationSeconds<u64, Flexible>")]
+        flexible_u64: Duration,
+
+        #[serde_as(as = "DurationSeconds<f64, Flexible>")]
+        flexible_f64: Duration,
+
+        #[serde_as(as = "DurationSeconds<String, Flexible>")]
+        flexible_str: Duration,
+    }
+
+    #[test]
+    fn test_serialized_is_valid() {
+        check_valid_json_schema(&DurationTest {
+            strict_u64: Duration::from_millis(2500),
+            strict_str: Duration::from_millis(2500),
+            strict_f64: Duration::from_millis(2500),
+            flexible_u64: Duration::from_millis(2500),
+            flexible_f64: Duration::from_millis(2500),
+            flexible_str: Duration::from_millis(2500),
+        });
+    }
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleU64Duration(#[serde_as(as = "DurationSeconds<u64, Flexible>")] Duration);
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleStringDuration(#[serde_as(as = "DurationSeconds<String, Flexible>")] Duration);
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct FlexibleTimestamp(#[serde_as(as = "TimestampSeconds<i64, Flexible>")] SystemTime);
+
+    #[test]
+    fn test_string_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!("32"));
+    }
+
+    #[test]
+    fn test_integer_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(16));
+    }
+
+    #[test]
+    fn test_number_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(54.1));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_negative_as_flexible_u64() {
+        check_matches_schema::<FlexibleU64Duration>(&json!(-5));
+    }
+
+    #[test]
+    fn test_string_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!("32"));
+    }
+
+    #[test]
+    fn test_integer_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(16));
+    }
+
+    #[test]
+    fn test_number_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(54.1));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_negative_as_flexible_string() {
+        check_matches_schema::<FlexibleStringDuration>(&json!(-5));
+    }
+
+    #[test]
+    fn test_negative_as_flexible_timestamp() {
+        check_matches_schema::<FlexibleTimestamp>(&json!(-50000));
+    }
+
+    #[test]
+    fn test_negative_string_as_flexible_timestamp() {
+        check_matches_schema::<FlexibleTimestamp>(&json!("-50000"));
+    }
+}
+
+#[test]
+fn test_borrow_cow() {
+    use std::borrow::Cow;
+
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Borrowed<'a> {
+        #[serde_as(as = "BorrowCow")]
+        data: Cow<'a, str>,
+    }
+
+    check_valid_json_schema(&Borrowed {
+        data: Cow::Borrowed("test"),
+    });
+}
+
+#[test]
+fn test_map() {
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        map: [(&'static str, u32); 2],
+    }
+
+    check_valid_json_schema(&Test {
+        map: [("a", 1), ("b", 2)],
+    });
+}
+
+#[test]
+fn test_if_is_human_readable() {
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "IfIsHumanReadable<DisplayFromStr>")]
+        data: i32,
+    }
+
+    check_valid_json_schema(&Test { data: 5 });
+    check_matches_schema::<Test>(&json!({ "data": "5" }));
+}
+
+#[test]
+fn test_set_last_value_wins_with_duplicates() {
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "SetLastValueWins<_>")]
+        set: BTreeSet<u32>,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "set": [ 1, 2, 3, 1, 4, 2 ]
+    }));
+}
+
+#[test]
+#[should_panic]
+fn test_set_prevent_duplicates_with_duplicates() {
+    #[serde_as]
+    #[derive(Serialize, JsonSchema)]
+    struct Test {
+        #[serde_as(as = "SetPreventDuplicates<_>")]
+        set: BTreeSet<u32>,
+    }
+
+    check_matches_schema::<Test>(&json!({
+        "set": [ 1, 1 ]
+    }));
+}
+
+mod key_value_map {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[serde_as]
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct KVMap<E>(
+        #[serde_as(as = "KeyValueMap<_>")]
+        #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+        Vec<E>,
+    );
+
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(untagged)]
+    enum UntaggedEnum {
+        A {
+            #[serde(rename = "$key$")]
+            key: String,
+            field1: String,
+        },
+        B(String, i32),
+    }
+
+    #[test]
+    fn test_untagged_enum() {
+        let value = KVMap(vec![
+            UntaggedEnum::A {
+                key: "v1".into(),
+                field1: "field".into(),
+            },
+            UntaggedEnum::B("v2".into(), 7),
+        ]);
+
+        check_valid_json_schema(&value);
+    }
+
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(untagged)]
+    enum UntaggedNestedEnum {
+        Nested(UntaggedEnum),
+        C {
+            #[serde(rename = "$key$")]
+            key: String,
+            field2: i32,
+        },
+    }
+
+    #[test]
+    fn test_untagged_nested_enum() {
+        let value = KVMap(vec![
+            UntaggedNestedEnum::Nested(UntaggedEnum::A {
+                key: "v1".into(),
+                field1: "field".into(),
+            }),
+            UntaggedNestedEnum::Nested(UntaggedEnum::B("v2".into(), 7)),
+            UntaggedNestedEnum::C {
+                key: "v2".into(),
+                field2: 222,
+            },
+        ]);
+
+        check_valid_json_schema(&value);
+    }
+
+    #[test]
+    fn test_btreemap() {
+        let value = KVMap(vec![
+            BTreeMap::from_iter([("$key$", "a"), ("value", "b")]),
+            BTreeMap::from_iter([("$key$", "b"), ("value", "d")]),
+        ]);
+
+        check_valid_json_schema(&value);
+    }
+}
+
+mod one_or_many {
+    use super::*;
+    use serde_with::formats::{PreferMany, PreferOne};
+
+    #[serde_as]
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct WithPreferOne(#[serde_as(as = "OneOrMany<_, PreferOne>")] Vec<i32>);
+
+    #[serde_as]
+    #[derive(Clone, Debug, JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct WithPreferMany(#[serde_as(as = "OneOrMany<_, PreferMany>")] Vec<i32>);
+
+    #[test]
+    fn test_prefer_one() {
+        let single = WithPreferOne(vec![7]);
+        let multiple = WithPreferOne(vec![1, 2, 3]);
+
+        check_valid_json_schema(&single);
+        check_valid_json_schema(&multiple);
+    }
+
+    #[test]
+    fn test_prefer_one_matches() {
+        check_matches_schema::<WithPreferOne>(&json!(7));
+        check_matches_schema::<WithPreferOne>(&json!([1, 2, 3]));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_prefer_one_no_invalid_type_one() {
+        check_matches_schema::<WithPreferOne>(&json!("test"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_prefer_one_no_invalid_type_many() {
+        check_matches_schema::<WithPreferOne>(&json!(["test", 1]));
+    }
+
+    #[test]
+    fn test_prefer_many() {
+        let single = WithPreferMany(vec![7]);
+        let multiple = WithPreferMany(vec![1, 2, 3]);
+
+        check_valid_json_schema(&single);
+        check_valid_json_schema(&multiple);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_prefer_many_no_invalid_type_one() {
+        check_matches_schema::<WithPreferMany>(&json!("test"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_prefer_many_no_invalid_type_many() {
+        check_matches_schema::<WithPreferMany>(&json!(["test", 1]));
+    }
+}
+
+#[test]
+fn test_pickfirst() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct IntOrDisplay(#[serde_as(as = "PickFirst<(_, DisplayFromStr)>")] u32);
+
+    check_matches_schema::<IntOrDisplay>(&json!(7));
+    check_matches_schema::<IntOrDisplay>(&json!("17"));
+}

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -74,11 +74,11 @@ fn schemars_basic() {
         /// Basic field, no attribute
         bare_field: u32,
 
-        /// Field that directly uses DisplayFromStr
+        /// Field that directly uses `DisplayFromStr`
         #[serde_as(as = "DisplayFromStr")]
         display_from_str: u32,
 
-        /// Same does not implement JsonSchema directly so this checks that the
+        /// Same does not implement `JsonSchema` directly so this checks that the
         /// correct schemars attribute was injected.
         #[serde_as(as = "Same")]
         same: u32,
@@ -154,16 +154,16 @@ fn schemars_deserialize_only_bug_735() {
         #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
         both: u32,
 
-        /// Can emit schemars with serialize_as, but it will be ignored
+        /// Can emit schemars with `serialize_as`, but it will be ignored
         #[serde_as(serialize_as = "PickFirst<(_, DisplayFromStr)>")]
         serialize_only: u32,
 
-        /// schemars doesn't support deserialize_as
+        /// schemars doesn't support `deserialize_as`
         #[serde_as(deserialize_as = "PickFirst<(_, DisplayFromStr)>")]
         deserialize_only: u32,
 
-        /// Can emit schemars with serialize_as, but it will be ignored
-        /// schemars doesn't support deserialize_as
+        /// Can emit schemars with `serialize_as`, but it will be ignored
+        /// schemars doesn't support `deserialize_as`
         #[serde_as(
             serialize_as = "PickFirst<(_, DisplayFromStr)>",
             deserialize_as = "PickFirst<(_, DisplayFromStr)>"
@@ -994,7 +994,7 @@ mod key_value_map {
             LimitedProperties(serde_json::json!({
                 "$key$": "B",
                 "a": "b",
-            }))
+            })),
         ]);
 
         check_valid_json_schema(&value);

--- a/serde_with/tests/schemars_0_9/schemars_basic.json
+++ b/serde_with/tests/schemars_0_9/schemars_basic.json
@@ -10,11 +10,11 @@
       "minimum": 0
     },
     "display_from_str": {
-      "description": "Field that directly uses DisplayFromStr",
+      "description": "Field that directly uses `DisplayFromStr`",
       "type": "string"
     },
     "same": {
-      "description": "Same does not implement JsonSchema directly so this checks that the\n correct schemars attribute was injected.",
+      "description": "Same does not implement `JsonSchema` directly so this checks that the\n correct schemars attribute was injected.",
       "type": "integer",
       "format": "uint32",
       "minimum": 0

--- a/serde_with/tests/schemars_0_9/schemars_basic.json
+++ b/serde_with/tests/schemars_0_9/schemars_basic.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Basic",
+  "type": "object",
+  "properties": {
+    "bare_field": {
+      "description": "Basic field, no attribute",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "display_from_str": {
+      "description": "Field that directly uses DisplayFromStr",
+      "type": "string"
+    },
+    "same": {
+      "description": "Same does not implement JsonSchema directly so this checks that the\n correct schemars attribute was injected.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "box_same": {
+      "description": "This checks that Same still works when wrapped in a box.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "vec_same": {
+      "description": "Same thing, but with a Vec this time.",
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    }
+  },
+  "required": [
+    "bare_field",
+    "display_from_str",
+    "same",
+    "box_same",
+    "vec_same"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/schemars_deserialize_only_bug_735.json
+++ b/serde_with/tests/schemars_0_9/schemars_deserialize_only_bug_735.json
@@ -14,19 +14,19 @@
       "$ref": "#/$defs/PickFirst(uint32string)"
     },
     "serialize_only": {
-      "description": "Can emit schemars with serialize_as, but it will be ignored",
+      "description": "Can emit schemars with `serialize_as`, but it will be ignored",
       "type": "integer",
       "format": "uint32",
       "minimum": 0
     },
     "deserialize_only": {
-      "description": "schemars doesn't support deserialize_as",
+      "description": "schemars doesn't support `deserialize_as`",
       "type": "integer",
       "format": "uint32",
       "minimum": 0
     },
     "serialize_and_deserialize": {
-      "description": "Can emit schemars with serialize_as, but it will be ignored\n schemars doesn't support deserialize_as",
+      "description": "Can emit schemars with `serialize_as`, but it will be ignored\n schemars doesn't support `deserialize_as`",
       "type": "integer",
       "format": "uint32",
       "minimum": 0

--- a/serde_with/tests/schemars_0_9/schemars_deserialize_only_bug_735.json
+++ b/serde_with/tests/schemars_0_9/schemars_deserialize_only_bug_735.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Basic",
+  "type": "object",
+  "properties": {
+    "bare_field": {
+      "description": "Basic field, no attribute",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "both": {
+      "description": "Will emit matching schemars attribute",
+      "$ref": "#/$defs/PickFirst(uint32string)"
+    },
+    "serialize_only": {
+      "description": "Can emit schemars with serialize_as, but it will be ignored",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "deserialize_only": {
+      "description": "schemars doesn't support deserialize_as",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "serialize_and_deserialize": {
+      "description": "Can emit schemars with serialize_as, but it will be ignored\n schemars doesn't support deserialize_as",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "bare_field",
+    "both",
+    "serialize_only",
+    "deserialize_only",
+    "serialize_and_deserialize"
+  ],
+  "$defs": {
+    "PickFirst(uint32string)": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        {
+          "writeOnly": true,
+          "allOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/bytes.json
+++ b/serde_with/tests/schemars_0_9/snapshots/bytes.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "bytes": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "required": [
+    "bytes"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/default_on_null.json
+++ b/serde_with/tests/schemars_0_9/snapshots/default_on_null.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/duration.json
+++ b/serde_with/tests/schemars_0_9/snapshots/duration.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "seconds": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "writeOnly": true
+        }
+      ]
+    },
+    "frac": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0.0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "writeOnly": true
+        }
+      ]
+    },
+    "flexible_string": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0.0,
+          "writeOnly": true
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$"
+        }
+      ]
+    },
+    "seconds_u64_strict": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    "time_i64": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "writeOnly": true
+        }
+      ]
+    }
+  },
+  "required": [
+    "seconds",
+    "frac",
+    "flexible_string",
+    "seconds_u64_strict",
+    "time_i64"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/enum_map.json
+++ b/serde_with/tests/schemars_0_9/snapshots/enum_map.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/$defs/EnumMap(Mappable)"
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "$defs": {
+    "EnumMap(Mappable)": {
+      "type": "object",
+      "properties": {
+        "A": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "B": {
+          "type": "string"
+        },
+        "C": {
+          "type": "object",
+          "properties": {
+            "c": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "b": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "c"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/from_into.json
+++ b/serde_with/tests/schemars_0_9/snapshots/from_into.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/key_value_map.json
+++ b/serde_with/tests/schemars_0_9/snapshots/key_value_map.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/$defs/KeyValueMap(KvMapData)"
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "$defs": {
+    "KeyValueMap(KvMapData)": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "d": {
+            "type": "boolean"
+          },
+          "a": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "b": {
+            "type": "string"
+          },
+          "c": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "required": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
+      }
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/key_value_map_enum.json
+++ b/serde_with/tests/schemars_0_9/snapshots/key_value_map_enum.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/$defs/KeyValueMap(KvMapEnum)"
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "$defs": {
+    "KeyValueMap(KvMapEnum)": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "a"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "b"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "c": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "c"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/key_value_map_flatten.json
+++ b/serde_with/tests/schemars_0_9/snapshots/key_value_map_flatten.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "#/$defs/KeyValueMap(KvMapFlatten)"
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "$defs": {
+    "KeyValueMap(KvMapFlatten)": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "extra": {
+            "type": "boolean"
+          }
+        },
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "a"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "b"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "c": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "c"
+            ]
+          }
+        ],
+        "required": [
+          "extra"
+        ]
+      }
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/map.json
+++ b/serde_with/tests/schemars_0_9/snapshots/map.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/map_fixed.json
+++ b/serde_with/tests/schemars_0_9/snapshots/map_fixed.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/one_or_many_nested.json
+++ b/serde_with/tests/schemars_0_9/snapshots/one_or_many_nested.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "optional_many": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OneOrMany(string,PreferOne)"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "$defs": {
+    "OneOrMany(string,PreferOne)": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/one_or_many_prefer_one.json
+++ b/serde_with/tests/schemars_0_9/snapshots/one_or_many_prefer_one.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OneOrMany(int32,PreferOne)",
+  "anyOf": [
+    {
+      "type": "integer",
+      "format": "int32"
+    },
+    {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/pickfirst.json
+++ b/serde_with/tests/schemars_0_9/snapshots/pickfirst.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PickFirst(uint32string)",
+  "anyOf": [
+    {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    {
+      "writeOnly": true,
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/pickfirst_nested.json
+++ b/serde_with/tests/schemars_0_9/snapshots/pickfirst_nested.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OneOrMany(PickFirst(uint32string),PreferOne)",
+  "anyOf": [
+    {
+      "$ref": "#/$defs/PickFirst(uint32string)"
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/PickFirst(uint32string)"
+      }
+    }
+  ],
+  "$defs": {
+    "PickFirst(uint32string)": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        {
+          "writeOnly": true,
+          "allOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/snapshots/set_last_value_wins.json
+++ b/serde_with/tests/schemars_0_9/snapshots/set_last_value_wins.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/set_prevent_duplicates.json
+++ b/serde_with/tests/schemars_0_9/snapshots/set_prevent_duplicates.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/snapshots/string_with_separator.json
+++ b/serde_with/tests/schemars_0_9/snapshots/string_with_separator.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/test_std/map.json
+++ b/serde_with/tests/schemars_0_9/test_std/map.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "map": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  },
+  "required": [
+    "map"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/test_std/option.json
+++ b/serde_with/tests/schemars_0_9/test_std/option.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "optional": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int32"
+    }
+  }
+}

--- a/serde_with/tests/schemars_0_9/test_std/set.json
+++ b/serde_with/tests/schemars_0_9/test_std/set.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "map": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "map"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/test_std/tuples.json
+++ b/serde_with/tests/schemars_0_9/test_std/tuples.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "tuple0": {
+      "type": "null"
+    },
+    "tuple1": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "integer",
+          "format": "int32"
+        }
+      ],
+      "minItems": 1,
+      "maxItems": 1
+    },
+    "tuple2": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "type": "integer",
+          "format": "int32"
+        }
+      ],
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "tuple3": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "minItems": 3,
+      "maxItems": 3
+    }
+  },
+  "required": [
+    "tuple0",
+    "tuple1",
+    "tuple2",
+    "tuple3"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/test_std/vec.json
+++ b/serde_with/tests/schemars_0_9/test_std/vec.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "vec": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "vec"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/test_std/vec_deque.json
+++ b/serde_with/tests/schemars_0_9/test_std/vec_deque.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "vec_deque": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "vec_deque"
+  ]
+}

--- a/serde_with/tests/schemars_0_9/utils.rs
+++ b/serde_with/tests/schemars_0_9/utils.rs
@@ -124,12 +124,12 @@ where
             &mut message,
             "Object was not valid according to its own schema:"
         );
-        let _ = writeln!(&mut message, "  -> {}", err);
+        let _ = writeln!(&mut message, "  -> {err}");
         let _ = writeln!(&mut message);
 
-        panic!("{} {}", message, output);
+        panic!("{message} {output}");
     } else {
-        eprint!("{}", output);
+        eprint!("{output}");
     }
 }
 

--- a/serde_with/tests/schemars_0_9/utils.rs
+++ b/serde_with/tests/schemars_0_9/utils.rs
@@ -1,0 +1,144 @@
+#![allow(dead_code, missing_docs)]
+
+use core::fmt::Debug;
+use expect_test::Expect;
+use pretty_assertions::assert_eq;
+use serde::{de::DeserializeOwned, Serialize};
+
+#[track_caller]
+pub fn is_equal<T>(value: T, expected: Expect)
+where
+    T: Debug + DeserializeOwned + PartialEq + Serialize,
+{
+    let serialized = serde_json::to_string_pretty(&value).unwrap();
+    expected.assert_eq(&serialized);
+    assert_eq!(
+        value,
+        serde_json::from_str::<T>(&serialized).unwrap(),
+        "Deserialization differs from expected value."
+    );
+}
+
+/// Like [`is_equal`] but not pretty-print
+#[track_caller]
+pub fn is_equal_compact<T>(value: T, expected: Expect)
+where
+    T: Debug + DeserializeOwned + PartialEq + Serialize,
+{
+    let serialized = serde_json::to_string(&value).unwrap();
+    expected.assert_eq(&serialized);
+    assert_eq!(
+        value,
+        serde_json::from_str::<T>(&serialized).unwrap(),
+        "Deserialization differs from expected value."
+    );
+}
+
+#[track_caller]
+pub fn check_deserialization<T>(value: T, deserialize_from: &str)
+where
+    T: Debug + DeserializeOwned + PartialEq,
+{
+    assert_eq!(
+        value,
+        serde_json::from_str::<T>(deserialize_from).unwrap(),
+        "Deserialization differs from expected value."
+    );
+}
+
+#[track_caller]
+pub fn check_serialization<T>(value: T, serialize_to: Expect)
+where
+    T: Debug + Serialize,
+{
+    serialize_to.assert_eq(&serde_json::to_string_pretty(&value).unwrap());
+}
+
+#[track_caller]
+pub fn check_error_serialization<T>(value: T, error_msg: Expect)
+where
+    T: Debug + Serialize,
+{
+    error_msg.assert_eq(
+        &serde_json::to_string_pretty(&value)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[track_caller]
+pub fn check_error_deserialization<T>(deserialize_from: &str, error_msg: Expect)
+where
+    T: Debug + DeserializeOwned,
+{
+    error_msg.assert_eq(
+        &serde_json::from_str::<T>(deserialize_from)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[track_caller]
+pub fn check_matches_schema<T>(value: &serde_json::Value)
+where
+    T: schemars_0_9::JsonSchema,
+{
+    use jsonschema::Validator;
+    use std::fmt::Write;
+
+    let schema_object = serde_json::to_value(schemars_0_9::schema_for!(T))
+        .expect("schema for T could not be serialized to json");
+    let schema = match Validator::new(&schema_object) {
+        Ok(schema) => schema,
+        Err(e) => panic!(
+            "\n\
+                schema for T was not a valid JSON schema: {e}\n\
+                \n\
+                Json Schema:\n\
+                {}\n\
+            ",
+            serde_json::to_string_pretty(&schema_object)
+                .unwrap_or_else(|e| format!("> error: {e}"))
+        ),
+    };
+
+    let mut output = String::new();
+
+    let _ = writeln!(&mut output, "Object Value:");
+    let _ = writeln!(
+        &mut output,
+        "{}",
+        serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("> error: {e}"))
+    );
+    let _ = writeln!(&mut output);
+    let _ = writeln!(&mut output, "JSON Schema:");
+    let _ = writeln!(
+        &mut output,
+        "{}",
+        serde_json::to_string_pretty(&schema_object).unwrap_or_else(|e| format!("> error: {e}"))
+    );
+
+    if let Err(err) = schema.validate(value) {
+        let mut message = String::new();
+        let _ = writeln!(
+            &mut message,
+            "Object was not valid according to its own schema:"
+        );
+        let _ = writeln!(&mut message, "  -> {}", err);
+        let _ = writeln!(&mut message);
+
+        panic!("{} {}", message, output);
+    } else {
+        eprint!("{}", output);
+    }
+}
+
+#[track_caller]
+pub fn check_valid_json_schema<T>(value: &T)
+where
+    T: schemars_0_9::JsonSchema + Serialize,
+{
+    let value = serde_json::to_value(value).expect("could not serialize T to json");
+
+    check_matches_schema::<T>(&value);
+}

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -34,6 +34,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 schemars_0_8 = []
+schemars_0_9 = []
 
 [dependencies]
 darling = "0.20.0"

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -573,7 +573,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// ```
 ///
 /// # A note on `schemars` integration
-/// When the `schemars_0_8` feature is enabled this macro will scan for
+/// When the `schemars_0_8` or `schemars_0_9` features are enabled this macro
+/// will scan for
 /// `#[derive(JsonSchema)]` attributes and, if found, will add
 /// `#[schemars(with = "Schema<T, ...>")]` annotations to any fields with a
 /// `#[serde_as(as = ...)]` annotation. If you wish to override the default
@@ -614,7 +615,9 @@ pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
                 .unwrap_or_else(|| syn::parse_quote!(::serde_with));
 
             let schemars_config = match container_options.enable_schemars_support {
-                _ if cfg!(not(feature = "schemars_0_8")) => SchemaFieldConfig::False,
+                _ if cfg!(not(any(feature = "schemars_0_8", feature = "schemars_0_9"))) => {
+                    SchemaFieldConfig::False
+                }
                 Some(condition) => condition.into(),
                 None => utils::has_derive_jsonschema(input.clone()).unwrap_or_default(),
             };


### PR DESCRIPTION
This is mostly a copy-paste from the support for schemars v0.8. There are a couple of changes which make the v0.9 support a bit more messy, but otherwise it's not bad. This commit also duplicates the existing tests, which all pass. Once schemars v1.0 gets released it should hopefully require fewer changes to add support again.

The big changes in schemars that cascade out to support here are
- Schema is now just a very thin wrapper around serde_json::Value. This is rather convenient for defining schemas, less convenient for the transformations we need to make here.
- Some of the trait methods on the JsonSchema trait have had their definitions change.

It's possible the schemars::transform module could be used to make this cleaner. I haven't looked too deeply into what that would involve.

Fixes #842