### PR TITLE
Guard with_capacity_and_hasher against untrusted size_hint (DoS)

### DIFF
--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+
+* Extend the [GHSA-7gcf-g7xr-8hxj](https://github.com/jonasbb/serde_with/security/advisories/GHSA-7gcf-g7xr-8hxj) fix to the duplicate-key-prevention collections.
+    The `rust::sets_duplicate_value_is_error`, `rust::maps_duplicate_key_is_error`, `rust::sets_last_value_wins`, and `rust::maps_first_key_wins` adapters created their backing sets/maps with `with_capacity_and_hasher` using the raw deserializer `size_hint`, bypassing the `size_hint_cautious` cap added in #966 (the `clippy.toml` `disallowed_methods` lint only covers `Vec::with_capacity`, not `with_capacity_and_hasher`, so these sites were not flagged).
+    Attacker-controlled input claiming a huge length could panic with `Hash table capacity overflow` before a single element was read. All such constructions now route through `size_hint_cautious`.
+
 ## [3.21.0] - 2026-06-04
 
 ### Security

--- a/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
+++ b/serde_with/src/duplicate_key_impls/error_on_duplicate.rs
@@ -1,4 +1,14 @@
 use crate::prelude::*;
+#[cfg(any(
+    feature = "std",
+    feature = "hashbrown_0_14",
+    feature = "hashbrown_0_15",
+    feature = "hashbrown_0_16",
+    feature = "hashbrown_0_17",
+    feature = "indexmap_1",
+    feature = "indexmap_2"
+))]
+use crate::utils::size_hint_cautious;
 
 pub trait PreventDuplicateInsertsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;
@@ -22,10 +32,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -42,10 +49,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -62,10 +66,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -82,10 +83,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -102,10 +100,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -122,10 +117,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -142,10 +134,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -177,10 +166,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -197,10 +183,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -217,10 +200,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -237,10 +217,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -257,10 +234,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -277,10 +251,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -297,10 +268,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]

--- a/serde_with/src/duplicate_key_impls/first_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/first_value_wins.rs
@@ -1,4 +1,14 @@
 use crate::prelude::*;
+#[cfg(any(
+    feature = "std",
+    feature = "hashbrown_0_14",
+    feature = "hashbrown_0_15",
+    feature = "hashbrown_0_16",
+    feature = "hashbrown_0_17",
+    feature = "indexmap_1",
+    feature = "indexmap_2"
+))]
+use crate::utils::size_hint_cautious;
 
 pub trait DuplicateInsertsFirstWinsMap<K, V> {
     fn new(size_hint: Option<usize>) -> Self;
@@ -15,10 +25,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -43,10 +50,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -71,10 +75,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -99,10 +100,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -127,10 +125,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -155,10 +150,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]
@@ -183,10 +175,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<(K, V)>(size_hint), S::default())
     }
 
     #[inline]

--- a/serde_with/src/duplicate_key_impls/last_value_wins.rs
+++ b/serde_with/src/duplicate_key_impls/last_value_wins.rs
@@ -1,4 +1,14 @@
 use crate::prelude::*;
+#[cfg(any(
+    feature = "std",
+    feature = "hashbrown_0_14",
+    feature = "hashbrown_0_15",
+    feature = "hashbrown_0_16",
+    feature = "hashbrown_0_17",
+    feature = "indexmap_1",
+    feature = "indexmap_2"
+))]
+use crate::utils::size_hint_cautious;
 
 pub trait DuplicateInsertsLastWinsSet<T> {
     fn new(size_hint: Option<usize>) -> Self;
@@ -15,10 +25,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -36,10 +43,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -57,10 +61,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -78,10 +79,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -99,10 +97,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -120,10 +115,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]
@@ -141,10 +133,7 @@ where
 {
     #[inline]
     fn new(size_hint: Option<usize>) -> Self {
-        match size_hint {
-            Some(size) => Self::with_capacity_and_hasher(size, S::default()),
-            None => Self::with_hasher(S::default()),
-        }
+        Self::with_capacity_and_hasher(size_hint_cautious::<T>(size_hint), S::default())
     }
 
     #[inline]

--- a/serde_with/tests/rust.rs
+++ b/serde_with/tests/rust.rs
@@ -489,3 +489,123 @@ fn unwrap_or_skip_none() {
         "Deserialization differs from expected value."
     );
 }
