### PR TITLE
Protect all collection creations against capacity overflow by using `size_hint_cautious`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ redundant_closure_for_method_calls = "warn"
 semicolon_if_nothing_returned = "warn"
 # std_instead_of_core = "warn"
 # std_instead_of_alloc = "warn"
+disallowed_methods = "warn"
 
 [workspace.lints.rustdoc]
 missing_crate_level_docs = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    {path = "std::vec::Vec::with_capacity", reason = "Large values can overflow the allocation capacity", replacement = "crate::utils::vec_with_capacity_cautious"},
+]

--- a/serde_with/src/content/de.rs
+++ b/serde_with/src/content/de.rs
@@ -15,10 +15,7 @@
 //! <https://github.com/serde-rs/serde/pull/2348>
 
 use self::utils::{get_unexpected_i128, get_unexpected_u128};
-use crate::{
-    prelude::*,
-    utils::{size_hint_cautious, size_hint_from_bounds},
-};
+use crate::{prelude::*, utils::size_hint_from_bounds};
 
 /// Used from generated code to buffer the contents of the Deserializer when
 /// deserializing untagged enums and internally tagged enums.
@@ -281,7 +278,7 @@ impl<'de> Visitor<'de> for ContentVisitor<'de> {
     where
         V: SeqAccess<'de>,
     {
-        let mut vec = Vec::with_capacity(size_hint_cautious::<Content<'_>>(visitor.size_hint()));
+        let mut vec = utils::vec_with_capacity_cautious(visitor.size_hint());
         while let Some(e) = visitor.next_element()? {
             vec.push(e);
         }
@@ -292,9 +289,7 @@ impl<'de> Visitor<'de> for ContentVisitor<'de> {
     where
         V: MapAccess<'de>,
     {
-        let mut vec = Vec::with_capacity(size_hint_cautious::<(Content<'_>, Content<'_>)>(
-            visitor.size_hint(),
-        ));
+        let mut vec = utils::vec_with_capacity_cautious(visitor.size_hint());
         while let Some(kv) = visitor.next_entry()? {
             vec.push(kv);
         }

--- a/serde_with/src/content/ser.rs
+++ b/serde_with/src/content/ser.rs
@@ -308,7 +308,7 @@ where
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, E> {
         Ok(SeqSerialize {
             is_human_readable: self.is_human_readable,
-            elements: Vec::with_capacity(len.unwrap_or(0)),
+            elements: utils::vec_with_capacity_cautious(len),
             error: PhantomData,
         })
     }
@@ -316,7 +316,7 @@ where
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, E> {
         Ok(TupleSerialize {
             is_human_readable: self.is_human_readable,
-            elements: Vec::with_capacity(len),
+            elements: utils::vec_with_capacity_cautious(Some(len)),
             error: PhantomData,
         })
     }
@@ -329,7 +329,7 @@ where
         Ok(TupleStructSerialize {
             is_human_readable: self.is_human_readable,
             name,
-            fields: Vec::with_capacity(len),
+            fields: utils::vec_with_capacity_cautious(Some(len)),
             error: PhantomData,
         })
     }
@@ -346,7 +346,7 @@ where
             name,
             variant_index,
             variant,
-            fields: Vec::with_capacity(len),
+            fields: utils::vec_with_capacity_cautious(Some(len)),
             error: PhantomData,
         })
     }
@@ -354,7 +354,7 @@ where
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, E> {
         Ok(MapSerialize {
             is_human_readable: self.is_human_readable,
-            entries: Vec::with_capacity(len.unwrap_or(0)),
+            entries: utils::vec_with_capacity_cautious(len),
             key: None,
             error: PhantomData,
         })
@@ -364,7 +364,7 @@ where
         Ok(StructSerialize {
             is_human_readable: self.is_human_readable,
             name,
-            fields: Vec::with_capacity(len),
+            fields: utils::vec_with_capacity_cautious(Some(len)),
             error: PhantomData,
         })
     }
@@ -381,7 +381,7 @@ where
             name,
             variant_index,
             variant,
-            fields: Vec::with_capacity(len),
+            fields: utils::vec_with_capacity_cautious(Some(len)),
             error: PhantomData,
         })
     }

