### PR TITLE
Removal of unnecessary prefixes and improvement of impl order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ trivial_numeric_casts = "warn"
 unused_extern_crates = "warn"
 unused_import_braces = "warn"
 # Causes problems with the darling derives in the serde_with_macros crate.
-# unused_qualifications = "warn"
+unused_qualifications = "warn"
 variant_size_differences = "warn"
 # Unsafe code is needed for array initialization using MaybeUninit.
 # unsafe_code = "forbid"

--- a/serde_with/src/content/de.rs
+++ b/serde_with/src/content/de.rs
@@ -249,13 +249,6 @@ impl<'de> Visitor<'de> for ContentVisitor<'de> {
         Ok(Content::ByteBuf(value))
     }
 
-    fn visit_unit<F>(self) -> Result<Self::Value, F>
-    where
-        F: DeError,
-    {
-        Ok(Content::Unit)
-    }
-
     fn visit_none<F>(self) -> Result<Self::Value, F>
     where
         F: DeError,
@@ -268,6 +261,13 @@ impl<'de> Visitor<'de> for ContentVisitor<'de> {
         D: Deserializer<'de>,
     {
         Deserialize::deserialize(deserializer).map(|v| Content::Some(Box::new(v)))
+    }
+
+    fn visit_unit<F>(self) -> Result<Self::Value, F>
+    where
+        F: DeError,
+    {
+        Ok(Content::Unit)
     }
 
     fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -414,11 +414,6 @@ where
     E: DeError,
 {
     type Error = E;
-
-    #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -803,6 +798,11 @@ where
         drop(self);
         visitor.visit_unit()
     }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
+    }
 }
 
 impl<'de, E> ContentDeserializer<'de, E> {
@@ -991,11 +991,6 @@ where
     type Error = E;
 
     #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-
-    #[inline]
     fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
@@ -1012,6 +1007,11 @@ where
                 Err(DeError::invalid_length(len, &"fewer elements in array"))
             }
         }
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -1112,16 +1112,16 @@ where
     type Error = E;
 
     #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-
-    #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         visitor.visit_map(self)
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -1235,11 +1235,6 @@ where
     E: DeError,
 {
     type Error = E;
-
-    #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, E>
     where
@@ -1595,6 +1590,11 @@ where
     {
         visitor.visit_unit()
     }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
+    }
 }
 
 impl<'a, 'de, E> ContentRefDeserializer<'a, 'de, E> {
@@ -1765,11 +1765,6 @@ where
     type Error = E;
 
     #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-
-    #[inline]
     fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
@@ -1786,6 +1781,11 @@ where
                 Err(DeError::invalid_length(len, &"fewer elements in array"))
             }
         }
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -1886,16 +1886,16 @@ where
     type Error = E;
 
     #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-
-    #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         visitor.visit_map(self)
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -1974,25 +1974,39 @@ where
         self.deserialize_map(visitor)
     }
 
-    fn deserialize_enum<V>(
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match visitor.__private_visit_untagged_option(self) {
+            Ok(value) => Ok(value),
+            Err(()) => Self::deserialize_other(),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
         self,
-        name: &'static str,
-        variants: &'static [&'static str],
+        _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        for entry in self.0 {
-            if let Some((key, value)) = flat_map_take_entry(entry, variants) {
-                return visitor.visit_enum(EnumDeserializer::new(key, Some(value), self.2));
-            }
-        }
+        visitor.visit_unit()
+    }
 
-        Err(DeError::custom(format_args!(
-            "no variant of enum {} found in flattened data",
-            name
-        )))
+    fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -2025,39 +2039,25 @@ where
         })
     }
 
-    fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match visitor.__private_visit_untagged_option(self) {
-            Ok(value) => Ok(value),
-            Err(()) => Self::deserialize_other(),
-        }
-    }
-
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_unit()
-    }
-
-    fn deserialize_unit_struct<V>(
+    fn deserialize_enum<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_unit()
+        for entry in self.0 {
+            if let Some((key, value)) = flat_map_take_entry(entry, variants) {
+                return visitor.visit_enum(EnumDeserializer::new(key, Some(value), self.2));
+            }
+        }
+
+        Err(DeError::custom(format_args!(
+            "no variant of enum {} found in flattened data",
+            name
+        )))
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -2212,8 +2212,8 @@ fn content_as_str<'a, 'de>(content: &'a Content<'de>) -> Option<&'a str> {
     match *content {
         Content::Str(x) => Some(x),
         Content::String(ref x) => Some(x),
-        Content::Bytes(x) => core::str::from_utf8(x).ok(),
-        Content::ByteBuf(ref x) => core::str::from_utf8(x).ok(),
+        Content::Bytes(x) => str::from_utf8(x).ok(),
+        Content::ByteBuf(ref x) => str::from_utf8(x).ok(),
         _ => None,
     }
 }

--- a/serde_with/src/content/ser.rs
+++ b/serde_with/src/content/ser.rs
@@ -62,7 +62,7 @@ impl Content {
     pub(crate) fn as_str(&self) -> Option<&str> {
         match self {
             Self::String(x) => Some(x),
-            Self::Bytes(x) => core::str::from_utf8(x).ok(),
+            Self::Bytes(x) => str::from_utf8(x).ok(),
             _ => None,
         }
     }
@@ -180,10 +180,6 @@ where
     type SerializeMap = MapSerialize<E>;
     type SerializeStruct = StructSerialize<E>;
     type SerializeStructVariant = StructVariantSerialize<E>;
-
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn serialize_bool(self, v: bool) -> Result<Content, E> {
         Ok(Content::Bool(v))
@@ -385,6 +381,10 @@ where
             error: PhantomData,
         })
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
+    }
 }
 
 pub(crate) struct SeqSerialize<E> {
@@ -540,10 +540,6 @@ where
         Ok(())
     }
 
-    fn end(self) -> Result<Content, E> {
-        Ok(Content::Map(self.entries))
-    }
-
     fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<(), E>
     where
         K: Serialize + ?Sized,
@@ -553,6 +549,10 @@ where
         let value = value.serialize(ContentSerializer::<E>::new(self.is_human_readable))?;
         self.entries.push((key, value));
         Ok(())
+    }
+
+    fn end(self) -> Result<Content, E> {
+        Ok(Content::Map(self.entries))
     }
 }
 

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -209,14 +209,6 @@ where
             }
 
             #[inline]
-            fn visit_unit<E>(self) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(None)
-            }
-
-            #[inline]
             fn visit_none<E>(self) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -230,6 +222,14 @@ where
                 D: Deserializer<'de>,
             {
                 U::deserialize_as(deserializer).map(Some)
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(None)
             }
         }
 
@@ -1192,15 +1192,6 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
                 formatter.write_str("a list of bytes or a string")
             }
 
-            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E> {
-                Ok(v.to_vec())
-            }
-
-            #[cfg(feature = "alloc")]
-            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E> {
-                Ok(v)
-            }
-
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(v.as_bytes().to_vec())
             }
@@ -1208,6 +1199,15 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for BytesOrString {
             #[cfg(feature = "alloc")]
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
                 Ok(v.into_bytes())
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E> {
+                Ok(v.to_vec())
+            }
+
+            #[cfg(feature = "alloc")]
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(v)
             }
 
             fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
@@ -1431,11 +1431,18 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Bytes {
                 formatter.write_str("a byte array")
             }
 
-            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                A: SeqAccess<'de>,
+                E: DeError,
             {
-                utils::SeqIter::new(seq).collect::<Result<_, _>>()
+                Ok(v.as_bytes().to_vec())
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(v.into_bytes())
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -1452,18 +1459,11 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Bytes {
                 Ok(v)
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
             where
-                E: DeError,
+                A: SeqAccess<'de>,
             {
-                Ok(v.as_bytes().to_vec())
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(v.into_bytes())
+                utils::SeqIter::new(seq).collect::<Result<_, _>>()
             }
         }
 
@@ -1508,11 +1508,11 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
                 formatter.write_str("a byte array")
             }
 
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
-                Ok(Cow::Borrowed(v))
+                Ok(Cow::Owned(v.as_bytes().to_vec()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
@@ -1522,6 +1522,13 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
                 Ok(Cow::Borrowed(v.as_bytes()))
             }
 
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(Cow::Owned(v.into_bytes()))
+            }
+
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -1529,11 +1536,11 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
                 Ok(Cow::Owned(v.to_vec()))
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
-                Ok(Cow::Owned(v.as_bytes().to_vec()))
+                Ok(Cow::Borrowed(v))
             }
 
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
@@ -1541,13 +1548,6 @@ impl<'de> DeserializeAs<'de, Cow<'de, [u8]>> for Bytes {
                 E: DeError,
             {
                 Ok(Cow::Owned(v))
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(Cow::Owned(v.into_bytes()))
             }
 
             fn visit_seq<V>(self, seq: V) -> Result<Self::Value, V::Error>
