### PR TITLE
feat: automatic `schemars` support for `Base64`

### DIFF
--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -135,7 +135,7 @@ macros = ["dep:serde_with_macros"]
 ##
 ## This pulls in [`schemars` v0.8](::schemars_0_8) as a dependency. It will also implicitly enable
 ## the `std` feature as `schemars` is not `#[no_std]`.
-schemars_0_8 = ["dep:schemars_0_8", "std", "serde_with_macros?/schemars_0_8"]
+schemars_0_8 = ["dep:schemars_0_8", "std", "serde_with_macros?/schemars_0_8", "dep:serde_json"]
 ## This feature enables integration with `schemars` v0.9
 ## This makes `#[derive(JsonSchema)]` pick up the correct schema for the type
 ## used within `#[serde_as(as = ...)]`.
@@ -291,17 +291,17 @@ required-features = ["smallvec_1", "macros"]
 [[test]]
 name = "schemars_0_8"
 path = "tests/schemars_0_8/main.rs"
-required-features = ["schemars_0_8", "base58", "hex"]
+required-features = ["schemars_0_8", "base58", "base64", "hex"]
 
 [[test]]
 name = "schemars_0_9"
 path = "tests/schemars_0_9/main.rs"
-required-features = ["schemars_0_9", "std", "base58", "hex"]
+required-features = ["schemars_0_9", "std", "base58", "base64", "hex"]
 
 [[test]]
 name = "schemars_1"
 path = "tests/schemars_1/main.rs"
-required-features = ["schemars_1", "std", "base58", "hex"]
+required-features = ["schemars_1", "std", "base58", "base64", "hex"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -428,6 +428,31 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
     }
 }
 
+#[cfg(feature = "base64")]
+impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn schema_name() -> String {
+        "Base64<A, F>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::base64::Base64<A, F>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            // See <https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.8.3>
+            extensions: [("contentEncoding".to_string(), serde_json::json!("base64"))].into(),
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
 #[cfg(feature = "hex")]
 impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> String {

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -428,6 +428,29 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
     }
 }
 
+#[cfg(feature = "base64")]
+impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn schema_name() -> Cow<'static, str> {
+        "Base64<A, F>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::base64::Base64<A, F>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            // See <https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.8.3>
+            "contentEncoding": "base64",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
 #[cfg(feature = "hex")]
 impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> Cow<'static, str> {

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -430,6 +430,29 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
     }
 }
 
+#[cfg(feature = "base64")]
+impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn schema_name() -> Cow<'static, str> {
+        "Base64<A, F>".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "serde_with::base64::Base64<A, F>".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            // See <https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.8.3>
+            "contentEncoding": "base64",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
 #[cfg(feature = "hex")]
 impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
     fn schema_name() -> Cow<'static, str> {

--- a/serde_with/tests/schemars_0_8/main.rs
+++ b/serde_with/tests/schemars_0_8/main.rs
@@ -5,7 +5,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
-use serde_with::{base58::*, hex::*, *};
+use serde_with::{base58::*, base64::*, hex::*, *};
 use std::collections::{BTreeMap, BTreeSet};
 
 // This avoids us having to add `#[schemars(crate = "::schemars_0_8")]` all
