### PR TITLE
Skip caching for rustfmt in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Rustfmt Check (${{ matrix.rust }})
         uses: actions-rust-lang/rustfmt@v1


### PR DESCRIPTION
Caching is not needed for rustfmt in CI, as it only operates on the
source code, thus no binary artifacts are produced.