### PR TITLE
Fix example for SerializeDisplayAlt

### DIFF
--- a/serde_with_macros/CHANGELOG.md
+++ b/serde_with_macros/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix example for SerializeDisplayAlt.
+    Remove unsupported attributes from example.
+
 ## [3.16.1] - 2025-11-27
 
 No changes.

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -1234,7 +1234,6 @@ pub fn derive_serialize_display(item: TokenStream) -> TokenStream {
 /// use serde_with::{SerializeDisplayAlt, DeserializeFromStr};
 ///
 /// #[derive(Debug, Clone, SerializeDisplayAlt, DeserializeFromStr)]
-/// #[serde(transparent)]
 /// pub struct MyType(u32);
 ///
 /// impl fmt::Display for MyType {


### PR DESCRIPTION
In #915 it was reported that the example for SerializeDisplayAlt was incorrect. It does not support the #[serde(transparent)] attribute.

Closes #915