@@ -1578,11 +1578,13 @@ impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Bytes {
                 formatter.write_fmt(format_args!("an byte array of size {M}"))
             }
 
-            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
-                A: SeqAccess<'de>,
+                E: DeError,
             {
-                utils::array_from_iterator(utils::SeqIter::new(seq), &self)
+                v.as_bytes()
+                    .try_into()
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -1593,13 +1595,11 @@ impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Bytes {
                     .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
             where
-                E: DeError,
+                A: SeqAccess<'de>,
             {
-                v.as_bytes()
-                    .try_into()
-                    .map_err(|_| DeError::invalid_length(v.len(), &self))
+                utils::array_from_iterator(utils::SeqIter::new(seq), &self)
             }
         }
 
@@ -1621,20 +1621,20 @@ impl<'de, const N: usize> DeserializeAs<'de, &'de [u8; N]> for Bytes {
                 formatter.write_fmt(format_args!("a borrowed byte array of size {M}"))
             }
 
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                v.try_into()
-                    .map_err(|_| DeError::invalid_length(v.len(), &self))
-            }
-
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
                 v.as_bytes()
                     .try_into()
+                    .map_err(|_| DeError::invalid_length(v.len(), &self))
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                v.try_into()
                     .map_err(|_| DeError::invalid_length(v.len(), &self))
             }
         }
@@ -1658,12 +1658,14 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
                 formatter.write_str("a byte array")
             }
 
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
-                Ok(Cow::Borrowed(
-                    v.try_into()
+                Ok(Cow::Owned(
+                    v.as_bytes()
+                        .to_vec()
+                        .try_into()
                         .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
@@ -1679,6 +1681,18 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
                 ))
             }
 
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                let len = v.len();
+                Ok(Cow::Owned(
+                    v.into_bytes()
+                        .try_into()
+                        .map_err(|_| DeError::invalid_length(len, &self))?,
+                ))
+            }
+
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -1690,14 +1704,12 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
                 ))
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
-                Ok(Cow::Owned(
-                    v.as_bytes()
-                        .to_vec()
-                        .try_into()
+                Ok(Cow::Borrowed(
+                    v.try_into()
                         .map_err(|_| DeError::invalid_length(v.len(), &self))?,
                 ))
             }
@@ -1709,18 +1721,6 @@ impl<'de, const N: usize> DeserializeAs<'de, Cow<'de, [u8; N]>> for Bytes {
                 let len = v.len();
                 Ok(Cow::Owned(
                     v.try_into()
-                        .map_err(|_| DeError::invalid_length(len, &self))?,
-                ))
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                let len = v.len();
-                Ok(Cow::Owned(
-                    v.into_bytes()
-                        .try_into()
                         .map_err(|_| DeError::invalid_length(len, &self))?,
                 ))
             }
@@ -1799,13 +1799,13 @@ macro_rules! one_or_many_impl {
 foreach_seq!(one_or_many_impl);
 
 #[cfg(all(feature = "alloc", feature = "smallvec_1"))]
-impl<'de, T, TAs, FORMAT, A> DeserializeAs<'de, smallvec_1::SmallVec<A>> for OneOrMany<TAs, FORMAT>
+impl<'de, T, TAs, FORMAT, A> DeserializeAs<'de, SmallVec<A>> for OneOrMany<TAs, FORMAT>
 where
     A: smallvec_1::Array<Item = T>,
     TAs: DeserializeAs<'de, T>,
     FORMAT: Format,
 {
-    fn deserialize_as<D>(deserializer: D) -> Result<smallvec_1::SmallVec<A>, D::Error>
+    fn deserialize_as<D>(deserializer: D) -> Result<SmallVec<A>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -1816,7 +1816,7 @@ where
             content::de::ContentRefDeserializer::new(&content, is_hr),
         ) {
             Ok(one) => {
-                let mut res = smallvec_1::SmallVec::<A>::new();
+                let mut res = SmallVec::<A>::new();
                 res.push(one.into_inner());
                 return Ok(res);
             }
@@ -1825,7 +1825,7 @@ where
         let many_err: D::Error = match <DeserializeAsWrap<Vec<T>, Vec<TAs>>>::deserialize(
             content::de::ContentDeserializer::new(content, is_hr),
         ) {
-            Ok(many) => return Ok(smallvec_1::SmallVec::from_vec(many.into_inner())),
+            Ok(many) => return Ok(SmallVec::from_vec(many.into_inner())),
             Err(err) => err,
         };
         Err(DeError::custom(format_args!(
@@ -2034,18 +2034,18 @@ impl<'de> DeserializeAs<'de, Cow<'de, str>> for BorrowCow {
                 formatter.write_str("an optionally borrowed string")
             }
 
-            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(Cow::Borrowed(v))
-            }
-
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
                 Ok(Cow::Owned(v.to_owned()))
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(Cow::Borrowed(v))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
@@ -2093,20 +2093,6 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                 formatter.write_str("an integer 0 or 1")
             }
 
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                match v {
-                    0 => Ok(false),
-                    1 => Ok(true),
-                    unexp => Err(DeError::invalid_value(
-                        Unexpected::Unsigned(u64::from(unexp)),
-                        &"0 or 1",
-                    )),
-                }
-            }
-
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -2116,6 +2102,48 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                     1 => Ok(true),
                     unexp => Err(DeError::invalid_value(
                         Unexpected::Signed(i64::from(unexp)),
+                        &"0 or 1",
+                    )),
+                }
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                match v {
+                    0 => Ok(false),
+                    1 => Ok(true),
+                    unexp => Err(DeError::invalid_value(Unexpected::Signed(unexp), &"0 or 1")),
+                }
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                match v {
+                    0 => Ok(false),
+                    1 => Ok(true),
+                    unexp => {
+                        let mut buf: [u8; 58] = [0u8; 58];
+                        Err(DeError::invalid_value(
+                            utils::get_unexpected_i128(unexp, &mut buf),
+                            &"0 or 1",
+                        ))
+                    }
+                }
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                match v {
+                    0 => Ok(false),
+                    1 => Ok(true),
+                    unexp => Err(DeError::invalid_value(
+                        Unexpected::Unsigned(u64::from(unexp)),
                         &"0 or 1",
                     )),
                 }
@@ -2135,17 +2163,6 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                 }
             }
 
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                match v {
-                    0 => Ok(false),
-                    1 => Ok(true),
-                    unexp => Err(DeError::invalid_value(Unexpected::Signed(unexp), &"0 or 1")),
-                }
-            }
-
             fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -2156,25 +2173,8 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Strict> {
                     unexp => {
                         let mut buf: [u8; 58] = [0u8; 58];
                         Err(DeError::invalid_value(
-                            crate::utils::get_unexpected_u128(unexp, &mut buf),
+                            utils::get_unexpected_u128(unexp, &mut buf),
                             &self,
-                        ))
-                    }
-                }
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                match v {
-                    0 => Ok(false),
-                    1 => Ok(true),
-                    unexp => {
-                        let mut buf: [u8; 58] = [0u8; 58];
-                        Err(DeError::invalid_value(
-                            crate::utils::get_unexpected_i128(unexp, &mut buf),
-                            &"0 or 1",
                         ))
                     }
                 }
@@ -2198,21 +2198,7 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Flexible> {
                 formatter.write_str("an integer")
             }
 
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(v != 0)
-            }
-
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(v != 0)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
@@ -2226,14 +2212,28 @@ impl<'de> DeserializeAs<'de, bool> for BoolFromInt<Flexible> {
                 Ok(v != 0)
             }
 
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
             where
                 E: DeError,
             {
                 Ok(v != 0)
             }
 
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(v != 0)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(v != 0)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
             where
                 E: DeError,
             {

--- a/serde_with/src/de/mod.rs
+++ b/serde_with/src/de/mod.rs
@@ -103,11 +103,11 @@ use crate::prelude::*;
 /// # assert!(!serde_json::from_str::<S>(r#""false""#).unwrap().0);
 /// # }
 /// ```
-/// [`Box`]: std::boxed::Box
-/// [`BTreeMap`]: std::collections::BTreeMap
-/// [`Duration`]: std::time::Duration
-/// [`FromStr`]: std::str::FromStr
-/// [`Vec`]: std::vec::Vec
+/// [`Box`]: Box
+/// [`BTreeMap`]: BTreeMap
+/// [`Duration`]: Duration
+/// [`FromStr`]: FromStr
+/// [`Vec`]: Vec
 /// [impl-deserialize]: https://serde.rs/impl-deserialize.html
 pub trait DeserializeAs<'de, T>: Sized {
     /// Deserialize this value from the given Serde deserializer.

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -230,10 +230,6 @@ where
     type SerializeStruct = Impossible<S::Ok, S::Error>;
     type SerializeStructVariant = Impossible<S::Ok, S::Error>;
 
-    fn is_human_readable(&self) -> bool {
-        self.0.is_human_readable()
-    }
-
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
         Err(SerError::custom("wrong type for EnumMap"))
     }
