### PR TITLE
Bump version to 3.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.16.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.16.0"
 dependencies = [
  "darling",
  "expect-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jonasbb/serde_with/"
 rust-version = "1.76"
-version = "3.15.1"
+version = "3.16.0"
 
 [workspace.metadata.release]
 consolidate-commits = true

--- a/README.md
+++ b/README.md
@@ -179,15 +179,15 @@ Foo::Bytes {
 }
 ```
 
-[`DisplayFromStr`]: https://docs.rs/serde_with/3.15.1/serde_with/struct.DisplayFromStr.html
-[`with_prefix!`]: https://docs.rs/serde_with/3.15.1/serde_with/macro.with_prefix.html
-[`with_suffix!`]: https://docs.rs/serde_with/3.15.1/serde_with/macro.with_suffix.html
-[feature flags]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
-[skip_serializing_none]: https://docs.rs/serde_with/3.15.1/serde_with/attr.skip_serializing_none.html
-[StringWithSeparator]: https://docs.rs/serde_with/3.15.1/serde_with/struct.StringWithSeparator.html
-[user guide]: https://docs.rs/serde_with/3.15.1/serde_with/guide/index.html
+[`DisplayFromStr`]: https://docs.rs/serde_with/3.16.0/serde_with/struct.DisplayFromStr.html
+[`with_prefix!`]: https://docs.rs/serde_with/3.16.0/serde_with/macro.with_prefix.html
+[`with_suffix!`]: https://docs.rs/serde_with/3.16.0/serde_with/macro.with_suffix.html
+[feature flags]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
+[skip_serializing_none]: https://docs.rs/serde_with/3.16.0/serde_with/attr.skip_serializing_none.html
+[StringWithSeparator]: https://docs.rs/serde_with/3.16.0/serde_with/struct.StringWithSeparator.html
+[user guide]: https://docs.rs/serde_with/3.16.0/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with
-[as-annotation]: https://docs.rs/serde_with/3.15.1/serde_with/guide/serde_as/index.html
+[as-annotation]: https://docs.rs/serde_with/3.16.0/serde_with/guide/serde_as/index.html
 
 ## License
 

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.16.0] - 2025-11-14
+
+### Added
+
+* Added support for `smallvec` v1 under the `smallvec_1` feature flag by @isharma228 (#895)
+* Add `JsonSchemaAs` implementation for `json::JsonString` by @yogevm15 (#901)
+
 ## [3.15.1] - 2025-10-21
 
 ### Fixed

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -167,7 +167,7 @@ schemars_0_9 = { package = "schemars", version = "0.9.0", optional = true, defau
 schemars_1 = { package = "schemars", version = "1.0.2", optional = true, default-features = false }
 serde_core = { version = "1.0.225", default-features = false, features = ["result"] }
 serde_json = { version = "1.0.145", optional = true, default-features = false }
-serde_with_macros = { path = "../serde_with_macros", version = "=3.15.1", optional = true }
+serde_with_macros = { path = "../serde_with_macros", version = "=3.16.0", optional = true }
 smallvec_1 = { package = "smallvec", version = "1", optional = true, default-features = false }
 time_0_3 = { package = "time", version = "~0.3.36", optional = true, default-features = false }
 

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -21,7 +21,7 @@
 )))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with/3.15.1/")]
+#![doc(html_root_url = "https://docs.rs/serde_with/3.16.0/")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
@@ -253,15 +253,15 @@
 //! # }
 //! ```
 //!
-//! [`DisplayFromStr`]: https://docs.rs/serde_with/3.15.1/serde_with/struct.DisplayFromStr.html
-//! [`with_prefix!`]: https://docs.rs/serde_with/3.15.1/serde_with/macro.with_prefix.html
-//! [`with_suffix!`]: https://docs.rs/serde_with/3.15.1/serde_with/macro.with_suffix.html
-//! [feature flags]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
-//! [skip_serializing_none]: https://docs.rs/serde_with/3.15.1/serde_with/attr.skip_serializing_none.html
-//! [StringWithSeparator]: https://docs.rs/serde_with/3.15.1/serde_with/struct.StringWithSeparator.html
-//! [user guide]: https://docs.rs/serde_with/3.15.1/serde_with/guide/index.html
+//! [`DisplayFromStr`]: https://docs.rs/serde_with/3.16.0/serde_with/struct.DisplayFromStr.html
+//! [`with_prefix!`]: https://docs.rs/serde_with/3.16.0/serde_with/macro.with_prefix.html
+//! [`with_suffix!`]: https://docs.rs/serde_with/3.16.0/serde_with/macro.with_suffix.html
+//! [feature flags]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
+//! [skip_serializing_none]: https://docs.rs/serde_with/3.16.0/serde_with/attr.skip_serializing_none.html
+//! [StringWithSeparator]: https://docs.rs/serde_with/3.16.0/serde_with/struct.StringWithSeparator.html
+//! [user guide]: https://docs.rs/serde_with/3.16.0/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with
-//! [as-annotation]: https://docs.rs/serde_with/3.15.1/serde_with/guide/serde_as/index.html
+//! [as-annotation]: https://docs.rs/serde_with/3.16.0/serde_with/guide/serde_as/index.html
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -494,7 +494,7 @@ pub use serde_with_macros::*;
 /// # }
 /// ```
 ///
-/// [serde_as]: https://docs.rs/serde_with/3.15.1/serde_with/attr.serde_as.html
+/// [serde_as]: https://docs.rs/serde_with/3.16.0/serde_with/attr.serde_as.html
 pub struct As<T: ?Sized>(PhantomData<T>);
 
 /// Adapter to convert from `serde_as` to the serde traits.
@@ -969,7 +969,7 @@ pub struct BytesOrString;
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSeconds<
     FORMAT: formats::Format = u64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1101,7 +1101,7 @@ pub struct DurationSeconds<
 /// ```
 ///
 /// [`chrono::Duration`]: ::chrono_0_4::Duration
-/// [feature flag]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
 pub struct DurationSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1303,7 +1303,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// [`SystemTime`]: std::time::SystemTime
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
-/// [feature flag]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
     STRICTNESS: formats::Strictness = formats::Strict,
@@ -1445,7 +1445,7 @@ pub struct TimestampSeconds<
 /// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
 /// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
 /// [NaiveDateTime]: ::chrono_0_4::NaiveDateTime
-/// [feature flag]: https://docs.rs/serde_with/3.15.1/serde_with/guide/feature_flags/index.html
+/// [feature flag]: https://docs.rs/serde_with/3.16.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,
     STRICTNESS: formats::Strictness = formats::Strict,

--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.16.0] - 2025-11-14
+
+No changes.
+
 ## [3.15.1] - 2025-10-21
 
 No changes.

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -20,7 +20,7 @@
 )))]
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
-#![doc(html_root_url = "https://docs.rs/serde_with_macros/3.15.1/")]
+#![doc(html_root_url = "https://docs.rs/serde_with_macros/3.16.0/")]
 // Tarpaulin does not work well with proc macros and marks most of the lines as uncovered.
 #![cfg(not(tarpaulin_include))]
 