@@ -107,6 +107,15 @@ fn schemars_basic() {
         /// charset.
         #[serde_as(as = "Base58<Flickr>")]
         base58_flickr: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string.
+        #[serde_as(as = "Base64")]
+        base64: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string in URL-safe
+        /// charset.
+        #[serde_as(as = "Base64<UrlSafe>")]
+        base64_urlsafe: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_0_8/schemars_basic.json
+++ b/serde_with/tests/schemars_0_8/schemars_basic.json
@@ -6,6 +6,8 @@
     "bare_field",
     "base58",
     "base58_flickr",
+    "base64",
+    "base64_urlsafe",
     "box_same",
     "display_from_str",
     "lowercase_hex",
@@ -27,6 +29,16 @@
     "base58_flickr": {
       "description": "A vector of bytes that's serialized as a base58 string in `Flickr` charset.",
       "type": "string"
+    },
+    "base64": {
+      "description": "A vector of bytes that's serialized as a base64 string.",
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "base64_urlsafe": {
+      "description": "A vector of bytes that's serialized as a base64 string in URL-safe charset.",
+      "type": "string",
+      "contentEncoding": "base64"
     },
     "box_same": {
       "description": "This checks that Same still works when wrapped in a box.",

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -6,7 +6,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
-use serde_with::{base58::*, hex::*, *};
+use serde_with::{base58::*, base64::*, hex::*, *};
 use std::collections::{BTreeMap, BTreeSet};
 
 // This avoids us having to add `#[schemars(crate = "::schemars_0_9")]` all
@@ -108,6 +108,15 @@ fn schemars_basic() {
         /// charset.
         #[serde_as(as = "Base58<Flickr>")]
         base58_flickr: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string.
+        #[serde_as(as = "Base64")]
+        base64: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string in URL-safe
+        /// charset.
+        #[serde_as(as = "Base64<UrlSafe>")]
+        base64_urlsafe: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_0_9/schemars_basic.json
+++ b/serde_with/tests/schemars_0_9/schemars_basic.json
@@ -51,6 +51,16 @@
     "base58_flickr": {
       "description": "A vector of bytes that's serialized as a base58 string in `Flickr`\n charset.",
       "type": "string"
+    },
+    "base64": {
+      "description": "A vector of bytes that's serialized as a base64 string.",
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "base64_urlsafe": {
+      "description": "A vector of bytes that's serialized as a base64 string in URL-safe\n charset.",
+      "type": "string",
+      "contentEncoding": "base64"
     }
   },
   "required": [
@@ -62,6 +72,8 @@
     "lowercase_hex",
     "uppercase_hex",
     "base58",
-    "base58_flickr"
+    "base58_flickr",
+    "base64",
+    "base64_urlsafe"
   ]
 }

--- a/serde_with/tests/schemars_1/main.rs
+++ b/serde_with/tests/schemars_1/main.rs
@@ -6,7 +6,7 @@ use expect_test::expect_file;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
-use serde_with::{base58::*, hex::*, *};
+use serde_with::{base58::*, base64::*, hex::*, *};
 use std::collections::{BTreeMap, BTreeSet};
 
 // This avoids us having to add `#[schemars(crate = "::schemars_1")]` all
@@ -108,6 +108,15 @@ fn schemars_basic() {
         /// charset.
         #[serde_as(as = "Base58<Flickr>")]
         base58_flickr: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string.
+        #[serde_as(as = "Base64")]
+        base64: Vec<u8>,
+
+        /// A vector of bytes that's serialized as a base64 string in URL-safe
+        /// charset.
+        #[serde_as(as = "Base64<UrlSafe>")]
+        base64_urlsafe: Vec<u8>,
     }
 
     let schema = schemars::schema_for!(Basic);

--- a/serde_with/tests/schemars_1/schemars_basic.json
+++ b/serde_with/tests/schemars_1/schemars_basic.json
@@ -51,6 +51,16 @@
     "base58_flickr": {
       "description": "A vector of bytes that's serialized as a base58 string in `Flickr`\ncharset.",
       "type": "string"
+    },
+    "base64": {
+      "description": "A vector of bytes that's serialized as a base64 string.",
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "base64_urlsafe": {
+      "description": "A vector of bytes that's serialized as a base64 string in URL-safe\ncharset.",
+      "type": "string",
+      "contentEncoding": "base64"
     }
   },
   "required": [
@@ -62,6 +72,8 @@
     "lowercase_hex",
     "uppercase_hex",
     "base58",
-    "base58_flickr"
+    "base58_flickr",
+    "base64",
+    "base64_urlsafe"
   ]
 }


### PR DESCRIPTION
Hey @jonasbb, here is a follow-up PR that adds `schemars` support for `#[serde_as(as = "Base64")]`.
Without it, devs have to annotate it every time:
```rust
#[serde_as]
#[derive(Serialize, Deserialize, JsonSchema)]
struct B64 {
    #[serde_as(as = "Base64")]
    #[schemars(with = "String")] // <- not needed anymore
    bytes: Vec<u8>,
}
```
Will be happy to address any comments and hope it can get included in next release as well 🤞🏻