@@ -403,6 +399,10 @@ where
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(SerError::custom("wrong type for EnumMap"))
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.0.is_human_readable()
+    }
 }
 
 /// Serialize a single element but turn the sequence into a map logic.
@@ -457,10 +457,6 @@ where
     type SerializeMap = Impossible<Self::Ok, Self::Error>;
     type SerializeStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeStructVariant = SerializeVariant<'a, M>;
-
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
         Err(SerError::custom("wrong type for EnumMap"))
@@ -637,6 +633,10 @@ where
             content: Content::Struct(name, Vec::with_capacity(len)),
         })
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
+    }
 }
 
 /// Serialize a struct or tuple variant enum as a map element
@@ -715,8 +715,11 @@ where
 {
     type Error = M::Error;
 
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -726,11 +729,8 @@ where
         visitor.visit_seq(self)
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -792,10 +792,6 @@ where
 {
     type Error = M::Error;
 
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
@@ -813,6 +809,10 @@ where
         V: Visitor<'de>,
     {
         visitor.visit_enum(self)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {

--- a/serde_with/src/flatten_maybe.rs
+++ b/serde_with/src/flatten_maybe.rs
@@ -184,12 +184,6 @@ where
             {
                 Ok(Field::other(content::de::Content::Char(value)))
             }
-            fn visit_unit<E>(self) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                Ok(Field::other(content::de::Content::Unit))
-            }
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -198,17 +192,6 @@ where
                     Ok(Field::field_not_flat)
                 } else {
                     let value = content::de::Content::String(ToString::to_string(value));
-                    Ok(Field::other(value))
-                }
-            }
-            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
-            where
-                E: DeError,
-            {
-                if value == self.fieldname.as_bytes() {
-                    Ok(Field::field_not_flat)
-                } else {
-                    let value = content::de::Content::ByteBuf(value.to_vec());
                     Ok(Field::other(value))
                 }
             }
@@ -223,6 +206,17 @@ where
                     Ok(Field::other(value))
                 }
             }
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                if value == self.fieldname.as_bytes() {
+                    Ok(Field::field_not_flat)
+                } else {
+                    let value = content::de::Content::ByteBuf(value.to_vec());
+                    Ok(Field::other(value))
+                }
+            }
             fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E>
             where
                 E: DeError,
@@ -233,6 +227,12 @@ where
                     let value = content::de::Content::Bytes(value);
                     Ok(Field::other(value))
                 }
+            }
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(Field::other(content::de::Content::Unit))
             }
         }
 

--- a/serde_with/src/key_value_map.rs
+++ b/serde_with/src/key_value_map.rs
@@ -235,10 +235,6 @@ where
     type SerializeStruct = Impossible<S::Ok, S::Error>;
     type SerializeStructVariant = Impossible<S::Ok, S::Error>;
 
-    fn is_human_readable(&self) -> bool {
-        self.0.is_human_readable()
-    }
-
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
         Err(SerError::custom("wrong type for KeyValueMap"))
     }
@@ -408,6 +404,10 @@ where
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(SerError::custom("wrong type for KeyValueMap"))
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.0.is_human_readable()
+    }
 }
 
 /// Serialize a single element but turn the sequence into a map logic.
@@ -462,10 +462,6 @@ where
     type SerializeMap = KeyValueMapSerializer<'a, M>;
     type SerializeStruct = KeyValueStructSerializer<'a, M>;
     type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
-
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
         Err(SerError::custom("wrong type for KeyValueMap"))
@@ -658,6 +654,10 @@ where
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(SerError::custom("wrong type for KeyValueMap"))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 }
 
@@ -905,8 +905,11 @@ where
 {
     type Error = M::Error;
 
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -916,11 +919,8 @@ where
         visitor.visit_seq(self)
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -969,10 +969,6 @@ where
     M: MapAccess<'de>,
 {
     type Error = M::Error;
-
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -1045,6 +1041,10 @@ where
             fields,
             first: Some(self.key_value),
         })
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 
     forward_to_deserialize_any! {
@@ -1206,23 +1206,23 @@ where
         self.delegate.expecting(formatter)
     }
 
-    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        self.delegate.visit_map(MapAccessWrapper {
-            delegate: map,
-            is_human_readable: self.is_human_readable,
-            first: self.first,
-        })
-    }
-
     fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,
     {
         self.delegate.visit_seq(SeqAccessWrapper {
             delegate: seq,
+            is_human_readable: self.is_human_readable,
+            first: self.first,
+        })
+    }
+
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        self.delegate.visit_map(MapAccessWrapper {
+            delegate: map,
             is_human_readable: self.is_human_readable,
             first: self.first,
         })

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -503,7 +503,7 @@ pub struct As<T: ?Sized>(PhantomData<T>);
 /// Adapter to convert from `serde_as` to the serde traits.
 ///
 /// This is the counter-type to [`As`][].
-/// It can be used whenever a type implementing [`DeserializeAs`]/[`SerializeAs`] is required but the normal [`Deserialize`](::serde_core::Deserialize)/[`Serialize`](::serde_core::Serialize) traits should be used.
+/// It can be used whenever a type implementing [`DeserializeAs`]/[`SerializeAs`] is required but the normal [`Deserialize`](serde_core::Deserialize)/[`Serialize`](serde_core::Serialize) traits should be used.
 /// Check [`As`] for an example.
 pub struct Same;
 
@@ -517,7 +517,7 @@ pub struct Same;
 /// support, which can be found in some crates.
 ///
 /// If you control the type you want to de/serialize, you can instead use the two derive macros, [`SerializeDisplay`] and [`DeserializeFromStr`].
-/// They properly implement the traits [`Serialize`](::serde_core::Serialize) and [`Deserialize`](::serde_core::Deserialize) such that user of the type no longer have to use the `serde_as` system.
+/// They properly implement the traits [`Serialize`](serde_core::Serialize) and [`Deserialize`](serde_core::Deserialize) such that user of the type no longer have to use the `serde_as` system.
 ///
 /// # Examples
 ///
@@ -558,7 +558,7 @@ pub struct DisplayFromStr;
 /// Use the first format if [`De/Serializer::is_human_readable`], otherwise use the second
 ///
 /// If the second format is not specified, the normal
-/// [`Deserialize`](::serde_core::Deserialize)/[`Serialize`](::serde_core::Serialize) traits are used.
+/// [`Deserialize`](serde_core::Deserialize)/[`Serialize`](serde_core::Serialize) traits are used.
 ///
 /// # Examples
 ///
@@ -600,7 +600,7 @@ pub struct IfIsHumanReadable<H, F = Same>(PhantomData<H>, PhantomData<F>);
 
 /// De/Serialize a [`Option<String>`] type while transforming the empty string to [`None`]
 ///
-/// Convert an [`Option<T>`] from/to string using [`FromStr`] and [`Display`](::core::fmt::Display) implementations.
+/// Convert an [`Option<T>`] from/to string using [`FromStr`] and [`Display`](core::fmt::Display) implementations.
 /// An empty string is deserialized as [`None`] and a [`None`] vice versa.
 ///
 /// # Examples
@@ -639,7 +639,7 @@ pub struct IfIsHumanReadable<H, F = Same>(PhantomData<H>, PhantomData<F>);
 /// [`FromStr`]: std::str::FromStr
 pub struct NoneAsEmptyString;
 
-/// De/Serialize an [`Option<NonZero*>`] losslessly as the inner integer
+/// De/Serialize [`Option`] of a non-zero integer losslessly as the inner integer
 ///
 /// Serde natively supports [`NonZeroU8`] and friends, but rejects `0` during deserialization.
 /// This adapter treats `0` as [`None`] and any other value as [`Some`], allowing the wire format
@@ -1357,8 +1357,8 @@ pub struct DurationNanoSecondsWithFrac<
 /// ```
 ///
 /// [`SystemTime`]: std::time::SystemTime
-/// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
-/// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
+/// [`chrono::DateTime<Local>`]: chrono_0_4::DateTime
+/// [`chrono::DateTime<Utc>`]: chrono_0_4::DateTime
 /// [feature flag]: https://docs.rs/serde_with/3.20.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSeconds<
     FORMAT: formats::Format = i64,
