### PR TITLE
Generate macro expansion in rustdoc

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Show macro expansion in the docs.rs generated rustdoc.
+    Since macros are used to generate trait implementations, this is useful to understand the exact generated code.
+
 ## [3.14.0] - 2025-06-30
 
 ### Added

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -266,10 +266,13 @@ all-features = true
 rustdoc-args = [
     # Enable doc_cfg showing the required features.
     "--cfg=docsrs",
+    "-Zunstable-options",
     # Generate links to definition in rustdoc source code pages
     # https://github.com/rust-lang/rust/pull/84176
-    "-Zunstable-options",
     "--generate-link-to-definition",
+    # Generate buttons to show macro expansions in the rustdoc output.
+    # https://github.com/rust-lang/rust/pull/137229
+    "--generate-macro-expansion",
     # Link to the stable documentation for core/alloc/std/proc_macro even though docs.rs uses nightly.
     # https://github.com/rust-lang/docs.rs/issues/506#issuecomment-2670501688
     "--extern-html-root-url=core=https://doc.rust-lang.org",

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Show macro expansion in the docs.rs generated rustdoc.
+    Since macros are used to generate trait implementations, this is useful to understand the exact generated code.
+
 ## [3.14.0] - 2025-06-30
 
 ### Added

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -61,6 +61,23 @@ version-sync = "0.9.1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = [
+    # Enable doc_cfg showing the required features.
+    "--cfg=docsrs",
+    "-Zunstable-options",
+    # Generate links to definition in rustdoc source code pages
+    # https://github.com/rust-lang/rust/pull/84176
+    "--generate-link-to-definition",
+    # Generate buttons to show macro expansions in the rustdoc output.
+    # https://github.com/rust-lang/rust/pull/137229
+    "--generate-macro-expansion",
+    # Link to the stable documentation for core/alloc/std/proc_macro even though docs.rs uses nightly.
+    # https://github.com/rust-lang/docs.rs/issues/506#issuecomment-2670501688
+    "--extern-html-root-url=core=https://doc.rust-lang.org",
+    "--extern-html-root-url=alloc=https://doc.rust-lang.org",
+    "--extern-html-root-url=std=https://doc.rust-lang.org",
+    "--extern-html-root-url=proc_macro=https://doc.rust-lang.org",
+]
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
A recent rust nightly added the ability to show macro expansions in the
rustdoc output. Since this crate uses macros for many trait
implementations, this is useful for users trying to understand the macro
output.
https://github.com/rust-lang/rust/pull/137229

Closes #879 