### PR TITLE
feat: add NoneAsZero adapter for Option<NonZero*>

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add `NoneAsZero` adapter that maps `Option<NonZero*>` to a plain integer, encoding `None` as `0` (#486)
+
 ## [3.20.0] - 2026-05-10
 
 ### Added

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -1117,6 +1117,39 @@ where
     }
 }
 
+macro_rules! none_as_zero_deserialize {
+    ($($nonzero:ident => $primitive:ident),* $(,)?) => {
+        $(
+            impl<'de> DeserializeAs<'de, Option<core::num::$nonzero>> for NoneAsZero {
+                fn deserialize_as<D>(
+                    deserializer: D,
+                ) -> Result<Option<core::num::$nonzero>, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let value = <$primitive>::deserialize(deserializer)?;
+                    Ok(core::num::$nonzero::new(value))
+                }
+            }
+        )*
+    };
+}
+
+none_as_zero_deserialize! {
+    NonZeroU8    => u8,
+    NonZeroU16   => u16,
+    NonZeroU32   => u32,
+    NonZeroU64   => u64,
+    NonZeroU128  => u128,
+    NonZeroUsize => usize,
+    NonZeroI8    => i8,
+    NonZeroI16   => i16,
+    NonZeroI32   => i32,
+    NonZeroI64   => i64,
+    NonZeroI128  => i128,
+    NonZeroIsize => isize,
+}
+
 #[cfg(feature = "alloc")]
 impl<'de, T, TAs> DeserializeAs<'de, T> for DefaultOnError<TAs>
 where

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -402,6 +402,21 @@ value: Option<String>,
 "value": "Hello World!", // converts to Some
 ```
 
+## `None` as zero for `Option<NonZero*>`
+
+[`NoneAsZero`]
+
+```ignore
+// Rust
+#[serde_as(as = "serde_with::NoneAsZero")]
+value: Option<core::num::NonZeroU32>,
+
+// JSON
+"value": 0, // converts to None
+
+"value": 42, // converts to Some(NonZeroU32::new(42).unwrap())
+```
+
 ## One or many elements into `Vec`
 
 [`OneOrMany`]
@@ -641,6 +656,7 @@ value: u128,
 [`MapFirstKeyWins`]: crate::MapFirstKeyWins
 [`MapPreventDuplicates`]: crate::MapPreventDuplicates
 [`NoneAsEmptyString`]: crate::NoneAsEmptyString
+[`NoneAsZero`]: crate::NoneAsZero
 [`OneOrMany`]: crate::OneOrMany
 [`PickFirst`]: crate::PickFirst
 [`SetLastValueWins`]: crate::SetLastValueWins

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -639,6 +639,59 @@ pub struct IfIsHumanReadable<H, F = Same>(PhantomData<H>, PhantomData<F>);
 /// [`FromStr`]: std::str::FromStr
 pub struct NoneAsEmptyString;
 
+/// De/Serialize an [`Option<NonZero*>`] losslessly as the inner integer
+///
+/// Serde natively supports [`NonZeroU8`] and friends, but rejects `0` during deserialization.
+/// This adapter treats `0` as [`None`] and any other value as [`Some`], allowing the wire format
+/// to always be a plain integer.
+///
+/// Supported in-memory types are [`Option<NonZeroU8>`], [`Option<NonZeroU16>`], [`Option<NonZeroU32>`],
+/// [`Option<NonZeroU64>`], [`Option<NonZeroU128>`], [`Option<NonZeroUsize>`], [`Option<NonZeroI8>`],
+/// [`Option<NonZeroI16>`], [`Option<NonZeroI32>`], [`Option<NonZeroI64>`], [`Option<NonZeroI128>`],
+/// and [`Option<NonZeroIsize>`].
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "macros")] {
+/// # use core::num::NonZeroU32;
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::{serde_as, NoneAsZero};
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct Data {
+///     #[serde_as(as = "NoneAsZero")]
+///     value: Option<NonZeroU32>,
+/// }
+///
+/// let data = Data { value: NonZeroU32::new(7) };
+/// assert_eq!(json!({"value": 7}), serde_json::to_value(&data).unwrap());
+/// assert_eq!(data, serde_json::from_value(json!({"value": 7})).unwrap());
+///
+/// let none = Data { value: None };
+/// assert_eq!(json!({"value": 0}), serde_json::to_value(&none).unwrap());
+/// assert_eq!(none, serde_json::from_value(json!({"value": 0})).unwrap());
+/// # }
+/// ```
+///
+/// [`NonZeroU8`]: core::num::NonZeroU8
+/// [`Option<NonZeroU8>`]: core::num::NonZeroU8
+/// [`Option<NonZeroU16>`]: core::num::NonZeroU16
+/// [`Option<NonZeroU32>`]: core::num::NonZeroU32
+/// [`Option<NonZeroU64>`]: core::num::NonZeroU64
+/// [`Option<NonZeroU128>`]: core::num::NonZeroU128
+/// [`Option<NonZeroUsize>`]: core::num::NonZeroUsize
+/// [`Option<NonZeroI8>`]: core::num::NonZeroI8
+/// [`Option<NonZeroI16>`]: core::num::NonZeroI16
+/// [`Option<NonZeroI32>`]: core::num::NonZeroI32
+/// [`Option<NonZeroI64>`]: core::num::NonZeroI64
+/// [`Option<NonZeroI128>`]: core::num::NonZeroI128
+/// [`Option<NonZeroIsize>`]: core::num::NonZeroIsize
+pub struct NoneAsZero;
+
 /// Deserialize value and return [`Default`] on error
 ///
 /// The main use case is ignoring error while deserializing.

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -676,6 +676,40 @@ where
     }
 }
 