@@ -589,8 +589,8 @@ fn field_has_attribute(field: &Field, namespace: &str, name: &str) -> bool {
 /// It will also work if the relevant derive is behind a `#[cfg_attr]` attribute
 /// and propagate the `#[cfg_attr]` to the various `#[schemars]` field attributes.
 ///
-/// [`serde_as`]: https://docs.rs/serde_with/3.15.1/serde_with/guide/index.html
-/// [re-exporting `serde_as`]: https://docs.rs/serde_with/3.15.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [`serde_as`]: https://docs.rs/serde_with/3.16.0/serde_with/guide/index.html
+/// [re-exporting `serde_as`]: https://docs.rs/serde_with/3.16.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 #[proc_macro_attribute]
 pub fn serde_as(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(FromMeta)]
@@ -1060,7 +1060,7 @@ fn has_type_embedded(type_: &Type, embedded_type: &syn::Ident) -> bool {
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/3.15.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/3.16.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(DeserializeFromStr, attributes(serde_with))]
 pub fn derive_deserialize_fromstr(item: TokenStream) -> TokenStream {
@@ -1180,7 +1180,7 @@ fn deserialize_fromstr(mut input: DeriveInput, serde_with_crate_path: Path) -> T
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
 /// [cargo-toml-rename]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
-/// [serde-as-crate]: https://docs.rs/serde_with/3.15.1/serde_with/guide/serde_as/index.html#re-exporting-serde_as
+/// [serde-as-crate]: https://docs.rs/serde_with/3.16.0/serde_with/guide/serde_as/index.html#re-exporting-serde_as
 /// [serde-crate]: https://serde.rs/container-attrs.html#crate
 #[proc_macro_derive(SerializeDisplay, attributes(serde_with))]
 pub fn derive_serialize_display(item: TokenStream) -> TokenStream {


### PR DESCRIPTION
### Added

* Added support for `smallvec` v1 under the `smallvec_1` feature flag by \@isharma228 (#895)
* Add `JsonSchemaAs` implementation for `json::JsonString` by \@yogevm15 (#901)