### PR TITLE
Allow for schema derivation for the Hex type

### DIFF
--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -420,7 +420,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
         SchemaObject {
             instance_type: Some(InstanceType::String.into()),
             string: Some(Box::new(StringValidation {
-                pattern: Some(r"^(?:[0-9a-f]{2})*$".to_owned()),
+                pattern: Some(r"^(?:[0-9A-Fa-f]{2})*$".to_owned()),
                 ..Default::default()
             })),
             ..Default::default()
@@ -449,7 +449,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
         SchemaObject {
             instance_type: Some(InstanceType::String.into()),
             string: Some(Box::new(StringValidation {
-                pattern: Some(r"^(?:[0-9A-F]{2})*$".to_owned()),
+                pattern: Some(r"^(?:[0-9A-Fa-f]{2})*$".to_owned()),
                 ..Default::default()
             })),
             ..Default::default()

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -405,42 +405,13 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 }
 
 #[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> String {
-        "Hex<Lowercase>".into()
+        "Hex<F>".into()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Lowercase>".into()
-    }
-
-    fn json_schema(_: &mut SchemaGenerator) -> Schema {
-        use ::schemars_0_8::schema::StringValidation;
-
-        SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            string: Some(Box::new(StringValidation {
-                pattern: Some(r"^(?:[0-9A-Fa-f]{2})*$".to_owned()),
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-        .into()
-    }
-
-    fn is_referenceable() -> bool {
-        false
-    }
-}
-
-#[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
-    fn schema_name() -> String {
-        "Hex<Uppercase>".into()
-    }
-
-    fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Uppercase>".into()
+        "serde_with::hex::Hex<F>".into()
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -404,6 +404,64 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
     forward_schema!(String);
 }
 
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+    fn schema_name() -> String {
+        "Hex<Lowercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Lowercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        use ::schemars_0_8::schema::StringValidation;
+
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some(r"^(?:[0-9a-f]{2})*$".to_owned()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
+    fn schema_name() -> String {
+        "Hex<Uppercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Uppercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        use ::schemars_0_8::schema::StringValidation;
+
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some(r"^(?:[0-9A-F]{2})*$".to_owned()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
     fn schema_name() -> String {
         "BoolFromInt<Strict>".into()

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -419,7 +419,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": r"^(?:[0-9a-f]{2})*$",
+            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
 
@@ -441,7 +441,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": r"^(?:[0-9A-F]{2})*$",
+            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
 

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -406,6 +406,50 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
     forward_schema!(String);
 }
 
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+    fn schema_name() -> Cow<'static, str> {
+        "Hex<Lowercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Lowercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^(?:[0-9a-f]{2})*$",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
+    fn schema_name() -> Cow<'static, str> {
+        "Hex<Uppercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Uppercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^(?:[0-9A-F]{2})*$",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Strict>".into()

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -407,35 +407,13 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 }
 
 #[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> Cow<'static, str> {
-        "Hex<Lowercase>".into()
+        "Hex<F>".into()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Lowercase>".into()
-    }
-
-    fn json_schema(_: &mut SchemaGenerator) -> Schema {
-        json_schema!({
-            "type": "string",
-            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
-        })
-    }
-
-    fn inline_schema() -> bool {
-        true
-    }
-}
-
-#[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
-    fn schema_name() -> Cow<'static, str> {
-        "Hex<Uppercase>".into()
-    }
-
-    fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Uppercase>".into()
+        "serde_with::hex::Hex<F>".into()
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -421,7 +421,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": r"^(?:[0-9a-f]{2})*$",
+            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
 
@@ -443,7 +443,7 @@ impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "string",
-            "pattern": r"^(?:[0-9A-F]{2})*$",
+            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
 

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -408,6 +408,50 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
     forward_schema!(String);
 }
 
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+    fn schema_name() -> Cow<'static, str> {
+        "Hex<Lowercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Lowercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^(?:[0-9a-f]{2})*$",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "hex")]
+impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
+    fn schema_name() -> Cow<'static, str> {
+        "Hex<Uppercase>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::hex::Hex<Uppercase>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^(?:[0-9A-F]{2})*$",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Strict>".into()

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -409,35 +409,13 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 }
 
 #[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Lowercase> {
+impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> Cow<'static, str> {
-        "Hex<Lowercase>".into()
+        "Hex<F>".into()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Lowercase>".into()
-    }
-
-    fn json_schema(_: &mut SchemaGenerator) -> Schema {
-        json_schema!({
-            "type": "string",
-            "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
-        })
-    }
-
-    fn inline_schema() -> bool {
-        true
-    }
-}
-
-#[cfg(feature = "hex")]
-impl<T> JsonSchemaAs<T> for hex::Hex<formats::Uppercase> {
-    fn schema_name() -> Cow<'static, str> {
-        "Hex<Uppercase>".into()
-    }
-
-    fn schema_id() -> Cow<'static, str> {
-        "serde_with::hex::Hex<Uppercase>".into()
+        "serde_with::hex::Hex<F>".into()
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/serde_with/tests/schemars_0_8/main.rs
+++ b/serde_with/tests/schemars_0_8/main.rs
@@ -5,6 +5,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
+use serde_with::hex::*;
 use serde_with::*;
 use std::collections::BTreeSet;
 
@@ -90,6 +91,14 @@ fn schemars_basic() {
         /// Same thing, but with a Vec this time.
         #[serde_as(as = "Vec<_>")]
         vec_same: Vec<u32>,
+
+        /// A vector of bytes that's serialized as a lowercase hex string.
+        #[serde_as(as = "Hex")]
+        lowercase_hex: Vec<u8>,
+
+        /// A vector of bytes that's serialized as an uppercase hex string.
+        #[serde_as(as = "Hex<formats::Uppercase>")]
+        uppercase_hex: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_0_8/schemars_basic.json
+++ b/serde_with/tests/schemars_0_8/schemars_basic.json
@@ -6,7 +6,9 @@
     "bare_field",
     "box_same",
     "display_from_str",
+    "lowercase_hex",
     "same",
+    "uppercase_hex",
     "vec_same"
   ],
   "properties": {
@@ -26,11 +28,21 @@
       "description": "Field that directly uses `DisplayFromStr`",
       "type": "string"
     },
