### PR TITLE
Support `serde_core` and remove dependencies on `serde_derive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,10 +1006,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1026,10 +1027,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.200"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1049,15 +1059,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1097,6 +1108,7 @@ dependencies = [
  "schemars 1.0.2",
  "serde",
  "serde-xml-rs",
+ "serde_core",
  "serde_json",
  "serde_test",
  "serde_with_macros",

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -37,11 +37,11 @@ default = ["std", "macros"]
 #! Some features require `alloc` or `std` support and might not work in a `no_std` environment.
 
 ## Enable support for types from the `alloc` crate when running in a `no_std` environment.
-alloc = ["serde/alloc", "base64?/alloc", "chrono_0_4?/alloc", "hex?/alloc", "serde_json?/alloc", "time_0_3?/alloc"]
+alloc = ["serde_core/alloc", "base64?/alloc", "chrono_0_4?/alloc", "hex?/alloc", "serde_json?/alloc", "time_0_3?/alloc"]
 ## Enables support for various types from the std library.
 ## This will enable `std` support in all dependencies too.
 ## The feature enabled by default and also enables `alloc`.
-std = ["alloc", "serde/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "time_0_3?/serde-well-known", "time_0_3?/std", "schemars_0_9?/std", "schemars_1?/std"]
+std = ["alloc", "serde_core/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "time_0_3?/serde-well-known", "time_0_3?/std", "schemars_0_9?/std", "schemars_1?/std"]
 
 #! # Documentation
 #!
@@ -161,8 +161,8 @@ indexmap_2 = { package = "indexmap", version = "2.0", optional = true, default-f
 schemars_0_8 = { package = "schemars", version = "0.8.16", optional = true, default-features = false }
 schemars_0_9 = { package = "schemars", version = "0.9.0", optional = true, default-features = false }
 schemars_1 = { package = "schemars", version = "1.0.2", optional = true, default-features = false }
-serde = { version = "1.0.152", default-features = false }
-serde_json = { version = "1.0.45", optional = true, default-features = false }
+serde_core = { version = "1.0.225", default-features = false, features = ["result"] }
+serde_json = { version = "1.0.145", optional = true, default-features = false }
 serde_with_macros = { path = "../serde_with_macros", version = "=3.14.1", optional = true }
 time_0_3 = { package = "time", version = "~0.3.36", optional = true, default-features = false }
 

--- a/serde_with/src/content/de.rs
+++ b/serde_with/src/content/de.rs
@@ -380,7 +380,7 @@ where
     let seq = content
         .into_iter()
         .map(|x| ContentDeserializer::new(x, is_human_readable));
-    let mut seq_visitor = serde::de::value::SeqDeserializer::new(seq);
+    let mut seq_visitor = serde_core::de::value::SeqDeserializer::new(seq);
     let value = visitor.visit_seq(&mut seq_visitor)?;
     seq_visitor.end()?;
     Ok(value)
@@ -401,7 +401,7 @@ where
             ContentDeserializer::new(v, is_human_readable),
         )
     });
-    let mut map_visitor = serde::de::value::MapDeserializer::new(map);
+    let mut map_visitor = serde_core::de::value::MapDeserializer::new(map);
     let value = visitor.visit_map(&mut map_visitor)?;
     map_visitor.end()?;
     Ok(value)
@@ -1201,7 +1201,7 @@ where
     let seq = content
         .iter()
         .map(|x| ContentRefDeserializer::new(x, is_human_readable));
-    let mut seq_visitor = serde::de::value::SeqDeserializer::new(seq);
+    let mut seq_visitor = serde_core::de::value::SeqDeserializer::new(seq);
     let value = visitor.visit_seq(&mut seq_visitor)?;
     seq_visitor.end()?;
     Ok(value)
@@ -1222,7 +1222,7 @@ where
             ContentRefDeserializer::new(v, is_human_readable),
         )
     });
-    let mut map_visitor = serde::de::value::MapDeserializer::new(map);
+    let mut map_visitor = serde_core::de::value::MapDeserializer::new(map);
     let value = visitor.visit_map(&mut map_visitor)?;
     map_visitor.end()?;
     Ok(value)

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -733,7 +733,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    serde::forward_to_deserialize_any! {
+    forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct tuple
         tuple_struct map struct enum identifier ignored_any
@@ -815,7 +815,7 @@ where
         visitor.visit_enum(self)
     }
 
-    serde::forward_to_deserialize_any! {
+    forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -57,10 +57,10 @@ macro_rules! flattened_maybe {
     ($fn:ident, $field:tt) => {
         fn $fn<'de, T, D>(deserializer: D) -> $crate::__private__::Result<T, D::Error>
         where
-            T: $crate::serde::Deserialize<'de>,
-            D: $crate::serde::Deserializer<'de>,
+            T: $crate::__private__::Deserialize<'de>,
+            D: $crate::__private__::Deserializer<'de>,
         {
-            $crate::serde::de::DeserializeSeed::deserialize(
+            $crate::__private__::DeserializeSeed::deserialize(
                 $crate::flatten_maybe::FlattenedMaybe($field, $crate::__private__::PhantomData),
                 deserializer,
             )
@@ -73,7 +73,7 @@ macro_rules! flattened_maybe {
 /// Takes as first value the field name of the non-flattened field.
 pub struct FlattenedMaybe<T>(pub &'static str, pub PhantomData<T>);
 
-impl<'de, T> serde::de::DeserializeSeed<'de> for FlattenedMaybe<T>
+impl<'de, T> DeserializeSeed<'de> for FlattenedMaybe<T>
 where
     T: Deserialize<'de>,
 {

--- a/serde_with/src/key_value_map.rs
+++ b/serde_with/src/key_value_map.rs
@@ -923,7 +923,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    serde::forward_to_deserialize_any! {
+    forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct tuple
         tuple_struct map struct enum identifier ignored_any
@@ -1047,7 +1047,7 @@ where
         })
     }
 
-    serde::forward_to_deserialize_any! {
+    forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct
         enum identifier ignored_any
@@ -1246,7 +1246,7 @@ where
         K: DeserializeSeed<'de>,
     {
         if self.first.is_some() {
-            seed.deserialize(serde::de::value::StringDeserializer::new(
+            seed.deserialize(serde_core::de::value::StringDeserializer::new(
                 MAP_KEY_IDENTIFIER.to_string(),
             ))
             .map(Some)

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -266,9 +266,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[doc(hidden)]
-pub extern crate core;
+extern crate core;
 #[doc(hidden)]
-pub extern crate serde;
+extern crate serde_core;
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -402,10 +402,10 @@ pub(crate) mod prelude {
         option::Option,
         pin::Pin,
         result::Result,
-        str::FromStr,
+        str::{self, FromStr},
         time::Duration,
     };
-    pub use serde::{
+    pub use serde_core::{
         de::{
             Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, EnumAccess,
             Error as DeError, Expected, IgnoredAny, IntoDeserializer, MapAccess, SeqAccess,
@@ -2192,12 +2192,12 @@ pub struct BorrowCow;
 #[cfg(feature = "alloc")]
 pub trait InspectError {
     /// Inspect a deserialization error which was skipped.
-    fn inspect_error(error: impl serde::de::Error);
+    fn inspect_error(error: impl serde_core::de::Error);
 }
 
 #[cfg(feature = "alloc")]
 impl InspectError for () {
-    fn inspect_error(_error: impl serde::de::Error) {}
+    fn inspect_error(_error: impl serde_core::de::Error) {}
 }
 
 /// Deserialize a sequence into `Vec<T>`, skipping elements which fail to deserialize.

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -467,7 +467,6 @@ macro_rules! tuple_impl {
             where
                 S: Serializer,
             {
-                use serde::ser::SerializeTuple;
                 let mut tup = serializer.serialize_tuple($len)?;
                 $(
                     tup.serialize_element(&SerializeAsWrap::<$t, $tas>::new(&tuple.$n))?;

--- a/serde_with/src/serde_conv.rs
+++ b/serde_with/src/serde_conv.rs
@@ -120,25 +120,25 @@ macro_rules! serde_conv {
             impl $m {
                 $vis fn serialize<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
                 where
-                    S: $crate::serde::Serializer,
+                    S: $crate::__private__::Serializer,
                 {
                     let y = $ser(x);
-                    $crate::serde::Serialize::serialize(&y, serializer)
+                    $crate::__private__::Serialize::serialize(&y, serializer)
                 }
 
                 $vis fn deserialize<'de, D>(deserializer: D) -> $crate::__private__::Result<$t, D::Error>
                 where
-                    D: $crate::serde::Deserializer<'de>,
+                    D: $crate::__private__::Deserializer<'de>,
                 {
-                    let y = $crate::serde::Deserialize::deserialize(deserializer)?;
-                    $de(y).map_err($crate::serde::de::Error::custom)
+                    let y = $crate::__private__::Deserialize::deserialize(deserializer)?;
+                    $de(y).map_err($crate::__private__::DeError::custom)
                 }
             }
 
             impl $crate::SerializeAs<$t> for $m {
                 fn serialize_as<S>(x: &$t, serializer: S) -> $crate::__private__::Result<S::Ok, S::Error>
                 where
-                    S: $crate::serde::Serializer,
+                    S: $crate::__private__::Serializer,
                 {
                     Self::serialize(x, serializer)
                 }
@@ -147,7 +147,7 @@ macro_rules! serde_conv {
             impl<'de> $crate::DeserializeAs<'de, $t> for $m {
                 fn deserialize_as<D>(deserializer: D) -> $crate::__private__::Result<$t, D::Error>
                 where
-                    D: $crate::serde::Deserializer<'de>,
+                    D: $crate::__private__::Deserializer<'de>,
                 {
                     Self::deserialize(deserializer)
                 }

--- a/serde_with/src/with_prefix.rs
+++ b/serde_with/src/with_prefix.rs
@@ -105,7 +105,7 @@ macro_rules! with_prefix {
     ($module:ident $prefix:expr) => {$crate::with_prefix!(pub(self) $module $prefix);};
     ($vis:vis $module:ident $prefix:expr) => {
         $vis mod $module {
-            use $crate::serde::{Deserialize, Deserializer, Serialize, Serializer};
+            use $crate::__private__::{Deserialize, Deserializer, Serialize, Serializer};
             use $crate::with_prefix::WithPrefix;
 
             #[allow(dead_code)]

--- a/serde_with/src/with_suffix.rs
+++ b/serde_with/src/with_suffix.rs
@@ -116,7 +116,7 @@ macro_rules! with_suffix {
     ($module:ident $suffix:expr) => {$crate::with_suffix!(pub(self) $module $suffix);};
     ($vis:vis $module:ident $suffix:expr) => {
         $vis mod $module {
-            use $crate::serde::{Deserialize, Deserializer, Serialize, Serializer};
+            use $crate::__private__::{Deserialize, Deserializer, Serialize, Serializer};
             use $crate::with_suffix::WithSuffix;
 
             #[allow(dead_code)]

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1087,21 +1087,21 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
     let (de_impl_generics, ty_generics, where_clause) = split_with_de_lifetime(&input.generics);
     quote! {
         #[automatically_derived]
-        impl #de_impl_generics #serde_with_crate_path::serde::Deserialize<'de> for #ident #ty_generics #where_clause {
+        impl #de_impl_generics #serde_with_crate_path::__private__::Deserialize<'de> for #ident #ty_generics #where_clause {
             fn deserialize<__D>(deserializer: __D) -> #serde_with_crate_path::__private__::Result<Self, __D::Error>
             where
-                __D: #serde_with_crate_path::serde::Deserializer<'de>,
+                __D: #serde_with_crate_path::__private__::Deserializer<'de>,
             {
                 struct Helper<__S>(#serde_with_crate_path::__private__::PhantomData<__S>);
 
-                impl<'de, __S> #serde_with_crate_path::serde::de::Visitor<'de> for Helper<__S>
+                impl<'de, __S> #serde_with_crate_path::__private__::Visitor<'de> for Helper<__S>
                 where
                     __S: #serde_with_crate_path::__private__::FromStr,
                     <__S as #serde_with_crate_path::__private__::FromStr>::Err: #serde_with_crate_path::__private__::Display,
                 {
                     type Value = __S;
 
-                    fn expecting(&self, formatter: &mut #serde_with_crate_path::core::fmt::Formatter<'_>) -> #serde_with_crate_path::core::fmt::Result {
+                    fn expecting(&self, formatter: &mut #serde_with_crate_path::__private__::fmt::Formatter<'_>) -> #serde_with_crate_path::__private__::fmt::Result {
                         #serde_with_crate_path::__private__::Display::fmt("a string", formatter)
                     }
 
@@ -1110,9 +1110,9 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
                         value: &str
                     ) -> #serde_with_crate_path::__private__::Result<Self::Value, __E>
                     where
-                        __E: #serde_with_crate_path::serde::de::Error,
+                        __E: #serde_with_crate_path::__private__::DeError,
                     {
-                        value.parse::<Self::Value>().map_err(#serde_with_crate_path::serde::de::Error::custom)
+                        value.parse::<Self::Value>().map_err(#serde_with_crate_path::__private__::DeError::custom)
                     }
 
                     fn visit_bytes<__E>(
@@ -1120,9 +1120,9 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
                         value: &[u8]
                     ) -> #serde_with_crate_path::__private__::Result<Self::Value, __E>
                     where
-                        __E: #serde_with_crate_path::serde::de::Error,
+                        __E: #serde_with_crate_path::__private__::DeError,
                     {
-                        let utf8 = #serde_with_crate_path::core::str::from_utf8(value).map_err(#serde_with_crate_path::serde::de::Error::custom)?;
+                        let utf8 = #serde_with_crate_path::__private__::str::from_utf8(value).map_err(#serde_with_crate_path::__private__::DeError::custom)?;
                         self.visit_str(utf8)
                     }
                 }
@@ -1294,13 +1294,13 @@ fn serialize_display(
 
     quote! {
         #[automatically_derived]
-        impl #impl_generics #serde_with_crate_path::serde::Serialize for #ident #ty_generics #where_clause {
+        impl #impl_generics #serde_with_crate_path::__private__::Serialize for #ident #ty_generics #where_clause {
             fn serialize<__S>(
                 &self,
                 serializer: __S
             ) -> #serde_with_crate_path::__private__::Result<__S::Ok, __S::Error>
             where
-                __S: #serde_with_crate_path::serde::Serializer,
+                __S: #serde_with_crate_path::__private__::Serializer,
             {
                 serializer.collect_str(#collect_str_param)
             }


### PR DESCRIPTION
`serde_core` is the new crate without all the derive related code. The idea is that is allows more build parallelism.

For this first the dependency on `serde_derive` needed to be removed. The only use case was in the macro of `flattened_maybe!`. The same implementation can be done by directly relying on the macros expanded code. `DeserializeSeed` allows the implementation to take variable field names.

The second commit renames all uses of `serde` and replaces them with `serde_core`. It also replaces references to `serde_with::serde` with `serde_with::__private__`, which were commonly used in macro generated code.