### PR TITLE
Add `skip_serializing_default` macro helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Foo {a: None, b: None, c: None, d: Some(4), e: None, f: None, g: Some(7)}
 
 If many fields should be omitted whenever they equal their default value, putting the annotations on each field can become tedious.
 The `#[skip_serializing_default]` attribute must be placed *before* the `#[derive]`.
+Fields with `#[serde(default = "...")]` are compared against that custom default function, making serialization and deserialization symmetric for that field.
 
 ```rust
 #[skip_serializing_default]
@@ -146,6 +147,11 @@ Foo {a: String::new(), b: 0, c: true}
 // into this JSON
 {"c": true}
 ```
+
+This macro relies on `PartialEq` for default values.
+Rust does not guarantee that two values returned by `Default::default()` compare equal.
+If that does not hold for a field type, use a manual `skip_serializing_if` or opt out with `#[serialize_always]`.
+Struct-level `#[serde(default)]` is not inspected; fields without their own custom default function are compared against their type's default value.
 
 ### Advanced `serde_as` usage
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Some common use cases are:
     With `serde_as` large arrays are supported, even if they are nested in other types.
     `[bool; 64]`, `Option<[u8; M]>`, and `Box<[[u8; 64]; N]>` are all supported, as [this examples shows](#large-and-const-generic-arrays).
 * Skip serializing all empty `Option` types with [`#[skip_serializing_none]`][skip_serializing_none].
+* Skip serializing all fields equal to their default value with [`#[skip_serializing_default]`][skip_serializing_default].
 * Apply a prefix / suffix to each field name of a struct, without changing the de/serialize implementations of the struct using [`with_prefix!`][] / [`with_suffix!`][].
 * Deserialize a comma separated list like `#hash,#tags,#are,#great` into a `Vec<String>`.
      Check the documentation for [`serde_with::StringWithSeparator::<CommaSeparator, T>`][StringWithSeparator].
@@ -125,6 +126,27 @@ Foo {a: None, b: None, c: None, d: Some(4), e: None, f: None, g: Some(7)}
 {"d": 4, "g": 7}
 ```
 
+### `skip_serializing_default`
+
+If many fields should be omitted whenever they equal their default value, putting the annotations on each field can become tedious.
+The `#[skip_serializing_default]` attribute must be placed *before* the `#[derive]`.
+
+```rust
+#[skip_serializing_default]
+#[derive(Serialize)]
+struct Foo {
+    a: String,
+    b: usize,
+    c: bool,
+}
+
+// This will serialize
+Foo {a: String::new(), b: 0, c: true}
+
+// into this JSON
+{"c": true}
+```
+
 ### Advanced `serde_as` usage
 
 This example is mainly supposed to highlight the flexibility of the `serde_as` annotation compared to [serde's `with` annotation][with-annotation].
@@ -184,6 +206,7 @@ Foo::Bytes {
 [`with_suffix!`]: https://docs.rs/serde_with/3.18.0/serde_with/macro.with_suffix.html
 [feature flags]: https://docs.rs/serde_with/3.18.0/serde_with/guide/feature_flags/index.html
 [skip_serializing_none]: https://docs.rs/serde_with/3.18.0/serde_with/attr.skip_serializing_none.html
+[skip_serializing_default]: https://docs.rs/serde_with/3.18.0/serde_with/attr.skip_serializing_default.html
 [StringWithSeparator]: https://docs.rs/serde_with/3.18.0/serde_with/struct.StringWithSeparator.html
 [user guide]: https://docs.rs/serde_with/3.18.0/serde_with/guide/index.html
 [with-annotation]: https://serde.rs/field-attrs.html#with

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -474,6 +474,13 @@ pub(crate) mod prelude {
 #[doc(hidden)]
 pub mod __private__ {
     pub use crate::prelude::*;
+
+    pub fn is_default<T>(value: &T) -> bool
+    where
+        T: Default + PartialEq,
+    {
+        value == &T::default()
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -41,6 +41,7 @@
 //!   With `serde_as` large arrays are supported, even if they are nested in other types.
 //!   `[bool; 64]`, `Option<[u8; M]>`, and `Box<[[u8; 64]; N]>` are all supported, as [this examples shows](#large-and-const-generic-arrays).
 //! * Skip serializing all empty `Option` types with [`#[skip_serializing_none]`][skip_serializing_none].
+//! * Skip serializing all fields equal to their default value with [`#[skip_serializing_default]`][skip_serializing_default].
 //! * Apply a prefix / suffix to each field name of a struct, without changing the de/serialize implementations of the struct using [`with_prefix!`][] / [`with_suffix!`][].
 //! * Deserialize a comma separated list like `#hash,#tags,#are,#great` into a `Vec<String>`.
 //!   Check the documentation for [`serde_with::StringWithSeparator::<CommaSeparator, T>`][StringWithSeparator].
@@ -177,6 +178,38 @@
 //! # }
 //! ```
 //!
+//! ## `skip_serializing_default`
+//!
+//! If many fields should be omitted whenever they equal their default value, putting the
+//! annotations on each field can become tedious. The `#[skip_serializing_default]` attribute must
+//! be placed *before* the `#[derive]`.
+//!
+//! ```rust
+//! # #[cfg(all(feature = "macros", feature = "json"))] {
+//! # use serde::Serialize;
+//! # use serde_with::skip_serializing_default;
+//! #[skip_serializing_default]
+//! # #[derive(Debug, Eq, PartialEq)]
+//! #[derive(Serialize)]
+//! struct Foo {
+//!     a: String,
+//!     b: usize,
+//!     c: bool,
+//! }
+//!
+//! // This will serialize
+//! # let foo =
+//! Foo {a: String::new(), b: 0, c: true}
+//! # ;
+//!
+//! // into this JSON
+//! # let json = r#"
+//! {"c": true}
+//! # "#;
+//! # assert_eq!(json.replace(" ", "").replace("\n", ""), serde_json::to_string(&foo).unwrap());
+//! # }
+//! ```
+//!
 //! ## Advanced `serde_as` usage
 //!
 //! This example is mainly supposed to highlight the flexibility of the `serde_as` annotation compared to [serde's `with` annotation][with-annotation].
@@ -258,6 +291,7 @@
 //! [`with_suffix!`]: https://docs.rs/serde_with/3.18.0/serde_with/macro.with_suffix.html
 //! [feature flags]: https://docs.rs/serde_with/3.18.0/serde_with/guide/feature_flags/index.html
 //! [skip_serializing_none]: https://docs.rs/serde_with/3.18.0/serde_with/attr.skip_serializing_none.html
+//! [skip_serializing_default]: https://docs.rs/serde_with/3.18.0/serde_with/attr.skip_serializing_default.html
 //! [StringWithSeparator]: https://docs.rs/serde_with/3.18.0/serde_with/struct.StringWithSeparator.html
 //! [user guide]: https://docs.rs/serde_with/3.18.0/serde_with/guide/index.html
 //! [with-annotation]: https://serde.rs/field-attrs.html#with

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -183,6 +183,8 @@
 //! If many fields should be omitted whenever they equal their default value, putting the
 //! annotations on each field can become tedious. The `#[skip_serializing_default]` attribute must
 //! be placed *before* the `#[derive]`.
+//! Fields with `#[serde(default = "...")]` are compared against that custom default function,
+//! making serialization and deserialization symmetric for that field.
 //!
 //! ```rust
 //! # #[cfg(all(feature = "macros", feature = "json"))] {
@@ -209,6 +211,12 @@
 //! # assert_eq!(json.replace(" ", "").replace("\n", ""), serde_json::to_string(&foo).unwrap());
 //! # }
 //! ```
+//!
+//! This macro relies on `PartialEq` for default values. Rust does not guarantee that two values
+//! returned by `Default::default()` compare equal. If that does not hold for a field type, use a
+//! manual `skip_serializing_if` or opt out with `#[serialize_always]`. Struct-level
+//! `#[serde(default)]` is not inspected; fields without their own custom default function are
+//! compared against their type's default value.
 //!
 //! ## Advanced `serde_as` usage
 //!

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -352,7 +352,7 @@ pub fn skip_serializing_default(_args: TokenStream, input: TokenStream) -> Token
 fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Error> {
     if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
         let helper = skip_serializing_default_helper(&input.ident);
-        let helper_path = LitStr::new(&helper.to_string(), Span::call_site());
+        let helper_path = serde_with_is_default_path();
         let cfg_attrs: Vec<_> = input
             .attrs
             .iter()
@@ -368,23 +368,13 @@ fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Err
             &mut helper_fns,
         )?;
         Ok(quote! {
-            #(#cfg_attrs)*
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #helper<T>(value: &T) -> bool
-            where
-                T: ::core::default::Default + ::core::cmp::PartialEq,
-            {
-                value == &<T as ::core::default::Default>::default()
-            }
-
             #(#helper_fns)*
 
             #input
         })
     } else if let Ok(mut input) = syn::parse::<ItemEnum>(input) {
         let helper = skip_serializing_default_helper(&input.ident);
-        let helper_path = LitStr::new(&helper.to_string(), Span::call_site());
+        let helper_path = serde_with_is_default_path();
         let cfg_attrs: Vec<_> = input
             .attrs
             .iter()
@@ -403,16 +393,6 @@ fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Err
             )?;
         }
         Ok(quote! {
-            #(#cfg_attrs)*
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #helper<T>(value: &T) -> bool
-            where
-                T: ::core::default::Default + ::core::cmp::PartialEq,
-            {
-                value == &<T as ::core::default::Default>::default()
-            }
-
             #(#helper_fns)*
 
             #input
@@ -427,6 +407,10 @@ fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Err
 
 fn skip_serializing_default_helper(ident: &syn::Ident) -> syn::Ident {
     format_ident!("__serde_with_skip_serializing_default_for_{ident}")
+}
+
+fn serde_with_is_default_path() -> LitStr {
+    LitStr::new("::serde_with::__private__::is_default", Span::call_site())
 }
 
 fn apply_skip_serializing_default_on_fields(

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -52,8 +52,8 @@ use syn::{
     parse_macro_input, parse_quote,
     punctuated::{Pair, Punctuated},
     spanned::Spanned,
-    DeriveInput, Error, Field, Fields, GenericArgument, ItemEnum, ItemStruct, LitStr, Meta, Path,
-    PathArguments, ReturnType, Token, Type,
+    DeriveInput, Error, Expr, Field, Fields, GenericArgument, ItemEnum, ItemStruct, Lit, LitStr,
+    Meta, Path, PathArguments, ReturnType, Token, Type,
 };
 
 /// Apply function on every field of structs or enums
@@ -334,8 +334,15 @@ pub fn skip_serializing_none(_args: TokenStream, input: TokenStream) -> TokenStr
 ///
 /// Existing `skip_serializing_if` annotations will not be altered.
 ///
-/// Each annotated field needs to implement [`Default`] and [`PartialEq`], as the generated
-/// predicate checks `value == Default::default()`.
+/// Each annotated field without a field-level `#[serde(default = "...")]` needs to implement
+/// [`Default`] and [`PartialEq`], as the generated predicate checks
+/// `value == Default::default()`. Rust does not guarantee that two values returned by
+/// [`Default::default`] compare equal. If that does not hold for a field type, use a manual
+/// `skip_serializing_if` or opt out with `#[serialize_always]`.
+///
+/// Fields with `#[serde(default = "some_func")]` are compared against `some_func()` instead.
+/// Struct-level `#[serde(default)]` is not inspected; fields without their own custom default
+/// function are compared against their type's default value.
 #[proc_macro_attribute]
 pub fn skip_serializing_default(_args: TokenStream, input: TokenStream) -> TokenStream {
     let res = skip_serializing_default_impl(input).unwrap_or_else(|err| err.to_compile_error());
@@ -345,61 +352,68 @@ pub fn skip_serializing_default(_args: TokenStream, input: TokenStream) -> Token
 fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Error> {
     if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
         let helper = skip_serializing_default_helper(&input.ident);
-        let helper_path = LitStr::new(&format!("{helper}::is_default"), Span::call_site());
+        let helper_path = LitStr::new(&helper.to_string(), Span::call_site());
         let cfg_attrs: Vec<_> = input
             .attrs
             .iter()
             .filter(|attr| attr.path().is_ident("cfg"))
             .cloned()
             .collect();
-        apply_on_fields(&mut input.fields, |field| {
-            skip_serializing_default_add_attr_to_field(field, &helper_path)
-        })?;
+        let mut helper_fns = Vec::new();
+        apply_skip_serializing_default_on_fields(
+            &mut input.fields,
+            &helper,
+            &helper_path,
+            &cfg_attrs,
+            &mut helper_fns,
+        )?;
         Ok(quote! {
             #(#cfg_attrs)*
             #[doc(hidden)]
             #[allow(non_snake_case)]
-            mod #helper {
-                pub fn is_default<T>(value: &T) -> bool
-                where
-                    T: ::core::default::Default + ::core::cmp::PartialEq,
-                {
-                    value == &<T as ::core::default::Default>::default()
-                }
+            fn #helper<T>(value: &T) -> bool
+            where
+                T: ::core::default::Default + ::core::cmp::PartialEq,
+            {
+                value == &<T as ::core::default::Default>::default()
             }
+
+            #(#helper_fns)*
 
             #input
         })
     } else if let Ok(mut input) = syn::parse::<ItemEnum>(input) {
         let helper = skip_serializing_default_helper(&input.ident);
-        let helper_path = LitStr::new(&format!("{helper}::is_default"), Span::call_site());
+        let helper_path = LitStr::new(&helper.to_string(), Span::call_site());
         let cfg_attrs: Vec<_> = input
             .attrs
             .iter()
             .filter(|attr| attr.path().is_ident("cfg"))
             .cloned()
             .collect();
-        input
-            .variants
-            .iter_mut()
-            .map(|variant| {
-                apply_on_fields(&mut variant.fields, |field| {
-                    skip_serializing_default_add_attr_to_field(field, &helper_path)
-                })
-            })
-            .collect_error()?;
+        let mut helper_fns = Vec::new();
+        for (variant_idx, variant) in input.variants.iter_mut().enumerate() {
+            let variant_helper = format_ident!("{helper}_variant_{variant_idx}");
+            apply_skip_serializing_default_on_fields(
+                &mut variant.fields,
+                &variant_helper,
+                &helper_path,
+                &cfg_attrs,
+                &mut helper_fns,
+            )?;
+        }
         Ok(quote! {
             #(#cfg_attrs)*
             #[doc(hidden)]
             #[allow(non_snake_case)]
-            mod #helper {
-                pub fn is_default<T>(value: &T) -> bool
-                where
-                    T: ::core::default::Default + ::core::cmp::PartialEq,
-                {
-                    value == &<T as ::core::default::Default>::default()
-                }
+            fn #helper<T>(value: &T) -> bool
+            where
+                T: ::core::default::Default + ::core::cmp::PartialEq,
+            {
+                value == &<T as ::core::default::Default>::default()
             }
+
+            #(#helper_fns)*
 
             #input
         })
@@ -415,21 +429,46 @@ fn skip_serializing_default_helper(ident: &syn::Ident) -> syn::Ident {
     format_ident!("__serde_with_skip_serializing_default_for_{ident}")
 }
 
-fn apply_on_fields<F>(fields: &mut Fields, function: F) -> Result<(), Error>
-where
-    F: Fn(&mut Field) -> Result<(), String>,
-{
+fn apply_skip_serializing_default_on_fields(
+    fields: &mut Fields,
+    helper: &syn::Ident,
+    type_default_helper_path: &LitStr,
+    item_cfg_attrs: &[syn::Attribute],
+    helper_fns: &mut Vec<TokenStream2>,
+) -> Result<(), Error> {
     match fields {
         Fields::Unit => Ok(()),
         Fields::Named(fields) => fields
             .named
             .iter_mut()
-            .map(|field| function(field).map_err(|err| Error::new(field.span(), err)))
+            .enumerate()
+            .map(|(idx, field)| {
+                skip_serializing_default_add_attr_to_field(
+                    field,
+                    idx,
+                    helper,
+                    type_default_helper_path,
+                    item_cfg_attrs,
+                    helper_fns,
+                )
+                .map_err(|err| Error::new(field.span(), err))
+            })
             .collect_error(),
         Fields::Unnamed(fields) => fields
             .unnamed
             .iter_mut()
-            .map(|field| function(field).map_err(|err| Error::new(field.span(), err)))
+            .enumerate()
+            .map(|(idx, field)| {
+                skip_serializing_default_add_attr_to_field(
+                    field,
+                    idx,
+                    helper,
+                    type_default_helper_path,
+                    item_cfg_attrs,
+                    helper_fns,
+                )
+                .map_err(|err| Error::new(field.span(), err))
+            })
             .collect_error(),
     }
 }
@@ -484,9 +523,14 @@ fn skip_serializing_none_add_attr_to_field(field: &mut Field) -> Result<(), Stri
 
 fn skip_serializing_default_add_attr_to_field(
     field: &mut Field,
-    helper_path: &LitStr,
+    field_idx: usize,
+    helper: &syn::Ident,
+    type_default_helper_path: &LitStr,
+    item_cfg_attrs: &[syn::Attribute],
+    helper_fns: &mut Vec<TokenStream2>,
 ) -> Result<(), String> {
     let has_skip_serializing_if = field_has_attribute(field, "serde", "skip_serializing_if");
+    let serde_default = field_serde_default(field)?;
 
     // Remove the `serialize_always` attribute
     let mut has_always_attr = false;
@@ -513,11 +557,84 @@ fn skip_serializing_default_add_attr_to_field(
         return Ok(());
     }
 
+    let helper_path = match serde_default {
+        Some(SerdeDefault::Function(default_fn)) => {
+            let helper_fn = format_ident!("{helper}_field_{field_idx}");
+            let helper_path = LitStr::new(&helper_fn.to_string(), Span::call_site());
+            let field_cfg_attrs: Vec<_> = field
+                .attrs
+                .iter()
+                .filter(|attr| attr.path().is_ident("cfg"))
+                .cloned()
+                .collect();
+            let ty = &field.ty;
+            helper_fns.push(quote! {
+                #(#item_cfg_attrs)*
+                #(#field_cfg_attrs)*
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                fn #helper_fn(value: &#ty) -> bool {
+                    value == &#default_fn()
+                }
+            });
+            helper_path
+        }
+        Some(SerdeDefault::Type) | None => type_default_helper_path.clone(),
+    };
+
     let attr = parse_quote!(
         #[serde(skip_serializing_if = #helper_path)]
     );
     field.attrs.push(attr);
     Ok(())
+}
+
+enum SerdeDefault {
+    Type,
+    Function(Path),
+}
+
+fn field_serde_default(field: &Field) -> Result<Option<SerdeDefault>, String> {
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Meta::List(expr) = &attr.meta else {
+            continue;
+        };
+        let nested =
+            match Punctuated::<Meta, Token![,]>::parse_terminated.parse2(expr.tokens.clone()) {
+                Ok(nested) => nested,
+                Err(_) => continue,
+            };
+        for expr in nested {
+            match expr {
+                Meta::Path(path) if path.is_ident("default") => {
+                    return Ok(Some(SerdeDefault::Type));
+                }
+                Meta::NameValue(expr) if expr.path.is_ident("default") => {
+                    let Expr::Lit(expr) = expr.value else {
+                        return Err(
+                            r#"Expected `serde(default = "...")` to use a string literal path."#
+                                .into(),
+                        );
+                    };
+                    let Lit::Str(default_fn) = expr.lit else {
+                        return Err(
+                            r#"Expected `serde(default = "...")` to use a string literal path."#
+                                .into(),
+                        );
+                    };
+                    let default_fn = default_fn
+                        .parse::<Path>()
+                        .map_err(|err| format!("Could not parse serde default path: {err}."))?;
+                    return Ok(Some(SerdeDefault::Function(default_fn)));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Return `true`, if the type path refers to `std::option::Option`

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -46,13 +46,13 @@ use darling::{
 };
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{
     parse::Parser,
     parse_macro_input, parse_quote,
     punctuated::{Pair, Punctuated},
     spanned::Spanned,
-    DeriveInput, Error, Field, Fields, GenericArgument, ItemEnum, ItemStruct, Meta, Path,
+    DeriveInput, Error, Field, Fields, GenericArgument, ItemEnum, ItemStruct, LitStr, Meta, Path,
     PathArguments, ReturnType, Token, Type,
 };
 
@@ -310,6 +310,130 @@ pub fn skip_serializing_none(_args: TokenStream, input: TokenStream) -> TokenStr
     TokenStream::from(res)
 }
 
+/// Add `skip_serializing_if` annotations to fields, which check if the value matches
+/// [`Default::default`].
+///
+/// The attribute can be added to structs and enums.
+/// The `#[skip_serializing_default]` attribute must be placed *before* the `#[derive]` attribute.
+///
+/// # Example
+///
+/// ```rust
+/// # use serde::Serialize;
+/// # use serde_with_macros::skip_serializing_default;
+/// #
+/// # #[allow(dead_code)]
+/// #[skip_serializing_default]
+/// #[derive(Serialize)]
+/// struct Data {
+///     a: String,
+///     b: u64,
+///     c: bool,
+/// }
+/// ```
+///
+/// Existing `skip_serializing_if` annotations will not be altered.
+///
+/// Each annotated field needs to implement [`Default`] and [`PartialEq`], as the generated
+/// predicate checks `value == Default::default()`.
+#[proc_macro_attribute]
+pub fn skip_serializing_default(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let res = skip_serializing_default_impl(input).unwrap_or_else(|err| err.to_compile_error());
+    TokenStream::from(res)
+}
+
+fn skip_serializing_default_impl(input: TokenStream) -> Result<TokenStream2, Error> {
+    if let Ok(mut input) = syn::parse::<ItemStruct>(input.clone()) {
+        let helper = skip_serializing_default_helper(&input.ident);
+        let helper_path = LitStr::new(&format!("{helper}::is_default"), Span::call_site());
+        let cfg_attrs: Vec<_> = input
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg"))
+            .cloned()
+            .collect();
+        apply_on_fields(&mut input.fields, |field| {
+            skip_serializing_default_add_attr_to_field(field, &helper_path)
+        })?;
+        Ok(quote! {
+            #(#cfg_attrs)*
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            mod #helper {
+                pub fn is_default<T>(value: &T) -> bool
+                where
+                    T: ::core::default::Default + ::core::cmp::PartialEq,
+                {
+                    value == &<T as ::core::default::Default>::default()
+                }
+            }
+
+            #input
+        })
+    } else if let Ok(mut input) = syn::parse::<ItemEnum>(input) {
+        let helper = skip_serializing_default_helper(&input.ident);
+        let helper_path = LitStr::new(&format!("{helper}::is_default"), Span::call_site());
+        let cfg_attrs: Vec<_> = input
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg"))
+            .cloned()
+            .collect();
+        input
+            .variants
+            .iter_mut()
+            .map(|variant| {
+                apply_on_fields(&mut variant.fields, |field| {
+                    skip_serializing_default_add_attr_to_field(field, &helper_path)
+                })
+            })
+            .collect_error()?;
+        Ok(quote! {
+            #(#cfg_attrs)*
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            mod #helper {
+                pub fn is_default<T>(value: &T) -> bool
+                where
+                    T: ::core::default::Default + ::core::cmp::PartialEq,
+                {
+                    value == &<T as ::core::default::Default>::default()
+                }
+            }
+
+            #input
+        })
+    } else {
+        Err(Error::new(
+            Span::call_site(),
+            "The attribute can only be applied to struct or enum definitions.",
+        ))
+    }
+}
+
+fn skip_serializing_default_helper(ident: &syn::Ident) -> syn::Ident {
+    format_ident!("__serde_with_skip_serializing_default_for_{ident}")
+}
+
+fn apply_on_fields<F>(fields: &mut Fields, function: F) -> Result<(), Error>
+where
+    F: Fn(&mut Field) -> Result<(), String>,
+{
+    match fields {
+        Fields::Unit => Ok(()),
+        Fields::Named(fields) => fields
+            .named
+            .iter_mut()
+            .map(|field| function(field).map_err(|err| Error::new(field.span(), err)))
+            .collect_error(),
+        Fields::Unnamed(fields) => fields
+            .unnamed
+            .iter_mut()
+            .map(|field| function(field).map_err(|err| Error::new(field.span(), err)))
+            .collect_error(),
+    }
+}
+
 /// Add the `skip_serializing_if` annotation to each field of the struct
 fn skip_serializing_none_add_attr_to_field(field: &mut Field) -> Result<(), String> {
     if is_std_option(&field.ty) {
@@ -355,6 +479,44 @@ fn skip_serializing_none_add_attr_to_field(field: &mut Field) -> Result<(), Stri
             return Err("`serialize_always` may only be used on fields of type `Option`.".into());
         }
     }
+    Ok(())
+}
+
+fn skip_serializing_default_add_attr_to_field(
+    field: &mut Field,
+    helper_path: &LitStr,
+) -> Result<(), String> {
+    let has_skip_serializing_if = field_has_attribute(field, "serde", "skip_serializing_if");
+
+    // Remove the `serialize_always` attribute
+    let mut has_always_attr = false;
+    field.attrs.retain(|attr| {
+        let has_attr = attr.path().is_ident("serialize_always");
+        has_always_attr |= has_attr;
+        !has_attr
+    });
+
+    // Error on conflicting attributes
+    if has_always_attr && has_skip_serializing_if {
+        let mut msg = r#"The attributes `serialize_always` and `serde(skip_serializing_if = "...")` cannot be used on the same field"#.to_string();
+        if let Some(ident) = &field.ident {
+            msg += ": `";
+            msg += &ident.to_string();
+            msg += "`";
+        }
+        msg += ".";
+        return Err(msg);
+    }
+
+    // Do nothing if `skip_serializing_if` or `serialize_always` is already present
+    if has_skip_serializing_if || has_always_attr {
+        return Ok(());
+    }
+
+    let attr = parse_quote!(
+        #[serde(skip_serializing_if = #helper_path)]
+    );
+    field.attrs.push(attr);
     Ok(())
 }
 

--- a/serde_with_macros/tests/skip_serializing_default.rs
+++ b/serde_with_macros/tests/skip_serializing_default.rs
@@ -1,0 +1,130 @@
+//! Test Cases
+
+use pretty_assertions::assert_eq;
+use serde::Serialize;
+use serde_json::json;
+use serde_with_macros::skip_serializing_default;
+
+fn never<T>(_t: &T) -> bool {
+    false
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DataBasic {
+    a: String,
+    b: u64,
+    c: bool,
+    d: Option<String>,
+}
+
+#[test]
+fn test_basic() {
+    let expected = json!({});
+    let data = DataBasic {
+        a: String::new(),
+        b: 0,
+        c: false,
+        d: None,
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+
+    let expected = json!({
+        "a": "test",
+        "b": 1,
+        "c": true,
+        "d": "value",
+    });
+    let data = DataBasic {
+        a: "test".to_string(),
+        b: 1,
+        c: true,
+        d: Some("value".to_string()),
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DataExistingAnnotation {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    a: String,
+    #[serde(skip_serializing_if = "never")]
+    #[serde(rename = "name")]
+    b: u64,
+    c: bool,
+}
+
+#[test]
+fn test_existing_annotation() {
+    let expected = json!({ "name": 0 });
+    let data = DataExistingAnnotation {
+        a: String::new(),
+        b: 0,
+        c: false,
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DataSerializeAlways {
+    #[serialize_always]
+    a: String,
+    b: u64,
+}
+
+#[test]
+fn test_serialize_always() {
+    let expected = json!({
+        "a": "",
+    });
+    let data = DataSerializeAlways {
+        a: String::new(),
+        b: 0,
+    };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DataTuple(String, u64);
+
+#[test]
+fn test_tuple() {
+    let expected = json!([]);
+    let data = DataTuple(String::new(), 0);
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+enum DataEnum {
+    Tuple(String, u64),
+    Struct { a: String, b: u64 },
+}
+
+#[test]
+fn test_enum() {
+    let expected = json!({
+        "Tuple": []
+    });
+    let data = DataEnum::Tuple(String::new(), 0);
+    let res = serde_json::to_value(data).unwrap();
+    assert_eq!(expected, res);
+
+    let expected = json!({
+        "Struct": {}
+    });
+    let data = DataEnum::Struct {
+        a: String::new(),
+        b: 0,
+    };
+    let res = serde_json::to_value(data).unwrap();
+    assert_eq!(expected, res);
+}

--- a/serde_with_macros/tests/skip_serializing_default.rs
+++ b/serde_with_macros/tests/skip_serializing_default.rs
@@ -5,6 +5,18 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with_macros::skip_serializing_default;
 
+extern crate self as serde_with;
+
+#[allow(missing_docs)]
+pub mod __private__ {
+    pub fn is_default<T>(value: &T) -> bool
+    where
+        T: Default + PartialEq,
+    {
+        value == &T::default()
+    }
+}
+
 fn never<T>(_t: &T) -> bool {
     false
 }

--- a/serde_with_macros/tests/skip_serializing_default.rs
+++ b/serde_with_macros/tests/skip_serializing_default.rs
@@ -1,13 +1,24 @@
 //! Test Cases
 
 use pretty_assertions::assert_eq;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with_macros::skip_serializing_default;
 
 fn never<T>(_t: &T) -> bool {
     false
 }
+
+fn custom_default() -> u64 {
+    42
+}
+
+fn custom_no_default() -> NoDefault {
+    NoDefault(1)
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct NoDefault(u64);
 
 #[skip_serializing_default]
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -65,6 +76,47 @@ fn test_existing_annotation() {
         b: 0,
         c: false,
     };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DataSerdeDefaultFunction {
+    #[serde(default = "custom_default")]
+    a: u64,
+}
+
+#[test]
+fn test_serde_default_function() {
+    let expected = json!({});
+    let data = DataSerdeDefaultFunction { a: 42 };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+    assert_eq!(data, serde_json::from_value(res).unwrap());
+
+    let expected = json!({ "a": 0 });
+    let data = DataSerdeDefaultFunction { a: 0 };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+}
+
+#[skip_serializing_default]
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct DataSerdeDefaultFunctionNoDefault {
+    #[serde(default = "custom_no_default")]
+    a: NoDefault,
+}
+
+#[test]
+fn test_serde_default_function_does_not_require_default() {
+    let expected = json!({});
+    let data = DataSerdeDefaultFunctionNoDefault { a: NoDefault(1) };
+    let res = serde_json::to_value(&data).unwrap();
+    assert_eq!(expected, res);
+
+    let expected = json!({ "a": 2 });
+    let data = DataSerdeDefaultFunctionNoDefault { a: NoDefault(2) };
     let res = serde_json::to_value(&data).unwrap();
     assert_eq!(expected, res);
 }


### PR DESCRIPTION
This helps like the Option one but for other types like Vec, wrappers around Option, etc.