@@ -1497,10 +1497,10 @@ pub struct TimestampSeconds<
 /// ```
 ///
 /// [`SystemTime`]: std::time::SystemTime
-/// [`chrono::DateTime`]: ::chrono_0_4::DateTime
-/// [`chrono::DateTime<Local>`]: ::chrono_0_4::DateTime
-/// [`chrono::DateTime<Utc>`]: ::chrono_0_4::DateTime
-/// [NaiveDateTime]: ::chrono_0_4::NaiveDateTime
+/// [`chrono::DateTime`]: chrono_0_4::DateTime
+/// [`chrono::DateTime<Local>`]: chrono_0_4::DateTime
+/// [`chrono::DateTime<Utc>`]: chrono_0_4::DateTime
+/// [NaiveDateTime]: chrono_0_4::NaiveDateTime
 /// [feature flag]: https://docs.rs/serde_with/3.20.0/serde_with/guide/feature_flags/index.html
 pub struct TimestampSecondsWithFrac<
     FORMAT: formats::Format = f64,
@@ -1713,8 +1713,8 @@ pub struct Bytes;
 /// The serialization behavior can be tweaked to either always serialize as a list using [`PreferMany`] or to serialize as the inner element if possible using [`PreferOne`].
 /// By default, [`PreferOne`] is assumed, which can also be omitted like `OneOrMany<_>`.
 ///
-/// [`PreferMany`]: crate::formats::PreferMany
-/// [`PreferOne`]: crate::formats::PreferOne
+/// [`PreferMany`]: formats::PreferMany
+/// [`PreferOne`]: formats::PreferOne
 ///
 /// # Examples
 ///
@@ -2451,7 +2451,7 @@ pub struct MapSkipError<K, V, I = ()>(PhantomData<(K, V, I)>);
 /// Deserialize a boolean from a number
 ///
 /// Deserialize a number (of `u8`) and turn it into a boolean.
-/// The adapter supports a [`Strict`](crate::formats::Strict) and [`Flexible`](crate::formats::Flexible) format.
+/// The adapter supports a [`Strict`](formats::Strict) and [`Flexible`](formats::Flexible) format.
 /// In `Strict` mode, the number must be `0` or `1`.
 /// All other values produce an error.
 /// In `Flexible` mode, the number any non-zero value is converted to `true`.
@@ -2543,7 +2543,7 @@ pub struct BoolFromInt<S: formats::Strictness = formats::Strict>(PhantomData<S>)
 ///
 /// [`Display`]: core::fmt::Display
 /// [`FromStr`]: core::str::FromStr
-/// [`Separator`]: crate::formats::Separator
+/// [`Separator`]: formats::Separator
 /// [`serde_as`]: crate::guide::serde_as
 pub struct StringWithSeparator<Sep, T>(PhantomData<(Sep, T)>);
 
@@ -2767,7 +2767,7 @@ pub struct SetLastValueWins<T>(PhantomData<T>);
 /// Helper for implementing [`JsonSchema`] on serializers whose output depends
 /// on the type of the concrete field.
 ///
-/// It is added implicitly by the [`#[serde_as]`](crate::serde_as) macro when any `schemars`
+/// It is added implicitly by the [`#[serde_as]`](serde_as) macro when any `schemars`
 /// feature is enabled.
 ///
 /// [`JsonSchema`]: ::schemars_1::JsonSchema

--- a/serde_with/src/rust.rs
+++ b/serde_with/src/rust.rs
@@ -192,8 +192,8 @@ pub mod unwrap_or_skip {
 /// # }
 /// ```
 ///
-/// [`HashSet`]: std::collections::HashSet
-/// [`BTreeSet`]: std::collections::HashSet
+/// [`HashSet`]: HashSet
+/// [`BTreeSet`]: HashSet
 ///
 /// # Example
 ///
@@ -308,8 +308,8 @@ pub mod sets_duplicate_value_is_error {
 /// # }
 /// ```
 ///
-/// [`HashMap`]: std::collections::HashMap
-/// [`BTreeMap`]: std::collections::HashMap
+/// [`HashMap`]: HashMap
+/// [`BTreeMap`]: HashMap
 ///
 /// # Example
 ///
@@ -428,8 +428,8 @@ pub mod maps_duplicate_key_is_error {
 /// # }
 /// ```
 ///
-/// [`HashSet`]: std::collections::HashSet
-/// [`BTreeSet`]: std::collections::HashSet
+/// [`HashSet`]: HashSet
+/// [`BTreeSet`]: HashSet
 #[cfg(feature = "alloc")]
 pub mod sets_last_value_wins {
     use super::*;
@@ -497,8 +497,8 @@ pub mod sets_last_value_wins {
 ///
 /// The implementation supports both the [`HashMap`] and the [`BTreeMap`] from the standard library.
 ///
-/// [`HashMap`]: std::collections::HashMap
-/// [`BTreeMap`]: std::collections::HashMap
+/// [`HashMap`]: HashMap
+/// [`BTreeMap`]: HashMap
 ///
 /// # Converting to `serde_as`
 ///

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -92,7 +92,7 @@ use ::schemars_0_8::{
 /// }
 /// ```
 ///
-/// [0]: crate::serde_as
+/// [0]: serde_as
 /// [1]: crate::Schema
 pub trait JsonSchemaAs<T: ?Sized> {
     /// Whether JSON Schemas generated for this type should be re-used where possible using the `$ref` keyword.
@@ -138,6 +138,10 @@ where
     T: ?Sized,
     TA: JsonSchemaAs<T>,
 {
+    fn is_referenceable() -> bool {
+        TA::is_referenceable()
+    }
+
     fn schema_name() -> String {
         TA::schema_name()
     }
@@ -148,10 +152,6 @@ where
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
         TA::json_schema(gen)
-    }
-
-    fn is_referenceable() -> bool {
-        TA::is_referenceable()
     }
 }
 
@@ -312,6 +312,10 @@ impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
     TA: JsonSchemaAs<T>,
 {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         std::format!("[{}; {}]", <WrapSchema<T, TA>>::schema_name(), N)
     }
@@ -337,10 +341,6 @@ where
             ..Default::default()
         }
         .into()
-    }
-
-    fn is_referenceable() -> bool {
-        false
     }
 }
 
@@ -406,6 +406,10 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 
 #[cfg(feature = "base58")]
 impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "Base58<A>".into()
     }
@@ -422,14 +426,14 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
         }
         .into()
     }
-
-    fn is_referenceable() -> bool {
-        false
-    }
 }
 
 #[cfg(feature = "base64")]
-impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+impl<T, A: base64::Alphabet, F: Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "Base64<A, F>".into()
     }
@@ -447,14 +451,14 @@ impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Bas
         }
         .into()
     }
-
-    fn is_referenceable() -> bool {
-        false
-    }
 }
 
 #[cfg(feature = "hex")]
-impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
+impl<T, F: Format> JsonSchemaAs<T> for hex::Hex<F> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "Hex<F>".into()
     }
@@ -476,13 +480,13 @@ impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
         }
         .into()
     }
-
-    fn is_referenceable() -> bool {
-        false
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "BoolFromInt<Strict>".into()
     }
@@ -503,13 +507,13 @@ impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
         }
         .into()
     }
-
-    fn is_referenceable() -> bool {
-        false
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "BoolFromInt<Flexible>".into()
     }
@@ -524,10 +528,6 @@ impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
             ..Default::default()
         }
         .into()
-    }
-
-    fn is_referenceable() -> bool {
-        false
     }
 }
 
@@ -544,6 +544,10 @@ impl<T> JsonSchemaAs<T> for Bytes {
 }
 
 impl JsonSchemaAs<Vec<u8>> for BytesOrString {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         "BytesOrString".into()
     }
@@ -572,10 +576,6 @@ impl JsonSchemaAs<Vec<u8>> for BytesOrString {
             ..Default::default()
         }
         .into()
-    }
-
-    fn is_referenceable() -> bool {
-        false
     }
 }
 
@@ -648,6 +648,10 @@ impl<T> JsonSchemaAs<Vec<T>> for EnumMap
 where
     T: JsonSchema,
 {
+    fn is_referenceable() -> bool {
+        true
+    }
+
     fn schema_name() -> String {
         std::format!("EnumMap({})", T::schema_name())
     }
@@ -687,10 +691,6 @@ where
 
         object.object().additional_properties = Some(Box::new(Schema::Bool(false)));
         object.into()
-    }
-
-    fn is_referenceable() -> bool {
-        true
     }
 }
 