--- a/serde_with/src/de/impls.rs
+++ b/serde_with/src/de/impls.rs
@@ -33,37 +33,37 @@ pub(crate) mod macros {
             #[cfg(feature = "std")]
             $m!(
                 HashMap<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| HashMap::with_capacity_and_hasher(size, Default::default()))
+                (|size| HashMap::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "hashbrown_0_14")]
             $m!(
                 HashbrownMap014<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| HashbrownMap014::with_capacity_and_hasher(size, Default::default()))
+                (|size| HashbrownMap014::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "hashbrown_0_15")]
             $m!(
                 HashbrownMap015<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| HashbrownMap015::with_capacity_and_hasher(size, Default::default()))
+                (|size| HashbrownMap015::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "hashbrown_0_16")]
             $m!(
                 HashbrownMap016<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| HashbrownMap016::with_capacity_and_hasher(size, Default::default()))
+                (|size| HashbrownMap016::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "hashbrown_0_17")]
             $m!(
                 HashbrownMap017<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| HashbrownMap017::with_capacity_and_hasher(size, Default::default()))
+                (|size| HashbrownMap017::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "indexmap_1")]
             $m!(
                 IndexMap<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| IndexMap::with_capacity_and_hasher(size, Default::default()))
+                (|size| IndexMap::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
             #[cfg(feature = "indexmap_2")]
             $m!(
                 IndexMap2<K: Eq + Hash, V, S: BuildHasher + Default>,
-                (|size| IndexMap2::with_capacity_and_hasher(size, Default::default()))
+                (|size| IndexMap2::with_capacity_and_hasher(crate::utils::size_hint_cautious::<(K,V)>(Some(size)), Default::default()))
             );
         };
     }
@@ -75,43 +75,43 @@ pub(crate) mod macros {
             #[cfg(feature = "std")]
             $m!(
                 HashSet<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| HashSet::with_capacity_and_hasher(size, S::default())),
+                (|size| HashSet::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "hashbrown_0_14")]
             $m!(
                 HashbrownSet014<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| HashbrownSet014::with_capacity_and_hasher(size, S::default())),
+                (|size| HashbrownSet014::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "hashbrown_0_15")]
             $m!(
                 HashbrownSet015<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| HashbrownSet015::with_capacity_and_hasher(size, S::default())),
+                (|size| HashbrownSet015::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "hashbrown_0_16")]
             $m!(
                 HashbrownSet016<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| HashbrownSet016::with_capacity_and_hasher(size, S::default())),
+                (|size| HashbrownSet016::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "hashbrown_0_17")]
             $m!(
                 HashbrownSet017<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| HashbrownSet017::with_capacity_and_hasher(size, S::default())),
+                (|size| HashbrownSet017::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "indexmap_1")]
             $m!(
                 IndexSet<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| IndexSet::with_capacity_and_hasher(size, S::default())),
+                (|size| IndexSet::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
             #[cfg(feature = "indexmap_2")]
             $m!(
                 IndexSet2<T: Eq + Hash, S: BuildHasher + Default>,
-                (|size| IndexSet2::with_capacity_and_hasher(size, S::default())),
+                (|size| IndexSet2::with_capacity_and_hasher(crate::utils::size_hint_cautious::<T>(Some(size)), S::default())),
                 insert
             );
         };
@@ -124,19 +124,19 @@ pub(crate) mod macros {
             #[cfg(feature = "alloc")]
             $m!(
                 BinaryHeap<T: Ord>,
-                (|size| BinaryHeap::with_capacity(size)),
+                (|size| BinaryHeap::with_capacity(crate::utils::size_hint_cautious::<T>(Some(size)))),
                 push
             );
             #[cfg(feature = "alloc")]
-            $m!(BoxedSlice<T>, (|size| Vec::with_capacity(size)), push);
+            $m!(BoxedSlice<T>, (|size| crate::utils::vec_with_capacity_cautious(Some(size))), push);
             #[cfg(feature = "alloc")]
             $m!(LinkedList<T>, (|_| LinkedList::new()), push_back);
             #[cfg(feature = "alloc")]
-            $m!(Vec<T>, (|size| Vec::with_capacity(size)), push);
+            $m!(Vec<T>, (|size| crate::utils::vec_with_capacity_cautious(Some(size))), push);
             #[cfg(feature = "alloc")]
             $m!(
                 VecDeque<T>,
-                (|size| VecDeque::with_capacity(size)),
+                (|size| VecDeque::with_capacity(crate::utils::size_hint_cautious::<T>(Some(size)))),
                 push_back
             );
         };

