### PR TITLE
Add support for `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive`

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add support for `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive` (#851)
+    `RangeToInclusive` is currently unsupported by serde.
+* Add `schemars` implementations for `Bound`, `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive`.
+
 ## [3.13.0] - 2025-06-14
 
 ### Added

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -410,6 +410,78 @@ where
 
 // endregion
 ///////////////////////////////////////////////////////////////////////////////
+// region: More complex wrappers that are not just a single value
+
+impl<'de, Idx, IdxAs> DeserializeAs<'de, Range<Idx>> for Range<IdxAs>
+where
+    IdxAs: DeserializeAs<'de, Idx>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<Range<Idx>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Range::<DeserializeAsWrap<Idx, IdxAs>> { start, end } =
+            Deserialize::deserialize(deserializer)?;
+
+        Ok(Range {
+            start: start.into_inner(),
+            end: end.into_inner(),
+        })
+    }
+}
+
+impl<'de, Idx, IdxAs> DeserializeAs<'de, RangeFrom<Idx>> for RangeFrom<IdxAs>
+where
+    IdxAs: DeserializeAs<'de, Idx>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<RangeFrom<Idx>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let RangeFrom::<DeserializeAsWrap<Idx, IdxAs>> { start } =
+            Deserialize::deserialize(deserializer)?;
+
+        Ok(RangeFrom {
+            start: start.into_inner(),
+        })
+    }
+}
+
+impl<'de, Idx, IdxAs> DeserializeAs<'de, RangeInclusive<Idx>> for RangeInclusive<IdxAs>
+where
+    IdxAs: DeserializeAs<'de, Idx>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<RangeInclusive<Idx>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (start, end) =
+            RangeInclusive::<DeserializeAsWrap<Idx, IdxAs>>::deserialize(deserializer)?
+                .into_inner();
+
+        Ok(RangeInclusive::new(start.into_inner(), end.into_inner()))
+    }
+}
+
+impl<'de, Idx, IdxAs> DeserializeAs<'de, RangeTo<Idx>> for RangeTo<IdxAs>
+where
+    IdxAs: DeserializeAs<'de, Idx>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<RangeTo<Idx>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let RangeTo::<DeserializeAsWrap<Idx, IdxAs>> { end } =
+            Deserialize::deserialize(deserializer)?;
+
+        Ok(RangeTo {
+            end: end.into_inner(),
+        })
+    }
+}
+
+// endregion
+///////////////////////////////////////////////////////////////////////////////
 // region: Collection Types (e.g., Maps, Sets, Vec)
 
 #[cfg(feature = "alloc")]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -395,7 +395,7 @@ pub(crate) mod prelude {
         fmt::{self, Display},
         hash::{BuildHasher, Hash},
         marker::PhantomData,
-        ops::Bound,
+        ops::{Bound, Range, RangeFrom, RangeInclusive, RangeTo},
         option::Option,
         pin::Pin,
         result::Result,

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -276,6 +276,42 @@ where
     forward_schema!(HashSet<WrapSchema<T, TA>, S>);
 }
 
+impl<T, TA> JsonSchemaAs<Bound<T>> for Bound<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(Bound<WrapSchema<T, TA>>);
+}
+
+impl<T, TA> JsonSchemaAs<Range<T>> for Range<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(Range<WrapSchema<T, TA>>);
+}
+
+// Note: Not included in `schemars`
+// impl<T, TA> JsonSchemaAs<RangeFrom<T>> for RangeFrom<TA>
+// where
+//     TA: JsonSchemaAs<T>,
+// {
+//     forward_schema!(RangeFrom<WrapSchema<T, TA>>);
+// }
+
+// impl<T, TA> JsonSchemaAs<RangeTo<T>> for RangeTo<TA>
+// where
+//     TA: JsonSchemaAs<T>,
+// {
+//     forward_schema!(RangeTo<WrapSchema<T, TA>>);
+// }
+
+impl<T, TA> JsonSchemaAs<RangeInclusive<T>> for RangeInclusive<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(RangeInclusive<WrapSchema<T, TA>>);
+}
+
 impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
     TA: JsonSchemaAs<T>,

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -282,6 +282,42 @@ where
     forward_schema!(HashSet<WrapSchema<T, TA>, S>);
 }
 
