### PR TITLE
Remove version-sync crate and reimplement needed functionality with regex and glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "fraction"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,17 +797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,12 +1005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
-
-[[package]]
 name = "serde"
 version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,15 +1061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_test"
 version = "1.0.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,7 +1103,6 @@ dependencies = [
  "serde_with_macros",
  "serde_yaml",
  "time",
- "version-sync",
 ]
 
 [[package]]
@@ -1147,15 +1111,16 @@ version = "3.14.1"
 dependencies = [
  "darling",
  "expect-test",
+ "glob",
  "pretty_assertions",
  "proc-macro2",
  "quote",
+ "regex",
  "rustversion",
  "serde",
  "serde_json",
  "syn",
  "trybuild",
- "version-sync",
 ]
 
 [[package]]
@@ -1292,40 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.7.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "trybuild"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,15 +1272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,17 +1282,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "utf16_iter"
@@ -1399,21 +1310,6 @@ dependencies = [
  "outref",
  "uuid",
  "vsimd",
-]
-
-[[package]]
-name = "version-sync"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835169da0173ea373ddf5987632aac1f918967fbbe58195e304342282efa6089"
-dependencies = [
- "proc-macro2",
- "pulldown-cmark",
- "regex",
- "semver",
- "syn",
- "toml",
- "url",
 ]
 
 [[package]]
@@ -1578,15 +1474,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "write16"

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -186,7 +186,6 @@ serde_json = { version = "1.0.25", features = ["preserve_order"] }
 serde_test = "1.0.124"
 serde_yaml = "0.9.2"
 serde-xml-rs = "0.8.1"
-version-sync = "0.9.1"
 
 [[test]]
 name = "base64"

--- a/serde_with_macros/Cargo.toml
+++ b/serde_with_macros/Cargo.toml
@@ -52,12 +52,13 @@ version = "2.0.0"
 
 [dev-dependencies]
 expect-test = "1.5.0"
+glob = "0.3.0"
 pretty_assertions = "1.4.0"
+regex = { version = "1.11.0", default-features = false, features = ["std"] }
 rustversion = "1.0.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.25"
 trybuild = "1.0.80"
-version-sync = "0.9.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/serde_with_macros/tests/version_numbers.rs
+++ b/serde_with_macros/tests/version_numbers.rs
@@ -1,19 +1,92 @@
-//! Test Cases
+//! Ensure version numbers in various files are up to date.
 
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
+#[track_caller]
+fn check_contains_regex(path: &str, template: &str) {
+    #[track_caller]
+    fn inner(path: &str, template: &str) -> Result<(), String> {
+        // Expand the placeholders in the template.
+        let pattern = template
+            .replace("{name}", &regex::escape(env!("CARGO_PKG_NAME")))
+            .replace("{version}", &regex::escape(env!("CARGO_PKG_VERSION")));
+        let re = regex::Regex::new(&pattern)
+            .map_err(|err| format!("could not parse template: {}", err))?;
+        let text = std::fs::read_to_string(path)
+            .map_err(|err| format!("could not read {}: {}", path, err))?;
+
+        println!("Searching for \"{pattern}\" in {path}...");
+        match re.find(&text) {
+            Some(m) => {
+                let line_no = text[..m.start()].lines().count();
+                println!("{} (line {}) ... ok", path, line_no + 1);
+                Ok(())
+            }
+            None => Err(format!("could not find \"{pattern}\" in {path}")),
+        }
+    }
+
+    if let Err(e) = inner(path, template) {
+        panic!("{e}");
+    }
 }
 
 #[test]
 fn test_changelog() {
-    version_sync::assert_contains_regex!("CHANGELOG.md", r"## \[{version}\]");
+    check_contains_regex("CHANGELOG.md", r"## \[{version}\]");
 }
 
 #[test]
 fn test_serde_with_dependency() {
-    version_sync::assert_contains_regex!(
+    check_contains_regex(
         "../serde_with/Cargo.toml",
-        r#"^serde_with_macros = .*? version = "={version}""#
+        r#"(?m)^serde_with_macros = .*? version = "={version}""#,
     );
+}
+
+/// Check that all docs.rs links point to the current version
+///
+/// Parse all docs.rs links in `*.rs` and `*.md` files and check that they point to the current version.
+/// If a link should point to latest version this can be done by using `latest` in the version.
+/// The `*` version specifier is not allowed.
+#[test]
+fn test_docs_rs_url_point_to_current_version() -> Result<(), Box<dyn std::error::Error>> {
+    let pkg_name = env!("CARGO_PKG_NAME");
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    let re = regex::Regex::new(&format!(
+        "https?://docs.rs/{pkg_name}/((\\d[^/]+|\\*|latest))/"
+    ))?;
+    let mut error = false;
+
+    for entry in glob::glob("**/*.rs")?.chain(glob::glob("**/README.md")?) {
+        let entry = entry?;
+        let content = std::fs::read_to_string(&entry)?;
+        for (line_number, line) in content.split('\n').enumerate() {
+            for capture in re.captures_iter(line) {
+                match capture
+                    .get(1)
+                    .expect("Will exist if regex matches")
+                    .as_str()
+                {
+                    "latest" => {}
+                    version if version != pkg_version => {
+                        error = true;
+                        println!(
+                            "{}:{} pkg_version is {} but found URL {}",
+                            entry.display(),
+                            line_number + 1,
+                            pkg_version,
+                            capture.get(0).expect("Group 0 always exists").as_str()
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    if error {
+        panic!("Found wrong URLs in file(s)");
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
The version-sync crate is not being actively maintained and has depends
on old version of crates like toml and pulls in unnecessary dependencies
like pulldown-cmark.