@@ -839,6 +839,10 @@ impl<T, TA> JsonSchemaAs<Vec<T>> for KeyValueMap<TA>
 where
     TA: JsonSchemaAs<T>,
 {
+    fn is_referenceable() -> bool {
+        true
+    }
+
     fn schema_name() -> String {
         std::format!("KeyValueMap({})", <WrapSchema<T, TA>>::schema_name())
     }
@@ -864,10 +868,6 @@ where
             ..Default::default()
         }
         .into()
-    }
-
-    fn is_referenceable() -> bool {
-        true
     }
 }
 
@@ -1320,6 +1320,10 @@ where
     T: TimespanSchemaTarget<F>,
     F: Format + JsonSchema,
 {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         <T as TimespanSchemaTarget<F>>::TYPE
             .schema_id()
@@ -1335,10 +1339,6 @@ where
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         <T as TimespanSchemaTarget<F>>::TYPE
             .into_flexible_schema(<T as TimespanSchemaTarget<F>>::SIGNED)
-    }
-
-    fn is_referenceable() -> bool {
-        false
     }
 }
 

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -94,7 +94,7 @@ use serde_json::Value;
 /// }
 /// ```
 ///
-/// [0]: crate::serde_as
+/// [0]: serde_as
 /// [1]: crate::Schema
 pub trait JsonSchemaAs<T: ?Sized> {
     /// Whether JSON schemas generated for this type should be included directly
@@ -143,6 +143,10 @@ where
     T: ?Sized,
     TA: JsonSchemaAs<T>,
 {
+    fn inline_schema() -> bool {
+        TA::inline_schema()
+    }
+
     fn schema_name() -> Cow<'static, str> {
         TA::schema_name()
     }
@@ -153,10 +157,6 @@ where
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         TA::json_schema(generator)
-    }
-
-    fn inline_schema() -> bool {
-        TA::inline_schema()
     }
 }
 
@@ -319,6 +319,10 @@ impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
     TA: JsonSchemaAs<T>,
 {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         format!("[{}; {}]", <WrapSchema<T, TA>>::schema_name(), N).into()
     }
@@ -339,10 +343,6 @@ where
             "maxItems": max,
             "minItems": min
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -408,6 +408,10 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 
 #[cfg(feature = "base58")]
 impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Base58<A>".into()
     }
@@ -422,14 +426,14 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
             // no regex pattern here, since it varies depending on the alphabet
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 #[cfg(feature = "base64")]
-impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+impl<T, A: base64::Alphabet, F: Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Base64<A, F>".into()
     }
@@ -445,14 +449,14 @@ impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Bas
             "contentEncoding": "base64",
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 #[cfg(feature = "hex")]
-impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
+impl<T, F: Format> JsonSchemaAs<T> for hex::Hex<F> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Hex<F>".into()
     }
@@ -467,13 +471,13 @@ impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
             "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Strict>".into()
     }
@@ -489,13 +493,13 @@ impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
             "maximum": 1.0
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Flexible>".into()
     }
@@ -508,10 +512,6 @@ impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
         json_schema!({
             "type": "integer",
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -528,6 +528,10 @@ impl<T> JsonSchemaAs<T> for Bytes {
 }
 
 impl JsonSchemaAs<Vec<u8>> for BytesOrString {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BytesOrString".into()
     }
@@ -546,10 +550,6 @@ impl JsonSchemaAs<Vec<u8>> for BytesOrString {
                 }
             ]
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -623,6 +623,10 @@ impl<T> JsonSchemaAs<Vec<T>> for EnumMap
 where
     T: JsonSchema,
 {
+    fn inline_schema() -> bool {
+        false
+    }
+
     fn schema_name() -> Cow<'static, str> {
         format!("EnumMap({})", T::schema_name()).into()
     }
@@ -664,10 +668,6 @@ where
             "properties": properties,
             "additionalProperties": false
         })
-    }
-
-    fn inline_schema() -> bool {
-        false
     }
 }
 

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -94,7 +94,7 @@ use serde_json::Value;
 /// }
 /// ```
 ///
-/// [0]: crate::serde_as
+/// [0]: serde_as
 /// [1]: crate::Schema
 pub trait JsonSchemaAs<T: ?Sized> {
     /// Whether JSON schemas generated for this type should be included directly
@@ -143,6 +143,10 @@ where
     T: ?Sized,
     TA: JsonSchemaAs<T>,
 {
+    fn inline_schema() -> bool {
+        TA::inline_schema()
+    }
+
     fn schema_name() -> Cow<'static, str> {
         TA::schema_name()
     }
@@ -153,10 +157,6 @@ where
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         TA::json_schema(generator)
-    }
-
-    fn inline_schema() -> bool {
-        TA::inline_schema()
     }
 }
 
@@ -321,6 +321,10 @@ impl<T, TA, const N: usize> JsonSchemaAs<[T; N]> for [TA; N]
 where
     TA: JsonSchemaAs<T>,
 {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         format!("[{}; {}]", <WrapSchema<T, TA>>::schema_name(), N).into()
     }
@@ -341,10 +345,6 @@ where
             "maxItems": max,
             "minItems": min
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -410,6 +410,10 @@ impl<T> JsonSchemaAs<T> for DisplayFromStr {
 
 #[cfg(feature = "base58")]
 impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Base58<A>".into()
     }
@@ -424,14 +428,14 @@ impl<T, A: base58::Alphabet> JsonSchemaAs<T> for base58::Base58<A> {
             // no regex pattern here, since it varies depending on the alphabet
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 #[cfg(feature = "base64")]
-impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+impl<T, A: base64::Alphabet, F: Format> JsonSchemaAs<T> for base64::Base64<A, F> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Base64<A, F>".into()
     }
@@ -447,14 +451,14 @@ impl<T, A: base64::Alphabet, F: formats::Format> JsonSchemaAs<T> for base64::Bas
             "contentEncoding": "base64",
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 #[cfg(feature = "hex")]
-impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
+impl<T, F: Format> JsonSchemaAs<T> for hex::Hex<F> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "Hex<F>".into()
     }
@@ -469,13 +473,13 @@ impl<T, F: formats::Format> JsonSchemaAs<T> for hex::Hex<F> {
             "pattern": r"^(?:[0-9A-Fa-f]{2})*$",
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Strict>".into()
     }
@@ -491,13 +495,13 @@ impl JsonSchemaAs<bool> for BoolFromInt<Strict> {
             "maximum": 1.0
         })
     }
-
-    fn inline_schema() -> bool {
-        true
-    }
 }
 
 impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BoolFromInt<Flexible>".into()
     }
@@ -510,10 +514,6 @@ impl JsonSchemaAs<bool> for BoolFromInt<Flexible> {
         json_schema!({
             "type": "integer",
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -530,6 +530,10 @@ impl<T> JsonSchemaAs<T> for Bytes {
 }
 
 impl JsonSchemaAs<Vec<u8>> for BytesOrString {
+    fn inline_schema() -> bool {
+        true
+    }
+
     fn schema_name() -> Cow<'static, str> {
         "BytesOrString".into()
     }
@@ -548,10 +552,6 @@ impl JsonSchemaAs<Vec<u8>> for BytesOrString {
                 }
             ]
         })
-    }
-
-    fn inline_schema() -> bool {
-        true
     }
 }
 
@@ -627,6 +627,10 @@ impl<T> JsonSchemaAs<Vec<T>> for EnumMap
 where
     T: JsonSchema,
 {
+    fn inline_schema() -> bool {
+        false
+    }
+
     fn schema_name() -> Cow<'static, str> {
         format!("EnumMap({})", T::schema_name()).into()
     }
@@ -668,10 +672,6 @@ where
             "properties": properties,
             "additionalProperties": false
         })
-    }
-
-    fn inline_schema() -> bool {
-        false
     }
 }
 