+impl<T, TA> JsonSchemaAs<Bound<T>> for Bound<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(Bound<WrapSchema<T, TA>>);
+}
+
+impl<T, TA> JsonSchemaAs<Range<T>> for Range<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(Range<WrapSchema<T, TA>>);
+}
+
+// Note: Not included in `schemars`
+// impl<T, TA> JsonSchemaAs<RangeFrom<T>> for RangeFrom<TA>
+// where
+//     TA: JsonSchemaAs<T>,
+// {
+//     forward_schema!(RangeFrom<WrapSchema<T, TA>>);
+// }
+
+// impl<T, TA> JsonSchemaAs<RangeTo<T>> for RangeTo<TA>
+// where
+//     TA: JsonSchemaAs<T>,
+// {
+//     forward_schema!(RangeTo<WrapSchema<T, TA>>);
+// }
+
+impl<T, TA> JsonSchemaAs<RangeInclusive<T>> for RangeInclusive<TA>
+where
+    TA: JsonSchemaAs<T>,
+{
+    forward_schema!(RangeInclusive<WrapSchema<T, TA>>);
+}
+
 impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
     TA: JsonSchemaAs<T>,

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -344,6 +344,72 @@ where
 
 // endregion
 ///////////////////////////////////////////////////////////////////////////////