--- a/serde_with/src/enum_map.rs
+++ b/serde_with/src/enum_map.rs
@@ -607,7 +607,7 @@ where
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
             variant,
-            content: Content::TupleStruct(name, Vec::with_capacity(len)),
+            content: Content::TupleStruct(name, utils::vec_with_capacity_cautious(Some(len))),
         })
     }
 
@@ -634,7 +634,7 @@ where
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
             variant,
-            content: Content::Struct(name, Vec::with_capacity(len)),
+            content: Content::Struct(name, utils::vec_with_capacity_cautious(Some(len))),
         })
     }
 }

--- a/serde_with/src/key_value_map.rs
+++ b/serde_with/src/key_value_map.rs
@@ -587,7 +587,7 @@ where
         Ok(KeyValueSeqSerializer {
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
-            content: Vec::with_capacity(len.unwrap_or(17) - 1),
+            content: utils::vec_with_capacity_cautious(Some(len.unwrap_or(17).saturating_sub(1))),
             key: None,
         })
     }
@@ -596,7 +596,7 @@ where
         Ok(KeyValueTupleSerializer {
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
-            content: Vec::with_capacity(len - 1),
+            content: utils::vec_with_capacity_cautious(Some(len.saturating_sub(1))),
             key: None,
         })
     }
@@ -610,7 +610,7 @@ where
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
             name,
-            content: Vec::with_capacity(len - 1),
+            content: utils::vec_with_capacity_cautious(Some(len.saturating_sub(1))),
             key: None,
         })
     }
@@ -629,7 +629,7 @@ where
         Ok(KeyValueMapSerializer {
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
-            content: Vec::with_capacity(len.unwrap_or(17) - 1),
+            content: utils::vec_with_capacity_cautious(Some(len.unwrap_or(17).saturating_sub(1))),
             next_is_magic_key: false,
             key: None,
             tmp: None,
@@ -645,7 +645,7 @@ where
             delegate: self.delegate,
             is_human_readable: self.is_human_readable,
             name,
-            content: Vec::with_capacity(len - 1),
+            content: utils::vec_with_capacity_cautious(Some(len.saturating_sub(1))),
             key: None,
         })
     }

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -15,6 +15,14 @@ pub(crate) fn size_hint_cautious<Element>(hint: Option<usize>) -> usize {
     }
 }
 
+/// Safer version of [`Vec::with_capacity`] that uses `size_hint_cautious` to prevent overflow when calculating the capacity.
+///
+/// Implemented to address crashes due to capacity overflow, e.g., GHSA-7gcf-g7xr-8hxj
+pub(crate) fn vec_with_capacity_cautious<Element>(hint: Option<usize>) -> Vec<Element> {
+    #[allow(clippy::disallowed_methods)]
+    Vec::with_capacity(size_hint_cautious::<Element>(hint))
+}
+
 /// Re-Implementation of `serde::private::de::size_hint::from_bounds`
 #[cfg(feature = "alloc")]
 #[inline]

--- a/serde_with/src/utils.rs
+++ b/serde_with/src/utils.rs
@@ -18,6 +18,8 @@ pub(crate) fn size_hint_cautious<Element>(hint: Option<usize>) -> usize {
 /// Safer version of [`Vec::with_capacity`] that uses `size_hint_cautious` to prevent overflow when calculating the capacity.
 ///
 /// Implemented to address crashes due to capacity overflow, e.g., GHSA-7gcf-g7xr-8hxj
+#[cfg(feature = "alloc")]
+#[inline]
 pub(crate) fn vec_with_capacity_cautious<Element>(hint: Option<usize>) -> Vec<Element> {
     #[allow(clippy::disallowed_methods)]
     Vec::with_capacity(size_hint_cautious::<Element>(hint))


### PR DESCRIPTION
`size_hint_cautious` limits the capacity to a reasonable maximum. This prevents allocating too much memory and crashing when deserializing maliciously crafted data that causes the size hint to overflow.

This addresses crashes due to capacity overflow reported as [GHSA-7gcf-g7xr-8hxj](https://github.com/jonasbb/serde_with/security/advisories/GHSA-7gcf-g7xr-8hxj).