### PR TITLE
Fix shortened sections of example code to match actual trait impl for `…Ref` variants of [`Try`]`FromInto`.

### DIFF
--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -1890,7 +1890,7 @@ pub struct FromInto<T>(PhantomData<T>);
 ///
 /// # /*
 /// impl From<(u8, u8, u8)> for Rgb { ... }
-/// impl From<Rgb> for (u8, u8, u8) { ... }
+/// impl<'a> From<&'a Rgb> for (u8, u8, u8) { ... }
 /// # */
 /// #
 /// # impl From<(u8, u8, u8)> for Rgb {
@@ -2061,7 +2061,7 @@ pub struct TryFromInto<T>(PhantomData<T>);
 /// }
 ///
 /// # /*
-/// impl From<Boollike> for u8 { ... }
+/// impl<'a> From<&'a Boollike> for u8 { ... }
 /// # */
 /// #
 /// impl TryFrom<u8> for Boollike {


### PR DESCRIPTION
(This is only a documentation fix/change.)

The previous/current version appears to have been a copy-paste error, forgetting to apply the necessary changes from the non-`…Ref` counterparts. This means that the documentation is confusing since [the example code](https://docs.rs/serde_with/3.19.0/serde_with/struct.FromIntoRef.html#example)

```rust
#[derive(Debug, PartialEq)]
struct Rgb {
    red: u8,
    green: u8,
    blue: u8,
}

impl From<(u8, u8, u8)> for Rgb { ... }
impl From<Rgb> for (u8, u8, u8) { ... }

#[serde_as]
#[derive(Deserialize, Serialize)]
struct Color {
    #[serde_as(as = "FromIntoRef<(u8, u8, u8)>")]
    rgb: Rgb,
}
let color = Color {
    rgb: Rgb {
        red: 128,
        green: 64,
        blue: 32,
    },
};

// Define our expected JSON form
let j = json!({
    "rgb": [128, 64, 32],
});
// Ensure serialization and deserialization produce the expected results
assert_eq!(j, serde_json::to_value(&color).unwrap());
assert_eq!(color, serde_json::from_value(j).unwrap());
```

fails to highlight the correct trait impl to make things work.