### PR TITLE
Update the documentation to refer to serde_core instead of serde

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -279,7 +279,8 @@ rustdoc-args = [
     "-Zunstable-options",
     # Generate links to definition in rustdoc source code pages
     # https://github.com/rust-lang/rust/pull/84176
-    "--generate-link-to-definition",
+    # Disable until https://github.com/rust-lang/rust/issues/147882 is resolved.
+    # "--generate-link-to-definition",
     # Generate buttons to show macro expansions in the rustdoc output.
     # https://github.com/rust-lang/rust/pull/137229
     "--generate-macro-expansion",

--- a/serde_with/src/guide.md
+++ b/serde_with/src/guide.md
@@ -1,6 +1,6 @@
 # `serde_with` User Guide
 
-This crate provides helper functions to extend and change how [`serde`] serializes different data types.
+This crate provides helper functions to extend and change how [`serde`](::serde_core) serializes different data types.
 For example, you can serialize [a map as a sequence of tuples][crate::guide::serde_as#maps-to-vec-of-tuples], serialize [using the `Display` and `FromStr` traits][`DisplayFromStr`], or serialize [an empty `String` like `None`][NoneAsEmptyString].
 `serde_with` covers types from the Rust Standard Library and some common crates like [`chrono`][serde_with_chrono].
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -500,7 +500,7 @@ pub struct As<T: ?Sized>(PhantomData<T>);
 /// Adapter to convert from `serde_as` to the serde traits.
 ///
 /// This is the counter-type to [`As`][].
-/// It can be used whenever a type implementing [`DeserializeAs`]/[`SerializeAs`] is required but the normal [`Deserialize`](::serde::Deserialize)/[`Serialize`](::serde::Serialize) traits should be used.
+/// It can be used whenever a type implementing [`DeserializeAs`]/[`SerializeAs`] is required but the normal [`Deserialize`](::serde_core::Deserialize)/[`Serialize`](::serde_core::Serialize) traits should be used.
 /// Check [`As`] for an example.
 pub struct Same;
 
@@ -514,7 +514,7 @@ pub struct Same;
 /// support, which can be found in some crates.
 ///
 /// If you control the type you want to de/serialize, you can instead use the two derive macros, [`SerializeDisplay`] and [`DeserializeFromStr`].
-/// They properly implement the traits [`serde::Serialize`] and [`serde::Deserialize`] such that user of the type no longer have to use the `serde_as` system.
+/// They properly implement the traits [`Serialize`](::serde_core::Serialize) and [`Deserialize`](::serde_core::Deserialize) such that user of the type no longer have to use the `serde_as` system.
 ///
 /// # Examples
 ///
@@ -555,7 +555,7 @@ pub struct DisplayFromStr;
 /// Use the first format if [`De/Serializer::is_human_readable`], otherwise use the second
 ///
 /// If the second format is not specified, the normal
-/// [`Deserialize`](::serde::Deserialize)/[`Serialize`](::serde::Serialize) traits are used.
+/// [`Deserialize`](::serde_core::Deserialize)/[`Serialize`](::serde_core::Serialize) traits are used.
 ///
 /// # Examples
 ///
@@ -591,8 +591,8 @@ pub struct DisplayFromStr;
 /// assert_eq!(vec![145, 2], rmp_serde::to_vec(&x).unwrap());
 /// # }
 /// ```
-/// [`De/Serializer::is_human_readable`]: serde::Serializer::is_human_readable
-/// [`is_human_readable`]: serde::Serializer::is_human_readable
+/// [`De/Serializer::is_human_readable`]: serde_core::Serializer::is_human_readable
+/// [`is_human_readable`]: serde_core::Serializer::is_human_readable
 pub struct IfIsHumanReadable<H, F = Same>(PhantomData<H>, PhantomData<F>);
 
 /// De/Serialize a [`Option<String>`] type while transforming the empty string to [`None`]


### PR DESCRIPTION
Disable --generate-link-to-definition for serde_with as Rust currently
panics when processing the crate with that flag enabled.
https://github.com/rust-lang/rust/issues/147882

Closes #896