+
+/// Regression test: a malicious `size_hint` must not cause a capacity-overflow
+/// panic when deserializing into the duplicate-key-prevention adapters.
+///
+/// This is the sibling of the `size_hint_cautious` protection added for
+/// GHSA-7gcf-g7xr-8hxj: the `duplicate_key_impls` constructors used by
+/// `rust::sets_duplicate_value_is_error`, `rust::maps_duplicate_key_is_error`,
+/// `rust::sets_last_value_wins` and `rust::maps_first_key_wins` previously
+/// passed the deserializer-reported `size_hint` straight to
+/// `with_capacity_and_hasher`, so a hostile self-describing input claiming a
+/// huge length panicked the parser ("Hash table capacity overflow") before a
+/// single element was read.
+mod malicious_size_hint {
+    use std::collections::{HashMap, HashSet};
+
+    use serde::de::{
+        value::Error as VError, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor,
+    };
+    use serde::Deserialize;
+
+    // A deserializer whose seq/map report `size_hint == usize::MAX` but yield no
+    // elements — mimicking untrusted input that lies about its length.
+    struct EvilDe;
+
+    impl<'de> Deserializer<'de> for EvilDe {
+        type Error = VError;
+
+        fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, VError> {
+            visitor.visit_seq(EvilAccess)
+        }
+        fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, VError> {
+            visitor.visit_map(EvilAccess)
+        }
+
+        serde::forward_to_deserialize_any! {
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bytes byte_buf option unit unit_struct newtype_struct tuple
+            tuple_struct struct enum identifier ignored_any
+        }
+        fn deserialize_any<V: Visitor<'de>>(self, _v: V) -> Result<V::Value, VError> {
+            unimplemented!()
+        }
+    }
+
+    struct EvilAccess;
+
+    impl<'de> SeqAccess<'de> for EvilAccess {
+        type Error = VError;
+        fn next_element_seed<T: DeserializeSeed<'de>>(
+            &mut self,
+            _seed: T,
+        ) -> Result<Option<T::Value>, VError> {
+            Ok(None)
+        }
+        fn size_hint(&self) -> Option<usize> {
+            Some(usize::MAX)
+        }
+    }
+
+    impl<'de> MapAccess<'de> for EvilAccess {
+        type Error = VError;
+        fn next_key_seed<K: DeserializeSeed<'de>>(
+            &mut self,
+            _seed: K,
+        ) -> Result<Option<K::Value>, VError> {
+            Ok(None)
+        }
+        fn next_value_seed<V: DeserializeSeed<'de>>(
+            &mut self,
+            _seed: V,
+        ) -> Result<V::Value, VError> {
+            unreachable!()
+        }
+        fn size_hint(&self) -> Option<usize> {
+            Some(usize::MAX)
+        }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    struct SetPreventDup(
+        #[serde(with = "::serde_with::rust::sets_duplicate_value_is_error")] HashSet<u64>,
+    );
+
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    struct MapPreventDup(
+        #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")] HashMap<u64, u64>,
+    );
+
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    struct SetLastWins(#[serde(with = "::serde_with::rust::sets_last_value_wins")] HashSet<u64>);
+
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    struct MapFirstWins(
+        #[serde(with = "::serde_with::rust::maps_first_key_wins")] HashMap<u64, u64>,
+    );
+
+    #[test]
+    fn sets_duplicate_value_is_error_huge_size_hint() {
+        assert!(SetPreventDup::deserialize(EvilDe).unwrap().0.is_empty());
+    }
+
+    #[test]
+    fn maps_duplicate_key_is_error_huge_size_hint() {
+        assert!(MapPreventDup::deserialize(EvilDe).unwrap().0.is_empty());
+    }
+
+    #[test]
+    fn sets_last_value_wins_huge_size_hint() {
+        assert!(SetLastWins::deserialize(EvilDe).unwrap().0.is_empty());
+    }
+
+    #[test]
+    fn maps_first_key_wins_huge_size_hint() {
+        assert!(MapFirstWins::deserialize(EvilDe).unwrap().0.is_empty());
+    }
+}


### PR DESCRIPTION
The duplicate-key handling generates `with_capacity_and_hasher(size_hint, ...)` from a deserializer-provided hint in many places. A malicious `usize::MAX` hint overflows the capacity and panics — the same DoS class addressed by advisory GHSA-7gcf and PR #966, which protected the other collections but missed this module (the clippy lint that catches the raw constructor does not flag `with_capacity_and_hasher`).

The fix caps the reserved capacity the same way #966 did elsewhere. Verified both ways.