+macro_rules! none_as_zero_serialize {
+    ($($nonzero:ident => $primitive:ident),* $(,)?) => {
+        $(
+            impl SerializeAs<Option<core::num::$nonzero>> for NoneAsZero {
+                fn serialize_as<S>(
+                    source: &Option<core::num::$nonzero>,
+                    serializer: S,
+                ) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let value: $primitive = source.map_or(0, core::num::$nonzero::get);
+                    value.serialize(serializer)
+                }
+            }
+        )*
+    };
+}
+
+none_as_zero_serialize! {
+    NonZeroU8    => u8,
+    NonZeroU16   => u16,
+    NonZeroU32   => u32,
+    NonZeroU64   => u64,
+    NonZeroU128  => u128,
+    NonZeroUsize => usize,
+    NonZeroI8    => i8,
+    NonZeroI16   => i16,
+    NonZeroI32   => i32,
+    NonZeroI64   => i64,
+    NonZeroI128  => i128,
+    NonZeroIsize => isize,
+}
+
 #[cfg(feature = "alloc")]
 impl<T, TAs> SerializeAs<T> for DefaultOnError<TAs>
 where

--- a/serde_with/tests/serde_as/lib.rs
+++ b/serde_with/tests/serde_as/lib.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{
     formats::{CommaSeparator, Flexible, Strict},
     serde_as, BoolFromInt, BytesOrString, DisplayFromStr, IfIsHumanReadable, Map,
-    NoneAsEmptyString, OneOrMany, Same, Seq, StringWithSeparator,
+    NoneAsEmptyString, NoneAsZero, OneOrMany, Same, Seq, StringWithSeparator,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -1641,4 +1641,49 @@ fn test_boolfromint() {
         r#""""#,
         expect![[r#"invalid type: string "", expected an integer at line 1 column 2"#]],
     );
+}
+
+#[test]
+fn test_none_as_zero() {
+    use core::num::{NonZeroI16, NonZeroI64, NonZeroU32, NonZeroU8, NonZeroUsize};
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SU8(#[serde_as(as = "NoneAsZero")] Option<NonZeroU8>);
+
+    is_equal(SU8(None), expect![[r#"0"#]]);
+    is_equal(SU8(NonZeroU8::new(1)), expect![[r#"1"#]]);
+    is_equal(SU8(NonZeroU8::new(255)), expect![[r#"255"#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SU32(#[serde_as(as = "NoneAsZero")] Option<NonZeroU32>);
+
+    is_equal(SU32(None), expect![[r#"0"#]]);
+    is_equal(SU32(NonZeroU32::new(42)), expect![[r#"42"#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI16(#[serde_as(as = "NoneAsZero")] Option<NonZeroI16>);
+
+    is_equal(SI16(None), expect![[r#"0"#]]);
+    is_equal(SI16(NonZeroI16::new(-7)), expect![[r#"-7"#]]);
+    is_equal(SI16(NonZeroI16::new(7)), expect![[r#"7"#]]);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SI64(#[serde_as(as = "NoneAsZero")] Option<NonZeroI64>);
+
+    is_equal(SI64(None), expect![[r#"0"#]]);
+    is_equal(
+        SI64(NonZeroI64::new(-9_000_000_000)),
+        expect![[r#"-9000000000"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SUsize(#[serde_as(as = "NoneAsZero")] Option<NonZeroUsize>);
+
+    is_equal(SUsize(None), expect![[r#"0"#]]);
+    is_equal(SUsize(NonZeroUsize::new(3)), expect![[r#"3"#]]);
 }


### PR DESCRIPTION
Closes #486.

Adds a `NoneAsZero` adapter so `Option<NonZeroU32>` (and the other NonZero variants) round-trip losslessly through a single integer field, encoding `None` as `0` and `Some(n)` as `n`. Implementations cover `NonZeroU8`/`U16`/`U32`/`U64`/`U128`/`Usize` and the signed counterparts; includes rustdoc, a transformations guide entry, and a behavior test.