### PR TITLE
Enable crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish-crates-io.yaml
+++ b/.github/workflows/publish-crates-io.yaml
@@ -9,9 +9,13 @@ jobs:
   publish_serde_with:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    # For extra security, limits to protected tags only
+    environment: release
     permissions:
       # Needed to publish releases
       contents: write
+      # Required for OIDC token exchange
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5
@@ -43,9 +47,12 @@ jobs:
           body: ${{ steps.changelog_reader.outputs.changes }}
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
-      - run: cargo login ${CRATES_IO_TOKEN}
-        env:
-          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       # The programs wait until the package is in the index.
       - run: cargo publish --package serde_with_macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - run: cargo publish --package serde_with
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This uses GitHub OIDC tokens to authenticate to crates.io, removing the
need for a long-lived token stored in GitHub secrets.
https://crates.io/docs/trusted-publishing

Closes #880