+// region: More complex wrappers that are not just a single value
+
+impl<Idx, IdxAs> SerializeAs<Range<Idx>> for Range<IdxAs>
+where
+    IdxAs: SerializeAs<Idx>,
+{
+    fn serialize_as<S>(value: &Range<Idx>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Range {
+            start: SerializeAsWrap::<Idx, IdxAs>::new(&value.start),
+            end: SerializeAsWrap::<Idx, IdxAs>::new(&value.end),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<Idx, IdxAs> SerializeAs<RangeFrom<Idx>> for RangeFrom<IdxAs>
+where
+    IdxAs: SerializeAs<Idx>,
+{
+    fn serialize_as<S>(value: &RangeFrom<Idx>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        RangeFrom {
+            start: SerializeAsWrap::<Idx, IdxAs>::new(&value.start),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<Idx, IdxAs> SerializeAs<RangeInclusive<Idx>> for RangeInclusive<IdxAs>
+where
+    IdxAs: SerializeAs<Idx>,
+{
+    fn serialize_as<S>(value: &RangeInclusive<Idx>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        RangeInclusive::new(
+            SerializeAsWrap::<Idx, IdxAs>::new(value.start()),
+            SerializeAsWrap::<Idx, IdxAs>::new(value.end()),
+        )
+        .serialize(serializer)
+    }
+}
+
+impl<Idx, IdxAs> SerializeAs<RangeTo<Idx>> for RangeTo<IdxAs>
+where
+    IdxAs: SerializeAs<Idx>,
+{
+    fn serialize_as<S>(value: &RangeTo<Idx>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        RangeTo {
+            end: SerializeAsWrap::<Idx, IdxAs>::new(&value.end),
+        }
+        .serialize(serializer)
+    }
+}
+
+// endregion
+///////////////////////////////////////////////////////////////////////////////
 // region: Collection Types (e.g., Maps, Sets, Vec)
 
 macro_rules! seq_impl {

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -1,6 +1,7 @@
 //! Test Cases
 
 use crate::utils::{check_matches_schema, check_valid_json_schema};
+use core::ops;
 use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -1073,4 +1074,57 @@ fn test_pickfirst() {
 
     check_matches_schema::<IntOrDisplay>(&json!(7));
     check_matches_schema::<IntOrDisplay>(&json!("17"));
+}
+
+#[test]
+fn test_bound() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct S(#[serde_as(as = "ops::Bound<DisplayFromStr>")] ops::Bound<u32>);
+
+    check_valid_json_schema(&S(ops::Bound::Unbounded));
+    check_valid_json_schema(&S(ops::Bound::Included(42)));
+    check_valid_json_schema(&S(ops::Bound::Excluded(42)));
+}
+
+#[test]
+fn test_range() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct S(#[serde_as(as = "ops::Range<DisplayFromStr>")] ops::Range<u32>);
+
+    check_valid_json_schema(&S(3..7));
+}
+
+// Note: Not included in `schemars`
+// #[test]
+// fn test_rangefrom() {
+//     #[serde_as]
+//     #[derive(JsonSchema, Serialize)]
+//     #[serde(transparent)]
+//     struct S(#[serde_as(as = "ops::RangeFrom<DisplayFromStr>")] ops::RangeFrom<u32>);
+
+//     check_valid_json_schema(&S(3..));
+// }
+
+// #[test]
+// fn test_rangeto() {
+//     #[serde_as]
+//     #[derive(JsonSchema, Serialize)]
+//     #[serde(transparent)]
+//     struct S(#[serde_as(as = "ops::RangeTo<DisplayFromStr>")] ops::RangeTo<u32>);
+
+//     check_valid_json_schema(&S(..7));
+// }
+
+#[test]
+fn test_rangeinclusive() {
+    #[serde_as]
+    #[derive(JsonSchema, Serialize)]
+    #[serde(transparent)]
+    struct S(#[serde_as(as = "ops::RangeInclusive<DisplayFromStr>")] ops::RangeInclusive<u32>);
+
+    check_valid_json_schema(&S(3..=7));
 }

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -24,7 +24,7 @@ use alloc::{
 };
 use core::{
     cell::{Cell, RefCell},
-    ops::Bound,
+    ops::{Bound, Range, RangeFrom, RangeInclusive, RangeTo},
     pin::Pin,
 };
 use expect_test::expect;
@@ -181,16 +181,83 @@ fn test_bound() {
         }"#]],
     );
     check_error_deserialization::<S>(r#"{}"#, expect![[r#"expected value at line 1 column 2"#]]);
+}
 
+#[test]
+fn test_range() {
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct Struct {
-        #[serde_as(as = "Bound<DisplayFromStr>")]
-        value: Bound<u32>,
-    }
-    check_error_deserialization::<Struct>(
-        r#"{}"#,
-        expect![[r#"missing field `value` at line 1 column 2"#]],
+    struct S(#[serde_as(as = "Range<DisplayFromStr>")] Range<u32>);
+
+    is_equal(
+        S(3..7),
+        expect![[r#"
+        {
+          "start": "3",
+          "end": "7"
+        }"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"{"start": false}"#,
+        expect!["invalid type: boolean `false`, expected a string at line 1 column 15"],
+    );
+}
+
+#[test]
+fn test_rangefrom() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "RangeFrom<DisplayFromStr>")] RangeFrom<u32>);
+
+    is_equal(
+        S(3..),
+        expect![[r#"
+        {
+          "start": "3"
+        }"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"{"start": false}"#,
+        expect!["invalid type: boolean `false`, expected a string at line 1 column 15"],
+    );
+}
+
+#[test]
+fn test_rangeto() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "RangeTo<DisplayFromStr>")] RangeTo<u32>);
+
+    is_equal(
+        S(..7),
+        expect![[r#"
+        {
+          "end": "7"
+        }"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"{"end": false}"#,
+        expect!["invalid type: boolean `false`, expected a string at line 1 column 13"],
+    );
+}
+
+#[test]
+fn test_rangeinclusive() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "RangeInclusive<DisplayFromStr>")] RangeInclusive<u32>);
+
+    is_equal(
+        S(3..=7),
+        expect![[r#"
+        {
+          "start": "3",
+          "end": "7"
+        }"#]],
+    );
+    check_error_deserialization::<S>(
+        r#"{"start": false}"#,
+        expect!["invalid type: boolean `false`, expected a string at line 1 column 15"],
     );
 }
 


### PR DESCRIPTION
Add `schemars` implementations for `Bound`, `Range`, `RangeFrom`,
`RangeTo`, `RangeInclusive`.

Closes #851