### PR TITLE
Dead code cleanup

### DIFF
--- a/serde_with/src/content/de.rs
+++ b/serde_with/src/content/de.rs
@@ -22,9 +22,6 @@ use crate::{
 
 /// Used from generated code to buffer the contents of the Deserializer when
 /// deserializing untagged enums and internally tagged enums.
-///
-/// Not public API. Use serde-value instead.
-#[derive(Debug, Clone)]
 pub(crate) enum Content<'de> {
     Bool(bool),
 

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -1059,18 +1059,11 @@ mod timespan {
     // #[non_exhaustive] is not actually necessary here but it should
     // help avoid warnings about semver breakage if this ever changes.
     #[non_exhaustive]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub enum TimespanTargetType {
         String,
         F64,
         U64,
         I64,
-    }
-
-    impl TimespanTargetType {
-        pub const fn is_signed(self) -> bool {
-            !matches!(self, Self::U64)
-        }
     }
 
     /// Internal helper trait used to constrain which types we implement
@@ -1194,7 +1187,7 @@ impl TimespanTargetType {
             ..Default::default()
         };
 
-        if self == Self::String {
+        if matches!(self, Self::String) {
             number.metadata().write_only = true;
         } else {
             string.metadata().write_only = true;

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -1157,7 +1157,7 @@ where
 }
 
 impl TimespanTargetType {
-    pub(crate) fn to_flexible_schema(self, signed: bool) -> Schema {
+    pub(crate) fn into_flexible_schema(self, signed: bool) -> Schema {
         use ::schemars_0_8::schema::StringValidation;
 
         let mut number = SchemaObject {
@@ -1232,7 +1232,7 @@ where
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         <T as TimespanSchemaTarget<F>>::TYPE
-            .to_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
+            .into_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
     }
 
     fn is_referenceable() -> bool {

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -1162,7 +1162,7 @@ where
 }
 
 impl TimespanTargetType {
-    pub(crate) fn to_flexible_schema(self, signed: bool) -> Schema {
+    pub(crate) fn into_flexible_schema(self, signed: bool) -> Schema {
         let mut number = json_schema!({
             "type": "number"
         });
@@ -1229,7 +1229,7 @@ where
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         <T as TimespanSchemaTarget<F>>::TYPE
-            .to_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
+            .into_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
     }
 
     fn inline_schema() -> bool {

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -1061,18 +1061,11 @@ mod timespan {
     // #[non_exhaustive] is not actually necessary here but it should
     // help avoid warnings about semver breakage if this ever changes.
     #[non_exhaustive]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub enum TimespanTargetType {
         String,
         F64,
         U64,
         I64,
-    }
-
-    impl TimespanTargetType {
-        pub const fn is_signed(self) -> bool {
-            !matches!(self, Self::U64)
-        }
     }
 
     /// Internal helper trait used to constrain which types we implement
@@ -1192,7 +1185,7 @@ impl TimespanTargetType {
             }
         });
 
-        if self == Self::String {
+        if matches!(self, Self::String) {
             number
                 .ensure_object()
                 .insert("writeOnly".into(), true.into());

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -1169,7 +1169,7 @@ where
 }
 
 impl TimespanTargetType {
-    pub(crate) fn to_flexible_schema(self, signed: bool) -> Schema {
+    pub(crate) fn into_flexible_schema(self, signed: bool) -> Schema {
         let mut number = json_schema!({
             "type": "number"
         });
@@ -1236,7 +1236,7 @@ where
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         <T as TimespanSchemaTarget<F>>::TYPE
-            .to_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
+            .into_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
     }
 
     fn inline_schema() -> bool {

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -1068,18 +1068,11 @@ mod timespan {
     // #[non_exhaustive] is not actually necessary here but it should
     // help avoid warnings about semver breakage if this ever changes.
     #[non_exhaustive]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub enum TimespanTargetType {
         String,
         F64,
         U64,
         I64,
-    }
-
-    impl TimespanTargetType {
-        pub const fn is_signed(self) -> bool {
-            !matches!(self, Self::U64)
-        }
     }
 
     /// Internal helper trait used to constrain which types we implement
@@ -1199,7 +1192,7 @@ impl TimespanTargetType {
             }
         });
 
-        if self == Self::String {
+        if matches!(self, Self::String) {
             number
                 .ensure_object()
                 .insert("writeOnly".into(), true.into());

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -8,6 +8,7 @@
 use crate::{
     formats::{Flexible, Format, PreferMany, PreferOne, Separator, Strict},
     prelude::{Schema as WrapSchema, *},
+    utils::NumberExt as _,
 };
 use ::schemars_1::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use alloc::{
@@ -16,10 +17,6 @@ use alloc::{
     format,
     rc::Rc,
     vec::Vec,
-};
-use core::{
-    mem::ManuallyDrop,
-    ops::{Deref, DerefMut},
 };
 use serde_json::Value;
 
@@ -694,9 +691,9 @@ where
             };
 
             parents.push(name);
-            DropGuard::new(parents, |parents| drop(parents.pop()))
+            utils::DropGuard::new(parents, |parents| drop(parents.pop()))
         } else {
-            DropGuard::unguarded(parents)
+            utils::DropGuard::unguarded(parents)
         };
 
         // We do comparisons here to avoid lifetime conflicts below
@@ -1293,77 +1290,3 @@ forward_duration_schema!(TimestampSecondsWithFrac);
 forward_duration_schema!(TimestampMilliSecondsWithFrac);
 forward_duration_schema!(TimestampMicroSecondsWithFrac);
 forward_duration_schema!(TimestampNanoSecondsWithFrac);
-
-//===================================================================
-// Extra internal helper structs
-
-struct DropGuard<T, F: FnOnce(T)> {
-    value: ManuallyDrop<T>,
-    guard: Option<F>,
-}
-
-impl<T, F: FnOnce(T)> DropGuard<T, F> {
-    pub fn new(value: T, guard: F) -> Self {
-        Self {
-            value: ManuallyDrop::new(value),
-            guard: Some(guard),
-        }
-    }
-
-    pub fn unguarded(value: T) -> Self {
-        Self {
-            value: ManuallyDrop::new(value),
-            guard: None,
-        }
-    }
-}
-
-impl<T, F: FnOnce(T)> Deref for DropGuard<T, F> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
-
-impl<T, F: FnOnce(T)> DerefMut for DropGuard<T, F> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
-impl<T, F: FnOnce(T)> Drop for DropGuard<T, F> {
-    fn drop(&mut self) {
-        // SAFETY: value is known to be initialized since we only ever remove it here.
-        let value = unsafe { ManuallyDrop::take(&mut self.value) };
-
-        if let Some(guard) = self.guard.take() {
-            guard(value);
-        }
-    }
-}
-
-trait NumberExt: Sized {
-    fn saturating_sub(&self, count: u64) -> Self;
-}
-
-impl NumberExt for serde_json::Number {
-    fn saturating_sub(&self, count: u64) -> Self {
-        if let Some(v) = self.as_u64() {
-            return v.saturating_sub(count).into();
-        }
-
-        if let Some(v) = self.as_i64() {
-            if count < i64::MAX as u64 {
-                return v.saturating_sub(count as _).into();
-            }
-        }
-
-        if let Some(v) = self.as_f64() {
-            return serde_json::Number::from_f64(v - (count as f64))
-                .expect("saturating_sub resulted in NaN");
-        }
-
-        unreachable!()
-    }
-}


### PR DESCRIPTION
* Remove unused derives from internal Content type
* Extract common DropGuard struct and NumberExt trait
* Remove unused derives and dead functions in schemars code