+    "lowercase_hex": {
+      "description": "A vector of bytes that's serialized as a lowercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{2})*$"
+    },
     "same": {
       "description": "Same does not implement `JsonSchema` directly so this checks that the correct schemars attribute was injected.",
       "type": "integer",
       "format": "uint32",
       "minimum": 0.0
+    },
+    "uppercase_hex": {
+      "description": "A vector of bytes that's serialized as an uppercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9A-F]{2})*$"
     },
     "vec_same": {
       "description": "Same thing, but with a Vec this time.",

--- a/serde_with/tests/schemars_0_8/schemars_basic.json
+++ b/serde_with/tests/schemars_0_8/schemars_basic.json
@@ -31,7 +31,7 @@
     "lowercase_hex": {
       "description": "A vector of bytes that's serialized as a lowercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9a-f]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     },
     "same": {
       "description": "Same does not implement `JsonSchema` directly so this checks that the correct schemars attribute was injected.",
@@ -42,7 +42,7 @@
     "uppercase_hex": {
       "description": "A vector of bytes that's serialized as an uppercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9A-F]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     },
     "vec_same": {
       "description": "Same thing, but with a Vec this time.",

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -6,6 +6,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
+use serde_with::hex::*;
 use serde_with::*;
 use std::collections::BTreeSet;
 
@@ -91,6 +92,14 @@ fn schemars_basic() {
         /// Same thing, but with a Vec this time.
         #[serde_as(as = "Vec<_>")]
         vec_same: Vec<u32>,
+
+        /// A vector of bytes that's serialized as a lowercase hex string.
+        #[serde_as(as = "Hex")]
+        lowercase_hex: Vec<u8>,
+
+        /// A vector of bytes that's serialized as an uppercase hex string.
+        #[serde_as(as = "Hex<formats::Uppercase>")]
+        uppercase_hex: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_0_9/schemars_basic.json
+++ b/serde_with/tests/schemars_0_9/schemars_basic.json
@@ -37,12 +37,12 @@
     "lowercase_hex": {
       "description": "A vector of bytes that's serialized as a lowercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9a-f]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     },
     "uppercase_hex": {
       "description": "A vector of bytes that's serialized as an uppercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9A-F]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     }
   },
   "required": [

--- a/serde_with/tests/schemars_0_9/schemars_basic.json
+++ b/serde_with/tests/schemars_0_9/schemars_basic.json
@@ -33,6 +33,16 @@
         "format": "uint32",
         "minimum": 0
       }
+    },
+    "lowercase_hex": {
+      "description": "A vector of bytes that's serialized as a lowercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{2})*$"
+    },
+    "uppercase_hex": {
+      "description": "A vector of bytes that's serialized as an uppercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9A-F]{2})*$"
     }
   },
   "required": [
@@ -40,6 +50,8 @@
     "display_from_str",
     "same",
     "box_same",
-    "vec_same"
+    "vec_same",
+    "lowercase_hex",
+    "uppercase_hex"
   ]
 }

--- a/serde_with/tests/schemars_1/main.rs
+++ b/serde_with/tests/schemars_1/main.rs
@@ -6,6 +6,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
+use serde_with::hex::*;
 use serde_with::*;
 use std::collections::BTreeSet;
 
@@ -91,6 +92,14 @@ fn schemars_basic() {
         /// Same thing, but with a Vec this time.
         #[serde_as(as = "Vec<_>")]
         vec_same: Vec<u32>,
+
+        /// A vector of bytes that's serialized as a lowercase hex string.
+        #[serde_as(as = "Hex")]
+        lowercase_hex: Vec<u8>,
+
+        /// A vector of bytes that's serialized as an uppercase hex string.
+        #[serde_as(as = "Hex<formats::Uppercase>")]
+        uppercase_hex: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_1/schemars_basic.json
+++ b/serde_with/tests/schemars_1/schemars_basic.json
@@ -37,12 +37,12 @@
     "lowercase_hex": {
       "description": "A vector of bytes that's serialized as a lowercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9a-f]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     },
     "uppercase_hex": {
       "description": "A vector of bytes that's serialized as an uppercase hex string.",
       "type": "string",
-      "pattern": "^(?:[0-9A-F]{2})*$"
+      "pattern": "^(?:[0-9A-Fa-f]{2})*$"
     }
   },
   "required": [

--- a/serde_with/tests/schemars_1/schemars_basic.json
+++ b/serde_with/tests/schemars_1/schemars_basic.json
@@ -33,6 +33,16 @@
         "format": "uint32",
         "minimum": 0
       }
+    },
+    "lowercase_hex": {
+      "description": "A vector of bytes that's serialized as a lowercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{2})*$"
+    },
+    "uppercase_hex": {
+      "description": "A vector of bytes that's serialized as an uppercase hex string.",
+      "type": "string",
+      "pattern": "^(?:[0-9A-F]{2})*$"
     }
   },
   "required": [
@@ -40,6 +50,8 @@
     "display_from_str",
     "same",
     "box_same",
-    "vec_same"
+    "vec_same",
+    "lowercase_hex",
+    "uppercase_hex"
   ]
 }


### PR DESCRIPTION
## Description

This PR allows for the `serde_with::hex::Hex` type to be used with `schemars`

## Tests

Updated the `schemars_basic` test cases with tests for lowercase and uppercase hex schemas