--- a/serde_with/src/ser/impls.rs
+++ b/serde_with/src/ser/impls.rs
@@ -1015,12 +1015,12 @@ macro_rules! one_or_many_impl {
 foreach_seq!(one_or_many_impl);
 
 #[cfg(all(feature = "alloc", feature = "smallvec_1"))]
-impl<T, TAs, A> SerializeAs<smallvec_1::SmallVec<A>> for OneOrMany<TAs, formats::PreferOne>
+impl<T, TAs, A> SerializeAs<SmallVec<A>> for OneOrMany<TAs, formats::PreferOne>
 where
     A: smallvec_1::Array<Item = T>,
     TAs: SerializeAs<T>,
 {
-    fn serialize_as<S>(source: &smallvec_1::SmallVec<A>, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize_as<S>(source: &SmallVec<A>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -1033,12 +1033,12 @@ where
 }
 
 #[cfg(all(feature = "alloc", feature = "smallvec_1"))]
-impl<T, TAs, A> SerializeAs<smallvec_1::SmallVec<A>> for OneOrMany<TAs, formats::PreferMany>
+impl<T, TAs, A> SerializeAs<SmallVec<A>> for OneOrMany<TAs, formats::PreferMany>
 where
     A: smallvec_1::Array<Item = T>,
     TAs: SerializeAs<T>,
 {
-    fn serialize_as<S>(source: &smallvec_1::SmallVec<A>, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize_as<S>(source: &SmallVec<A>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/serde_with/src/ser/mod.rs
+++ b/serde_with/src/ser/mod.rs
@@ -100,11 +100,11 @@ use crate::prelude::*;
 /// # }
 /// ```
 ///
-/// [`Box`]: std::boxed::Box
-/// [`BTreeMap`]: std::collections::BTreeMap
-/// [`Display`]: std::fmt::Display
-/// [`Duration`]: std::time::Duration
-/// [`Vec`]: std::vec::Vec
+/// [`Box`]: Box
+/// [`BTreeMap`]: BTreeMap
+/// [`Display`]: Display
+/// [`Duration`]: Duration
+/// [`Vec`]: Vec
 /// [impl-serialize]: https://serde.rs/impl-serialize.html
 pub trait SerializeAs<T: ?Sized> {
     /// Serialize this value into the given Serde serializer.

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -8,13 +8,10 @@ use crate::prelude::*;
 pub(crate) fn size_hint_cautious<Element>(hint: Option<usize>) -> usize {
     const MAX_PREALLOC_BYTES: usize = 1024 * 1024;
 
-    if core::mem::size_of::<Element>() == 0 {
+    if size_of::<Element>() == 0 {
         0
     } else {
-        core::cmp::min(
-            hint.unwrap_or(0),
-            MAX_PREALLOC_BYTES / core::mem::size_of::<Element>(),
-        )
+        core::cmp::min(hint.unwrap_or(0), MAX_PREALLOC_BYTES / size_of::<Element>())
     }
 }
 
@@ -210,12 +207,12 @@ impl<'a> BufWriter<'a> {
 
     fn into_str(self) -> &'a str {
         let slice = &self.bytes[..self.offset];
-        core::str::from_utf8(slice)
+        str::from_utf8(slice)
             .unwrap_or("Failed to extract valid string from BufWriter. This should never happen.")
     }
 }
 
-impl core::fmt::Write for BufWriter<'_> {
+impl fmt::Write for BufWriter<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if s.len() > self.bytes.len() - self.offset {
             Err(fmt::Error)

--- a/serde_with/tests/chrono_0_4.rs
+++ b/serde_with/tests/chrono_0_4.rs
@@ -614,7 +614,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         Duration, "DurationNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         Duration, "DurationNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         Duration, "DurationSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -625,7 +625,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         Duration, "DurationNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         Duration, "DurationNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         Duration, "DurationSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -633,7 +633,7 @@ fn test_duration_smoketest() {
         Duration, "DurationSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         Duration, "DurationSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         Duration, "DurationSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]
@@ -650,7 +650,7 @@ fn test_datetime_utc_smoketest() {
         DateTime<Utc>, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         DateTime<Utc>, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         DateTime<Utc>, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         DateTime<Utc>, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -661,7 +661,7 @@ fn test_datetime_utc_smoketest() {
         DateTime<Utc>, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         DateTime<Utc>, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         DateTime<Utc>, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         DateTime<Utc>, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -669,7 +669,7 @@ fn test_datetime_utc_smoketest() {
         DateTime<Utc>, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         DateTime<Utc>, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         DateTime<Utc>, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]
@@ -686,7 +686,7 @@ fn test_datetime_local_smoketest() {
         DateTime<Local>, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         DateTime<Local>, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         DateTime<Local>, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         DateTime<Local>, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -697,7 +697,7 @@ fn test_datetime_local_smoketest() {
         DateTime<Local>, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         DateTime<Local>, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         DateTime<Local>, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         DateTime<Local>, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -705,7 +705,7 @@ fn test_datetime_local_smoketest() {
         DateTime<Local>, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         DateTime<Local>, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         DateTime<Local>, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]
@@ -722,7 +722,7 @@ fn test_naive_datetime_smoketest() {
         NaiveDateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         NaiveDateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         NaiveDateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         NaiveDateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -733,7 +733,7 @@ fn test_naive_datetime_smoketest() {
         NaiveDateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         NaiveDateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         NaiveDateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         NaiveDateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -741,5 +741,5 @@ fn test_naive_datetime_smoketest() {
         NaiveDateTime, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         NaiveDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         NaiveDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }

--- a/serde_with/tests/schemars_0_8/main.rs
+++ b/serde_with/tests/schemars_0_8/main.rs
@@ -206,6 +206,7 @@ fn schemars_deserialize_only_bug_735() {
 }
 
 #[test]
+#[allow(unused_qualifications)]
 fn schemars_custom_schema_with() {
     fn custom_int(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         use schemars::schema::*;
@@ -1037,14 +1038,14 @@ mod key_value_map {
     #[test]
     fn test_num_properties() {
         let value = KVMap(vec![
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "A",
                 "a": "b",
                 "c": "d",
                 "e": "f",
                 "g": "h",
             })),
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "B",
                 "a": "b",
             })),

--- a/serde_with/tests/schemars_0_9/main.rs
+++ b/serde_with/tests/schemars_0_9/main.rs
@@ -207,6 +207,7 @@ fn schemars_deserialize_only_bug_735() {
 }
 
 #[test]
+#[allow(unused_qualifications)]
 fn schemars_custom_schema_with() {
     fn custom_int(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         use schemars::json_schema;
@@ -1025,14 +1026,14 @@ mod key_value_map {
     #[test]
     fn test_num_properties() {
         let value = KVMap(vec![
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "A",
                 "a": "b",
                 "c": "d",
                 "e": "f",
                 "g": "h",
             })),
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "B",
                 "a": "b",
             })),

--- a/serde_with/tests/schemars_1/main.rs
+++ b/serde_with/tests/schemars_1/main.rs
@@ -207,6 +207,7 @@ fn schemars_deserialize_only_bug_735() {
 }
 
 #[test]
+#[allow(unused_qualifications)]
 fn schemars_custom_schema_with() {
     fn custom_int(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         use schemars::json_schema;
@@ -1025,14 +1026,14 @@ mod key_value_map {
     #[test]
     fn test_num_properties() {
         let value = KVMap(vec![
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "A",
                 "a": "b",
                 "c": "d",
                 "e": "f",
                 "g": "h",
             })),
-            LimitedProperties(serde_json::json!({
+            LimitedProperties(json!({
                 "$key$": "B",
                 "a": "b",
             })),

--- a/serde_with/tests/serde_as/enum_map.rs
+++ b/serde_with/tests/serde_as/enum_map.rs
@@ -62,7 +62,7 @@ fn json_round_trip() {
     };
 
     let json = serde_json::to_string_pretty(&values).unwrap();
-    expect_test::expect![[r#"
+    expect![[r#"
             {
               "vec": {
                 "Int": 123,
@@ -107,7 +107,7 @@ fn ron_serialize() {
 
     let pretty_config = ron::ser::PrettyConfig::new().new_line("\n");
     let ron = ron::ser::to_string_pretty(&values, pretty_config).unwrap();
-    expect_test::expect![[r#"
+    expect![[r#"
             (
                 vec: {
                     "Int": 123,
@@ -126,7 +126,7 @@ fn ron_serialize() {
     .assert_eq(&ron);
     // TODO deserializing a Strings as an Identifier seems unsupported
     let deser_values: ron::Value = ron::de::from_str(&ron).unwrap();
-    expect_test::expect![[r#"
+    expect![[r#"
         Map(
             Map(
                 {
@@ -224,7 +224,7 @@ fn xml_round_trip() {
     };
 
     let xml = serde_xml_rs::to_string(&values).unwrap();
-    expect_test::expect![[r#"<?xml version="1.0" encoding="utf-8"?><VecEnumValues><vec><Int>123</Int><String>FooBar</String><Int>456</Int><String>XXX</String><Unit /></vec></VecEnumValues>"#]]
+    expect![[r#"<?xml version="1.0" encoding="utf-8"?><VecEnumValues><vec><Int>123</Int><String>FooBar</String><Int>456</Int><String>XXX</String><Unit /></vec></VecEnumValues>"#]]
         .assert_eq(&xml);
     let deser_values: VecEnumValues = serde_xml_rs::from_str(&xml).unwrap();
     assert_eq!(values, deser_values);
@@ -412,7 +412,7 @@ fn rmp_round_trip() {
     };
 
     let rmp = rmp_serde::to_vec(&values).unwrap();
-    expect_test::expect![[r"\x91\x88\xa3Int{\xa6String\xa6FooBar\xa3Int\xcd\x01\xc8\xa6String\xa3XXX\xa4Unit\xc0\xa5Tuple\x93\x01\xa6Middle\xc2\xa6Struct\x93\xcd\x02\x9a\xa3BBB\xc3\xa2Ip\x92\x81\xa2V4\x94\x7f\x00\x00\x01\x81\xa2V6\xdc\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ww\xcc\xde\xcc\xad\xcc\xbe\xcc\xef"]]
+    expect![[r"\x91\x88\xa3Int{\xa6String\xa6FooBar\xa3Int\xcd\x01\xc8\xa6String\xa3XXX\xa4Unit\xc0\xa5Tuple\x93\x01\xa6Middle\xc2\xa6Struct\x93\xcd\x02\x9a\xa3BBB\xc3\xa2Ip\x92\x81\xa2V4\x94\x7f\x00\x00\x01\x81\xa2V6\xdc\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ww\xcc\xde\xcc\xad\xcc\xbe\xcc\xef"]]
         .assert_eq(&bytes_debug_readable(&rmp));
     let deser_values: VecEnumValues = rmp_serde::from_read(&*rmp).unwrap();
     assert_eq!(values, deser_values);
@@ -438,7 +438,7 @@ fn yaml_round_trip() {
     };
 
     let yaml = yaml_serde::to_string(&values).unwrap();
-    expect_test::expect![[r#"
+    expect![[r#"
         vec:
           Int: 123
           String: FooBar

--- a/serde_with/tests/serde_as/key_value_map.rs
+++ b/serde_with/tests/serde_as/key_value_map.rs
@@ -334,7 +334,7 @@ fn test_kvmap_complex_key_yaml() {
     };
 
     let yaml = yaml_serde::to_string(&kvmap).unwrap();
-    expect_test::expect![[r#"
+    expect![[r#"
         ? - 127.0.0.0
           - 24
         : bar: b

--- a/serde_with/tests/serde_as/time.rs
+++ b/serde_with/tests/serde_as/time.rs
@@ -477,7 +477,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         Duration, "DurationNanoSeconds<u64>", one_second, {expect![[r#"1000000000"#]]};
         Duration, "DurationNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         Duration, "DurationSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -488,7 +488,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         Duration, "DurationNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         Duration, "DurationNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 }
 
 #[test]
@@ -506,7 +506,7 @@ fn test_timestamp_systemtime_smoketest() {
         SystemTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         SystemTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         SystemTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         SystemTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -517,5 +517,5 @@ fn test_timestamp_systemtime_smoketest() {
         SystemTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         SystemTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         SystemTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 }

--- a/serde_with/tests/time_0_3.rs
+++ b/serde_with/tests/time_0_3.rs
@@ -48,7 +48,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         Duration, "DurationNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         Duration, "DurationNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         Duration, "DurationSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -59,7 +59,7 @@ fn test_duration_smoketest() {
         Duration, "DurationMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         Duration, "DurationNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         Duration, "DurationNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         Duration, "DurationSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -67,7 +67,7 @@ fn test_duration_smoketest() {
         Duration, "DurationSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         Duration, "DurationSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         Duration, "DurationSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn test_datetime_utc_smoketest() {
         OffsetDateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         OffsetDateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         OffsetDateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         OffsetDateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -95,7 +95,7 @@ fn test_datetime_utc_smoketest() {
         OffsetDateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         OffsetDateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         OffsetDateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         OffsetDateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -103,7 +103,7 @@ fn test_datetime_utc_smoketest() {
         OffsetDateTime, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         OffsetDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         OffsetDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn test_naive_datetime_smoketest() {
         PrimitiveDateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
         PrimitiveDateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
         PrimitiveDateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
-    };
+    }
 
     smoketest! {
         PrimitiveDateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
@@ -131,7 +131,7 @@ fn test_naive_datetime_smoketest() {
         PrimitiveDateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
         PrimitiveDateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
         PrimitiveDateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
-    };
+    }
 
     smoketest! {
         PrimitiveDateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
@@ -139,7 +139,7 @@ fn test_naive_datetime_smoketest() {
         PrimitiveDateTime, "TimestampSecondsWithFrac", zero + Duration::seconds(1), {expect![[r#"1.0"#]]};
         PrimitiveDateTime, "TimestampSecondsWithFrac", zero - Duration::nanoseconds(500_000_000), {expect![[r#"-0.5"#]]};
         PrimitiveDateTime, "TimestampSecondsWithFrac", zero - Duration::seconds(1), {expect![[r#"-1.0"#]]};
-    };
+    }
 }
 
 #[test]

--- a/serde_with_macros/src/apply.rs
+++ b/serde_with_macros/src/apply.rs
@@ -77,14 +77,12 @@ pub fn apply(args: TokenStream, input: TokenStream) -> TokenStream {
         .alt_crate_path
         .unwrap_or_else(|| syn::parse_quote!(::serde_with));
 
-    let res = match super::apply_function_to_struct_and_enum_fields_darling(
+    let res = super::apply_function_to_struct_and_enum_fields_darling(
         input,
         &serde_with_crate_path,
         &prepare_apply_attribute_to_field(args),
-    ) {
-        Ok(res) => res,
-        Err(err) => err.write_errors(),
-    };
+    )
+    .unwrap_or_else(DarlingError::write_errors);
     TokenStream::from(res)
 }
 

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -130,7 +130,7 @@ where
                     .iter_mut()
                     .map(|field| function(field).map_err(|err| err.with_span(&field)))
                     // turn the Err variant into the Some, such that we only collect errors
-                    .filter_map(std::result::Result::err)
+                    .filter_map(Result::err)
                     .collect();
                 if errors.is_empty() {
                     Ok(())
@@ -144,7 +144,7 @@ where
                     .iter_mut()
                     .map(|field| function(field).map_err(|err| err.with_span(&field)))
                     // turn the Err variant into the Some, such that we only collect errors
-                    .filter_map(std::result::Result::err)
+                    .filter_map(Result::err)
                     .collect();
                 if errors.is_empty() {
                     Ok(())
@@ -193,7 +193,7 @@ where
                 .iter_mut()
                 .map(|variant| apply_on_fields(&mut variant.fields, function))
                 // turn the Err variant into the Some, such that we only collect errors
-                .filter_map(std::result::Result::err),
+                .filter_map(Result::err),
         );
 
         if errors.is_empty() {
@@ -387,7 +387,7 @@ fn is_std_option(type_: &Type) -> bool {
             ..
         }) => is_std_option(elem),
 
-        Type::Path(syn::TypePath { qself: None, path }) => {
+        Type::Path(syn::TypePath { qself: _none, path }) => {
             (path.leading_colon.is_none()
                 && path.segments.len() == 1
                 && path.segments[0].ident == "Option")
@@ -1255,7 +1255,7 @@ pub fn derive_serialize_display(item: TokenStream) -> TokenStream {
 ///
 /// [`Display`]: std::fmt::Display
 /// [`FromStr`]: std::str::FromStr
-/// [`DeserializeFromStr`]: crate::DeserializeFromStr
+/// [`DeserializeFromStr`]: DeserializeFromStr
 #[proc_macro_derive(SerializeDisplayAlt, attributes(serde_with))]
 pub fn derive_serialize_display_alt(item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item);

--- a/serde_with_test/tests/derive_display_alt_fromstr.rs
+++ b/serde_with_test/tests/derive_display_alt_fromstr.rs
@@ -4,22 +4,27 @@
 #![no_implicit_prelude]
 #![allow(dead_code)]
 
+use ::std::result::Result;
+use ::std::str::FromStr;
+use ::std::string::String;
+use ::std::unimplemented;
+
 use ::s_with::{DeserializeFromStr, SerializeDisplayAlt};
 
 #[derive(DeserializeFromStr, SerializeDisplayAlt)]
 #[serde_with(crate = "::s_with")]
 struct A;
 
-impl ::std::str::FromStr for A {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl FromStr for A {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
 impl ::std::fmt::Display for A {
     fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+        unimplemented!()
     }
 }
 
@@ -27,16 +32,16 @@ impl ::std::fmt::Display for A {
 #[serde_with(crate = "::s_with")]
 struct G<T>(T);
 
-impl<T> ::std::str::FromStr for G<T> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl<T> FromStr for G<T> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
 impl<T> ::std::fmt::Display for G<T> {
     fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+        unimplemented!()
     }
 }
 
@@ -50,16 +55,16 @@ impl<T> ::std::fmt::Display for G<T> {
 #[serde_with(crate = "::s_with")]
 struct MoreG<D, E, S>(D, E, S);
 
-impl<D, E, S> ::std::str::FromStr for MoreG<D, E, S> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl<D, E, S> FromStr for MoreG<D, E, S> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
 impl<D, E, S> ::std::fmt::Display for MoreG<D, E, S> {
     fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+        unimplemented!()
     }
 }
 
@@ -67,15 +72,15 @@ impl<D, E, S> ::std::fmt::Display for MoreG<D, E, S> {
 #[serde_with(crate = "::s_with")]
 struct LT<'a>(&'a ());
 
-impl ::std::str::FromStr for LT<'_> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl FromStr for LT<'_> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
 impl ::std::fmt::Display for LT<'_> {
     fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+        unimplemented!()
     }
 }

--- a/serde_with_test/tests/derive_display_fromstr.rs
+++ b/serde_with_test/tests/derive_display_fromstr.rs
@@ -4,22 +4,28 @@
 #![no_implicit_prelude]
 #![allow(dead_code)]
 
+use ::std::fmt::{self, Display};
+use ::std::result::Result;
+use ::std::str::FromStr;
+use ::std::string::String;
+use ::std::unimplemented;
+
 use ::s_with::{DeserializeFromStr, SerializeDisplay};
 
 #[derive(DeserializeFromStr, SerializeDisplay)]
 #[serde_with(crate = "::s_with")]
 struct A;
 
-impl ::std::str::FromStr for A {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl FromStr for A {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
-impl ::std::fmt::Display for A {
-    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+impl Display for A {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
     }
 }
 
@@ -27,16 +33,16 @@ impl ::std::fmt::Display for A {
 #[serde_with(crate = "::s_with")]
 struct G<T>(T);
 
-impl<T> ::std::str::FromStr for G<T> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl<T> FromStr for G<T> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
-impl<T> ::std::fmt::Display for G<T> {
-    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+impl<T> Display for G<T> {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
     }
 }
 
@@ -50,16 +56,16 @@ impl<T> ::std::fmt::Display for G<T> {
 #[serde_with(crate = "::s_with")]
 struct MoreG<D, E, S>(D, E, S);
 
-impl<D, E, S> ::std::str::FromStr for MoreG<D, E, S> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl<D, E, S> FromStr for MoreG<D, E, S> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
-impl<D, E, S> ::std::fmt::Display for MoreG<D, E, S> {
-    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+impl<D, E, S> Display for MoreG<D, E, S> {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
     }
 }
 
@@ -67,15 +73,15 @@ impl<D, E, S> ::std::fmt::Display for MoreG<D, E, S> {
 #[serde_with(crate = "::s_with")]
 struct LT<'a>(&'a ());
 
-impl ::std::str::FromStr for LT<'_> {
-    type Err = ::std::string::String;
-    fn from_str(_: &str) -> ::std::result::Result<Self, Self::Err> {
-        ::std::unimplemented!()
+impl FromStr for LT<'_> {
+    type Err = String;
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
     }
 }
 
-impl ::std::fmt::Display for LT<'_> {
-    fn fmt(&self, _: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::unimplemented!()
+impl Display for LT<'_> {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
     }
 }

--- a/serde_with_test/tests/flattened_maybe.rs
+++ b/serde_with_test/tests/flattened_maybe.rs
@@ -4,18 +4,22 @@
 #![no_implicit_prelude]
 #![allow(dead_code)]
 
+use ::s::Deserialize;
+use ::s_json::from_str;
+use ::s_with::flattened_maybe;
+
 // The macro creates custom deserialization code.
 // You need to specify a function name and the field name of the flattened field.
-::s_with::flattened_maybe!(deserialize_t, "t");
+flattened_maybe!(deserialize_t, "t");
 // Setup the types
-#[derive(::s::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(crate = "::s")]
 struct S {
     #[serde(flatten, deserialize_with = "deserialize_t")]
     t: T,
 }
 
-#[derive(::s::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(crate = "::s")]
 struct T {
     i: i32,
@@ -25,17 +29,17 @@ struct T {
 fn flattened_maybe() {
     // Supports both flattened
     let j = r#" {"i":1} "#;
-    ::s_json::from_str::<S>(j).unwrap();
+    from_str::<S>(j).unwrap();
 
     // and non-flattened versions.
     let j = r#" {"t":{"i":1}} "#;
-    ::s_json::from_str::<S>(j).unwrap();
+    from_str::<S>(j).unwrap();
 
     // Ensure that the value is given
     let j = r#" {} "#;
-    ::s_json::from_str::<S>(j).unwrap_err();
+    from_str::<S>(j).unwrap_err();
 
     // and only occurs once, not multiple times.
     let j = r#" {"i":1,"t":{"i":1}} "#;
-    ::s_json::from_str::<S>(j).unwrap_err();
+    from_str::<S>(j).unwrap_err();
 }

--- a/serde_with_test/tests/serde_as_cfg.rs
+++ b/serde_with_test/tests/serde_as_cfg.rs
@@ -4,8 +4,14 @@
 #![no_implicit_prelude]
 #![allow(dead_code)]
 
-#[cfg_attr(test, ::cfg_eval::cfg_eval, ::s_with::serde_as(crate = "::s_with"))]
-#[cfg_attr(test, derive(::s::Serialize, ::s::Deserialize))]
+use ::cfg_eval::cfg_eval;
+use ::s::{Deserialize, Serialize};
+use ::s_json::{from_str, to_string};
+use ::s_with::serde_as;
+use ::std::assert_eq;
+
+#[cfg_attr(test, cfg_eval, serde_as(crate = "::s_with"))]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[serde(crate = "::s")]
 struct S {
@@ -17,8 +23,8 @@ struct S {
 fn serde_as_cfg_gated() {
     let s = S { int: 42 };
     // Check serialization
-    let s = ::s_json::to_string(&s).unwrap();
-    ::std::assert_eq!(s, r#"{"int":"42"}"#);
-    let s: S = ::s_json::from_str(&s).unwrap();
-    ::std::assert_eq!(s.int, 42);
+    let s = to_string(&s).unwrap();
+    assert_eq!(s, r#"{"int":"42"}"#);
+    let s: S = from_str(&s).unwrap();
+    assert_eq!(s.int, 42);
 }

--- a/serde_with_test/tests/serde_conv.rs
+++ b/serde_with_test/tests/serde_conv.rs
@@ -5,12 +5,18 @@
 #![allow(dead_code)]
 
 use ::s_with::serde_conv;
+use ::std::borrow::ToOwned;
+use ::std::convert::Infallible;
+use ::std::num::ParseIntError;
+use ::std::result::Result;
+use ::std::result::Result::Ok;
+use ::std::string::{String, ToString};
 
 serde_conv!(
     BoolAsString,
     bool,
-    |x: &bool| ::std::string::ToString::to_string(x),
-    |x: ::std::string::String| x.parse()
+    |x: &bool| ToString::to_string(x),
+    |x: String| x.parse()
 );
 
 #[derive(::s::Serialize, ::s::Deserialize)]
@@ -21,13 +27,11 @@ struct S(#[serde(with = "BoolAsString")] bool);
 // This makes it look more like a module.
 serde_conv!(number, u32, u32_to_string, string_to_u32);
 
-fn u32_to_string(x: &u32) -> ::std::string::String {
-    ::std::string::ToString::to_string(x)
+fn u32_to_string(x: &u32) -> String {
+    ToString::to_string(x)
 }
 
-fn string_to_u32(
-    s: ::std::string::String,
-) -> ::std::result::Result<u32, ::std::num::ParseIntError> {
+fn string_to_u32(s: String) -> Result<u32, ParseIntError> {
     s.parse()
 }
 
@@ -41,10 +45,10 @@ struct S2(#[serde(with = "number")] u32);
 // https://github.com/jonasbb/serde_with/pull/729
 serde_conv!(
     pub StringAsHtml,
-    ::std::string::String,
-    |string: &str| ::std::borrow::ToOwned::to_owned(string),
-    |string: ::std::string::String| -> ::std::result::Result<_, ::std::convert::Infallible> {
-::std::result::Result::Ok(string)
+    String,
+    |string: &str| ToOwned::to_owned(string),
+    |string: String| -> Result<_, Infallible> {
+Ok(string)
     }
 );
 


### PR DESCRIPTION
Unnecessary prefixes were removed from the entire code and integrated into 'use'.

The impl structure was standardized.

No code logic was modified or added separately.

It was verified that the tests passed successfully locally using `cargo test --all`.