### PR TITLE
Add support for jiff v0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: "Check no_std+alloc (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }})"
         run: cargo check --package serde_with --no-default-features --features=alloc --target thumbv7em-none-eabihf
       - name: "Check no_std+alloc+optional (No Default Features / ${{ matrix.os }} / ${{ matrix.rust }})"
-        run: cargo check --package serde_with --no-default-features --features=alloc,base58,base64,chrono_0_4,hashbrown_0_14,hashbrown_0_15,hashbrown_0_16,hex,indexmap_1,indexmap_2,json,time_0_3 --target thumbv7em-none-eabihf
+        run: cargo check --package serde_with --no-default-features --features=alloc,base58,base64,chrono_0_4,hashbrown_0_14,hashbrown_0_15,hashbrown_0_16,hex,indexmap_1,indexmap_2,jiff_0_2,json,time_0_3 --target thumbv7em-none-eabihf
 
       # The tests are split into build and run steps, to see the time impact of each
       # cargo test --all-targets does NOT run doctests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3590fea8e9e22d449600c9bbd481a8163bef223e4ff938e5f55899f8cf1adb93"
+dependencies = [
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -780,6 +809,21 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1118,6 +1162,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.11.4",
+ "jiff",
  "jsonschema",
  "mime",
  "pretty_assertions",

--- a/serde_with/CHANGELOG.md
+++ b/serde_with/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Add support for `jiff` v0.2 behind the new `jiff_0_2` feature flag (#936)
+    `jiff::SignedDuration` works with `DurationSeconds` and its variants.
+    `jiff::Timestamp`, `jiff::Zoned`, and `jiff::civil::DateTime` work with `TimestampSeconds` and its variants.
+    Deserializing a `jiff::Zoned` uses the system time zone, like `chrono::DateTime<Local>`.
+
 ## [3.21.0] - 2026-06-04
 
 ### Security

--- a/serde_with/Cargo.toml
+++ b/serde_with/Cargo.toml
@@ -37,11 +37,11 @@ default = ["std", "macros"]
 #! Some features require `alloc` or `std` support and might not work in a `no_std` environment.
 
 ## Enable support for types from the `alloc` crate when running in a `no_std` environment.
-alloc = ["serde_core/alloc", "base64?/alloc", "bs58?/alloc", "chrono_0_4?/alloc", "hex?/alloc", "serde_json?/alloc", "time_0_3?/alloc"]
+alloc = ["serde_core/alloc", "base64?/alloc", "bs58?/alloc", "chrono_0_4?/alloc", "hex?/alloc", "jiff_0_2?/alloc", "serde_json?/alloc", "time_0_3?/alloc"]
 ## Enables support for various types from the std library.
 ## This will enable `std` support in all dependencies too.
 ## The feature enabled by default and also enables `alloc`.
-std = ["alloc", "bs58?/std", "serde_core/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "time_0_3?/serde-well-known", "time_0_3?/std", "schemars_0_9?/std", "schemars_1?/std"]
+std = ["alloc", "bs58?/std", "serde_core/std", "chrono_0_4?/clock", "chrono_0_4?/std", "indexmap_1?/std", "indexmap_2?/std", "jiff_0_2?/std", "jiff_0_2?/tz-system", "jiff_0_2?/tzdb-bundle-platform", "jiff_0_2?/tzdb-concatenated", "jiff_0_2?/tzdb-zoneinfo", "time_0_3?/serde-well-known", "time_0_3?/std", "schemars_0_9?/std", "schemars_1?/std"]
 
 #! # Documentation
 #!
@@ -119,6 +119,12 @@ indexmap_1 = ["dep:indexmap_1", "alloc"]
 ## It enables the `alloc` feature.
 ## Some functionality is only available when `std` is enabled too.
 indexmap_2 = ["dep:indexmap_2", "alloc"]
+## The feature enables integration of `jiff` v0.2 specific conversions.
+## This includes support for the timestamp, duration, zoned and civil datetime types.
+##
+## This pulls in [`jiff` v0.2](::jiff_0_2) as a dependency.
+## Some functionality is only available when `alloc` or `std` is enabled too.
+jiff_0_2 = ["dep:jiff_0_2"]
 ## The feature enables JSON conversions from the `json` module.
 ##
 ## This pulls in [`serde_json`] as a dependency.
@@ -174,6 +180,7 @@ hashbrown_0_17 = { package = "hashbrown", version = "0.17.0", optional = true, d
 hex = { version = "0.4.3", optional = true, default-features = false }
 indexmap_1 = { package = "indexmap", version = "1.8", optional = true, default-features = false, features = ["serde-1"] }
 indexmap_2 = { package = "indexmap", version = "2.0", optional = true, default-features = false, features = ["serde"] }
+jiff_0_2 = { package = "jiff", version = "0.2.0", optional = true, default-features = false }
 schemars_0_8 = { package = "schemars", version = "0.8.16", optional = true, default-features = false }
 schemars_0_9 = { package = "schemars", version = "0.9.0", optional = true, default-features = false }
 schemars_1 = { package = "schemars", version = "1.0.2", optional = true, default-features = false }
@@ -252,6 +259,11 @@ required-features = ["indexmap_1", "macros"]
 name = "indexmap_2"
 path = "tests/indexmap_2.rs"
 required-features = ["indexmap_2", "macros"]
+
+[[test]]
+name = "jiff_0_2"
+path = "tests/jiff_0_2.rs"
+required-features = ["jiff_0_2", "macros"]
 
 [[test]]
 name = "json"

--- a/serde_with/src/guide/serde_as_transformations.md
+++ b/serde_with/src/guide/serde_as_transformations.md
@@ -276,6 +276,8 @@ value: Duration,
 
 The same conversions are also implemented for [`chrono::Duration`] with the `chrono` feature.
 
+The same conversions are also implemented for [`jiff::SignedDuration`] with the `jiff_0_2` feature.
+
 The same conversions are also implemented for [`time::Duration`] with the `time_0_3` feature.
 
 ## Hex encode bytes
@@ -545,6 +547,8 @@ value: SystemTime,
 
 The same conversions are also implemented for [`chrono::DateTime<Utc>`], [`chrono::DateTime<Local>`], and [`chrono::NaiveDateTime`] with the `chrono` feature.
 
+The conversions are available for [`jiff::Timestamp`], [`jiff::Zoned`], and [`jiff::civil::DateTime`] with the `jiff_0_2` feature enabled.
+
 The conversions are available for [`time::OffsetDateTime`] and [`time::PrimitiveDateTime`] with the `time_0_3` feature enabled.
 
 ## Value into JSON String
@@ -651,6 +655,10 @@ value: u128,
 [`FromInto`]: crate::FromInto
 [`Hex`]: crate::hex::Hex
 [`IfIsHumanReadable`]: crate::IfIsHumanReadable
+[`jiff::civil::DateTime`]: jiff_0_2::civil::DateTime
+[`jiff::SignedDuration`]: jiff_0_2::SignedDuration
+[`jiff::Timestamp`]: jiff_0_2::Timestamp
+[`jiff::Zoned`]: jiff_0_2::Zoned
 [`JsonString`]: crate::json::JsonString
 [`KeyValueMap`]: crate::KeyValueMap
 [`MapFirstKeyWins`]: crate::MapFirstKeyWins

--- a/serde_with/src/jiff_0_2.rs
+++ b/serde_with/src/jiff_0_2.rs
@@ -1,0 +1,621 @@
+//! De/Serialization of [jiff v0.2][jiff] types
+//!
+//! This modules is only available if using the `jiff_0_2` feature of the crate.
+//! No extra types are exposed. Instead it enables support for [`jiff_0_2::SignedDuration`] together with [`DurationSeconds`] and its variants.
+//! The types [`jiff_0_2::Timestamp`], [`jiff_0_2::Zoned`], and [`jiff_0_2::civil::DateTime`][::jiff_0_2::civil::DateTime] are supported by [`TimestampSeconds`] and its variants.
+//!
+//! [jiff]: https://docs.rs/jiff/0.2/
+
+// Serialization of large numbers can result in overflows
+// The time calculations are prone to this, so lint here extra
+// https://github.com/jonasbb/serde_with/issues/771
+#![warn(clippy::as_conversions)]
+
+use crate::{
+    formats::{Flexible, Format, Strict, Strictness},
+    prelude::*,
+};
+#[cfg(feature = "std")]
+use ::jiff_0_2::tz::TimeZone;
+use ::jiff_0_2::{civil::DateTime as CivilDateTime, SignedDuration, Timestamp, Zoned};
+
+/// Create a [`CivilDateTime`] for the Unix Epoch
+fn unix_epoch_civil() -> CivilDateTime {
+    ::jiff_0_2::civil::datetime(1970, 1, 1, 0, 0, 0, 0)
+}
+
+/// Convert a [`SignedDuration`] into a [`DurationSigned`]
+fn duration_into_duration_signed(dur: &SignedDuration) -> DurationSigned {
+    // The seconds and nanoseconds of a SignedDuration always have the same sign.
+    let std_dur = Duration::new(
+        dur.as_secs().unsigned_abs(),
+        dur.subsec_nanos().unsigned_abs(),
+    );
+
+    DurationSigned::with_duration(
+        // A duration of 0 is not positive, so check for negative value.
+        if dur.is_negative() {
+            Sign::Negative
+        } else {
+            Sign::Positive
+        },
+        std_dur,
+    )
+}
+
+/// Convert a [`DurationSigned`] into a [`SignedDuration`]
+fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<SignedDuration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut dur: SignedDuration = match sdur.duration.try_into() {
+        Ok(dur) => dur,
+        Err(msg) => {
+            return Err(DeError::custom(format_args!(
+                "Duration is outside of the representable range: {msg}"
+            )))
+        }
+    };
+    if sdur.sign.is_negative() {
+        dur = -dur;
+    }
+    Ok(dur)
+}
+
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident =>
+        {
+            $ty:ty; $converter:ident =>
+            $({
+                $format:ty, $strictness:ty =>
+                $($tbound:ident: $bound:ident $(,)?)*
+            })*
+        }
+    ) => {
+        $(
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*
+    };
+    (
+        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
+    ) => {
+        $( use_duration_signed_ser!($main_trait $internal_trait => $rest); )+
+    };
+}
+
+fn timestamp_to_duration(source: &Timestamp) -> DurationSigned {
+    duration_into_duration_signed(&source.as_duration())
+}
+
+fn zoned_to_duration(source: &Zoned) -> DurationSigned {
+    timestamp_to_duration(&source.timestamp())
+}
+
+fn civil_datetime_to_duration(source: &CivilDateTime) -> DurationSigned {
+    duration_into_duration_signed(&source.duration_since(unix_epoch_civil()))
+}
+
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Zoned; zoned_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Zoned; zoned_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Zoned; zoned_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Zoned; zoned_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Zoned; zoned_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident =>
+        {
+            $ty:ty; $converter:ident =>
+            $({
+                $format:ty, $strictness:ty =>
+                $($tbound:ident: $bound:ident)*
+            })*
+        }
+    ) =>{
+        $(
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*
+    };
+    (
+        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
+    ) => {
+        $( use_duration_signed_de!($main_trait $internal_trait => $rest); )+
+    };
+}
+
+fn duration_to_timestamp<'de, D>(dur: DurationSigned) -> Result<Timestamp, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Timestamp::from_duration(duration_from_duration_signed::<D>(dur)?).map_err(|msg| {
+        DeError::custom(format_args!(
+            "Timestamp is outside of the representable range: {msg}"
+        ))
+    })
+}
+
+#[cfg(feature = "std")]
+fn duration_to_zoned<'de, D>(dur: DurationSigned) -> Result<Zoned, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(duration_to_timestamp::<D>(dur)?.to_zoned(TimeZone::system()))
+}
+
+fn duration_to_civil_datetime<'de, D>(dur: DurationSigned) -> Result<CivilDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    unix_epoch_civil()
+        .checked_add(duration_from_duration_signed::<D>(dur)?)
+        .map_err(|msg| {
+            DeError::custom(format_args!(
+                "DateTime is outside of the representable range: {msg}"
+            ))
+        })
+}
+
+// No sub-second precision
+use_duration_signed_de!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {i64, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {f64, Strict =>}
+    }
+);
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {i64, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {f64, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Zoned; duration_to_zoned =>
+        {i64, Strict =>}
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {i64, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {f64, Strict =>}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_de!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_from_duration_signed =>
+        {f64, Strict =>}
+    }
+);
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; duration_to_timestamp =>
+        {f64, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Zoned; duration_to_zoned =>
+        {f64, Strict =>}
+        {String, Strict =>}
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {FORMAT, Flexible => FORMAT: Format}
+    }
+);
+#[cfg(feature = "alloc")]
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {String, Strict =>}
+    }
+);
+#[cfg(feature = "std")]
+use_duration_signed_de!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
+        {f64, Strict =>}
+    }
+);

--- a/serde_with/src/lib.rs
+++ b/serde_with/src/lib.rs
@@ -303,6 +303,9 @@ pub mod formats;
 #[cfg(feature = "hex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hex")))]
 pub mod hex;
+#[cfg(feature = "jiff_0_2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jiff_0_2")))]
+pub mod jiff_0_2;
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
@@ -898,19 +901,22 @@ pub struct BytesOrString;
 /// Serialization of integers will round the duration to the nearest value.
 ///
 /// This type also supports [`chrono::Duration`] with the `chrono_0_4`-[feature flag].
+/// This type also supports [`jiff::SignedDuration`][::jiff_0_2::SignedDuration] with the `jiff_0_2`-[feature flag].
 /// This type also supports [`time::Duration`][::time_0_3::Duration] with the `time_0_3`-[feature flag].
 ///
 /// This table lists the available `FORMAT`s for the different duration types.
 /// The `FORMAT` specifier defaults to `u64`/`f64`.
 ///
-/// | Duration Type         | Converter                 | Available `FORMAT`s      |
-/// | --------------------- | ------------------------- | ------------------------ |
-/// | `std::time::Duration` | `DurationSeconds`         | *`u64`*, `f64`, `String` |
-/// | `std::time::Duration` | `DurationSecondsWithFrac` | *`f64`*, `String`        |
-/// | `chrono::Duration`    | `DurationSeconds`         | `i64`, `f64`, `String`   |
-/// | `chrono::Duration`    | `DurationSecondsWithFrac` | *`f64`*, `String`        |
-/// | `time::Duration`      | `DurationSeconds`         | `i64`, `f64`, `String`   |
-/// | `time::Duration`      | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | Duration Type          | Converter                 | Available `FORMAT`s      |
+/// | ---------------------- | ------------------------- | ------------------------ |
+/// | `std::time::Duration`  | `DurationSeconds`         | *`u64`*, `f64`, `String` |
+/// | `std::time::Duration`  | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `chrono::Duration`     | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `chrono::Duration`     | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::SignedDuration` | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `jiff::SignedDuration` | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `time::Duration`       | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `time::Duration`       | `DurationSecondsWithFrac` | *`f64`*, `String`        |
 ///
 /// # Examples
 ///
@@ -1044,19 +1050,22 @@ pub struct DurationSeconds<
 /// For example, deserializing `DurationSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::Duration`] with the `chrono`-[feature flag].
+/// This type also supports [`jiff::SignedDuration`][::jiff_0_2::SignedDuration] with the `jiff_0_2`-[feature flag].
 /// This type also supports [`time::Duration`][::time_0_3::Duration] with the `time_0_3`-[feature flag].
 ///
 /// This table lists the available `FORMAT`s for the different duration types.
 /// The `FORMAT` specifier defaults to `u64`/`f64`.
 ///
-/// | Duration Type         | Converter                 | Available `FORMAT`s      |
-/// | --------------------- | ------------------------- | ------------------------ |
-/// | `std::time::Duration` | `DurationSeconds`         | *`u64`*, `f64`, `String` |
-/// | `std::time::Duration` | `DurationSecondsWithFrac` | *`f64`*, `String`        |
-/// | `chrono::Duration`    | `DurationSeconds`         | `i64`, `f64`, `String`   |
-/// | `chrono::Duration`    | `DurationSecondsWithFrac` | *`f64`*, `String`        |
-/// | `time::Duration`      | `DurationSeconds`         | `i64`, `f64`, `String`   |
-/// | `time::Duration`      | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | Duration Type          | Converter                 | Available `FORMAT`s      |
+/// | ---------------------- | ------------------------- | ------------------------ |
+/// | `std::time::Duration`  | `DurationSeconds`         | *`u64`*, `f64`, `String` |
+/// | `std::time::Duration`  | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `chrono::Duration`     | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `chrono::Duration`     | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::SignedDuration` | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `jiff::SignedDuration` | `DurationSecondsWithFrac` | *`f64`*, `String`        |
+/// | `time::Duration`       | `DurationSeconds`         | `i64`, `f64`, `String`   |
+/// | `time::Duration`       | `DurationSecondsWithFrac` | *`f64`*, `String`        |
 ///
 /// # Examples
 ///
@@ -1224,6 +1233,7 @@ pub struct DurationNanoSecondsWithFrac<
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::DateTime`] with the `chrono_0_4`-[feature flag].
+/// This type also supports [`jiff::Timestamp`][::jiff_0_2::Timestamp], [`jiff::Zoned`][::jiff_0_2::Zoned], and [`jiff::civil::DateTime`][::jiff_0_2::civil::DateTime] with the `jiff_0_2`-[feature flag].
 /// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// This table lists the available `FORMAT`s for the different timestamp types.
@@ -1239,6 +1249,12 @@ pub struct DurationNanoSecondsWithFrac<
 /// | `chrono::DateTime<Local>` | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `chrono::NaiveDateTime`   | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
 /// | `chrono::NaiveDateTime`   | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::Timestamp`         | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::Timestamp`         | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::Zoned`             | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::Zoned`             | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::civil::DateTime`   | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::civil::DateTime`   | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `time::OffsetDateTime`    | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
 /// | `time::OffsetDateTime`    | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `time::PrimitiveDateTime` | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
@@ -1378,6 +1394,7 @@ pub struct TimestampSeconds<
 /// For example, deserializing `TimestampSeconds<f64, Flexible>` will discard any subsecond precision during deserialization from `f64` and will parse a `String` as an integer number.
 ///
 /// This type also supports [`chrono::DateTime`] and [`chrono::NaiveDateTime`][NaiveDateTime] with the `chrono`-[feature flag].
+/// This type also supports [`jiff::Timestamp`][::jiff_0_2::Timestamp], [`jiff::Zoned`][::jiff_0_2::Zoned], and [`jiff::civil::DateTime`][::jiff_0_2::civil::DateTime] with the `jiff_0_2`-[feature flag].
 /// This type also supports [`time::OffsetDateTime`][::time_0_3::OffsetDateTime] and [`time::PrimitiveDateTime`][::time_0_3::PrimitiveDateTime] with the `time_0_3`-[feature flag].
 ///
 /// This table lists the available `FORMAT`s for the different timestamp types.
@@ -1393,6 +1410,12 @@ pub struct TimestampSeconds<
 /// | `chrono::DateTime<Local>` | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `chrono::NaiveDateTime`   | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
 /// | `chrono::NaiveDateTime`   | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::Timestamp`         | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::Timestamp`         | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::Zoned`             | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::Zoned`             | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
+/// | `jiff::civil::DateTime`   | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
+/// | `jiff::civil::DateTime`   | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `time::OffsetDateTime`    | `TimestampSeconds`         | *`i64`*, `f64`, `String` |
 /// | `time::OffsetDateTime`    | `TimestampSecondsWithFrac` | *`f64`*, `String`        |
 /// | `time::PrimitiveDateTime` | `TimestampSeconds`         | *`i64`*, `f64`, `String` |

--- a/serde_with/src/schemars_0_8.rs
+++ b/serde_with/src/schemars_0_8.rs
@@ -1234,6 +1234,15 @@ mod timespan {
     #[cfg(feature = "chrono_0_4")]
     declare_timespan_target!(::chrono_0_4::NaiveDateTime { i64, f64, String });
 
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::SignedDuration { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::Timestamp { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::Zoned { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::civil::DateTime { i64, f64, String });
+
     #[cfg(feature = "time_0_3")]
     declare_timespan_target!(::time_0_3::Duration { i64, f64, String });
     #[cfg(feature = "time_0_3")]

--- a/serde_with/src/schemars_0_9.rs
+++ b/serde_with/src/schemars_0_9.rs
@@ -1228,6 +1228,15 @@ mod timespan {
     #[cfg(feature = "chrono_0_4")]
     declare_timespan_target!(::chrono_0_4::NaiveDateTime { i64, f64, String });
 
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::SignedDuration { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::Timestamp { i64, f64, String });
+    #[cfg(all(feature = "jiff_0_2", feature = "std"))]
+    declare_timespan_target!(::jiff_0_2::Zoned { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::civil::DateTime { i64, f64, String });
+
     #[cfg(feature = "time_0_3")]
     declare_timespan_target!(::time_0_3::Duration { i64, f64, String });
     #[cfg(feature = "time_0_3")]

--- a/serde_with/src/schemars_1.rs
+++ b/serde_with/src/schemars_1.rs
@@ -1235,6 +1235,15 @@ mod timespan {
     #[cfg(feature = "chrono_0_4")]
     declare_timespan_target!(::chrono_0_4::NaiveDateTime { i64, f64, String });
 
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::SignedDuration { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::Timestamp { i64, f64, String });
+    #[cfg(all(feature = "jiff_0_2", feature = "std"))]
+    declare_timespan_target!(::jiff_0_2::Zoned { i64, f64, String });
+    #[cfg(feature = "jiff_0_2")]
+    declare_timespan_target!(::jiff_0_2::civil::DateTime { i64, f64, String });
+
     #[cfg(feature = "time_0_3")]
     declare_timespan_target!(::time_0_3::Duration { i64, f64, String });
     #[cfg(feature = "time_0_3")]

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -67,7 +67,7 @@ impl DurationSigned {
         Some(self)
     }
 
-    #[cfg(any(feature = "chrono_0_4", feature = "time_0_3"))]
+    #[cfg(any(feature = "chrono_0_4", feature = "jiff_0_2", feature = "time_0_3"))]
     pub(crate) fn with_duration(sign: Sign, duration: Duration) -> Self {
         Self { sign, duration }
     }

--- a/serde_with/tests/jiff_0_2.rs
+++ b/serde_with/tests/jiff_0_2.rs
@@ -1,0 +1,335 @@
+//! Test Cases
+
+mod utils;
+
+use crate::utils::{
+    check_deserialization, check_error_deserialization, check_serialization, is_equal,
+};
+use expect_test::expect;
+use jiff_0_2::{civil, tz::TimeZone, SignedDuration, Timestamp, Zoned};
+use serde::{Deserialize, Serialize};
+use serde_with::{
+    formats::Flexible, serde_as, DurationMicroSeconds, DurationMicroSecondsWithFrac,
+    DurationMilliSeconds, DurationMilliSecondsWithFrac, DurationNanoSeconds,
+    DurationNanoSecondsWithFrac, DurationSeconds, DurationSecondsWithFrac, TimestampMicroSeconds,
+    TimestampMicroSecondsWithFrac, TimestampMilliSeconds, TimestampMilliSecondsWithFrac,
+    TimestampNanoSeconds, TimestampNanoSecondsWithFrac, TimestampSeconds, TimestampSecondsWithFrac,
+};
+
+macro_rules! smoketest {
+    ($($valuety:ty, $adapter:literal, $value:expr, $expect:tt;)*) => {
+        $({
+            #[serde_as]
+            #[derive(Debug, Serialize, Deserialize, PartialEq)]
+            struct S(#[serde_as(as = $adapter)] $valuety);
+            #[allow(unused_braces)]
+            is_equal(S($value), $expect);
+        })*
+    };
+}
+
+#[test]
+fn test_duration_smoketest() {
+    let zero = SignedDuration::ZERO;
+    let one_second = SignedDuration::from_secs(1);
+
+    smoketest! {
+        SignedDuration, "DurationSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        SignedDuration, "DurationSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        SignedDuration, "DurationMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        SignedDuration, "DurationMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        SignedDuration, "DurationMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        SignedDuration, "DurationMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        SignedDuration, "DurationNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        SignedDuration, "DurationNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        SignedDuration, "DurationSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        SignedDuration, "DurationSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        SignedDuration, "DurationMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        SignedDuration, "DurationMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        SignedDuration, "DurationMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        SignedDuration, "DurationMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        SignedDuration, "DurationNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        SignedDuration, "DurationNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        SignedDuration, "DurationSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        SignedDuration, "DurationSecondsWithFrac", SignedDuration::new(0, 500_000_000), {expect![[r#"0.5"#]]};
+        SignedDuration, "DurationSecondsWithFrac", SignedDuration::from_secs(1), {expect![[r#"1.0"#]]};
+        SignedDuration, "DurationSecondsWithFrac", SignedDuration::new(0, -500_000_000), {expect![[r#"-0.5"#]]};
+        SignedDuration, "DurationSecondsWithFrac", SignedDuration::from_secs(-1), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_timestamp_smoketest() {
+    let zero = Timestamp::UNIX_EPOCH;
+    let one_second = Timestamp::new(1, 0).unwrap();
+
+    smoketest! {
+        Timestamp, "TimestampSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        Timestamp, "TimestampSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        Timestamp, "TimestampMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        Timestamp, "TimestampMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        Timestamp, "TimestampMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        Timestamp, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        Timestamp, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        Timestamp, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        Timestamp, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        Timestamp, "TimestampSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        Timestamp, "TimestampMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        Timestamp, "TimestampMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        Timestamp, "TimestampMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        Timestamp, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        Timestamp, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        Timestamp, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        Timestamp, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        Timestamp, "TimestampSecondsWithFrac", Timestamp::new(0, 500_000_000).unwrap(), {expect![[r#"0.5"#]]};
+        Timestamp, "TimestampSecondsWithFrac", Timestamp::new(1, 0).unwrap(), {expect![[r#"1.0"#]]};
+        Timestamp, "TimestampSecondsWithFrac", Timestamp::new(0, -500_000_000).unwrap(), {expect![[r#"-0.5"#]]};
+        Timestamp, "TimestampSecondsWithFrac", Timestamp::new(-1, 0).unwrap(), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_zoned_smoketest() {
+    // Zoned equality compares the instant, so deserializing into the system
+    // time zone round-trips on every machine.
+    let zoned_utc = |second: i64, nanosecond: i32| {
+        Timestamp::new(second, nanosecond)
+            .unwrap()
+            .to_zoned(TimeZone::UTC)
+    };
+    let one_second = zoned_utc(1, 0);
+
+    smoketest! {
+        Zoned, "TimestampSeconds<i64>", one_second.clone(), {expect![[r#"1"#]]};
+        Zoned, "TimestampSeconds<f64>", one_second.clone(), {expect![[r#"1.0"#]]};
+        Zoned, "TimestampMilliSeconds<i64>", one_second.clone(), {expect![[r#"1000"#]]};
+        Zoned, "TimestampMilliSeconds<f64>", one_second.clone(), {expect![[r#"1000.0"#]]};
+        Zoned, "TimestampMicroSeconds<i64>", one_second.clone(), {expect![[r#"1000000"#]]};
+        Zoned, "TimestampMicroSeconds<f64>", one_second.clone(), {expect![[r#"1000000.0"#]]};
+        Zoned, "TimestampNanoSeconds<i64>", one_second.clone(), {expect![[r#"1000000000"#]]};
+        Zoned, "TimestampNanoSeconds<f64>", one_second.clone(), {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        Zoned, "TimestampSecondsWithFrac", one_second.clone(), {expect![[r#"1.0"#]]};
+        Zoned, "TimestampSecondsWithFrac<String>", one_second.clone(), {expect![[r#""1""#]]};
+        Zoned, "TimestampMilliSecondsWithFrac", one_second.clone(), {expect![[r#"1000.0"#]]};
+        Zoned, "TimestampMilliSecondsWithFrac<String>", one_second.clone(), {expect![[r#""1000""#]]};
+        Zoned, "TimestampMicroSecondsWithFrac", one_second.clone(), {expect![[r#"1000000.0"#]]};
+        Zoned, "TimestampMicroSecondsWithFrac<String>", one_second.clone(), {expect![[r#""1000000""#]]};
+        Zoned, "TimestampNanoSecondsWithFrac", one_second.clone(), {expect![[r#"1000000000.0"#]]};
+        Zoned, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        Zoned, "TimestampSecondsWithFrac", zoned_utc(0, 0), {expect![[r#"0.0"#]]};
+        Zoned, "TimestampSecondsWithFrac", zoned_utc(0, 500_000_000), {expect![[r#"0.5"#]]};
+        Zoned, "TimestampSecondsWithFrac", zoned_utc(1, 0), {expect![[r#"1.0"#]]};
+        Zoned, "TimestampSecondsWithFrac", zoned_utc(0, -500_000_000), {expect![[r#"-0.5"#]]};
+        Zoned, "TimestampSecondsWithFrac", zoned_utc(-1, 0), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_civil_datetime_smoketest() {
+    let zero = civil::date(1970, 1, 1).at(0, 0, 0, 0);
+    let one_second = civil::date(1970, 1, 1).at(0, 0, 1, 0);
+
+    smoketest! {
+        civil::DateTime, "TimestampSeconds<i64>", one_second, {expect![[r#"1"#]]};
+        civil::DateTime, "TimestampSeconds<f64>", one_second, {expect![[r#"1.0"#]]};
+        civil::DateTime, "TimestampMilliSeconds<i64>", one_second, {expect![[r#"1000"#]]};
+        civil::DateTime, "TimestampMilliSeconds<f64>", one_second, {expect![[r#"1000.0"#]]};
+        civil::DateTime, "TimestampMicroSeconds<i64>", one_second, {expect![[r#"1000000"#]]};
+        civil::DateTime, "TimestampMicroSeconds<f64>", one_second, {expect![[r#"1000000.0"#]]};
+        civil::DateTime, "TimestampNanoSeconds<i64>", one_second, {expect![[r#"1000000000"#]]};
+        civil::DateTime, "TimestampNanoSeconds<f64>", one_second, {expect![[r#"1000000000.0"#]]};
+    };
+
+    smoketest! {
+        civil::DateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        civil::DateTime, "TimestampSecondsWithFrac<String>", one_second, {expect![[r#""1""#]]};
+        civil::DateTime, "TimestampMilliSecondsWithFrac", one_second, {expect![[r#"1000.0"#]]};
+        civil::DateTime, "TimestampMilliSecondsWithFrac<String>", one_second, {expect![[r#""1000""#]]};
+        civil::DateTime, "TimestampMicroSecondsWithFrac", one_second, {expect![[r#"1000000.0"#]]};
+        civil::DateTime, "TimestampMicroSecondsWithFrac<String>", one_second, {expect![[r#""1000000""#]]};
+        civil::DateTime, "TimestampNanoSecondsWithFrac", one_second, {expect![[r#"1000000000.0"#]]};
+        civil::DateTime, "TimestampNanoSecondsWithFrac<String>", one_second, {expect![[r#""1000000000""#]]};
+    };
+
+    smoketest! {
+        civil::DateTime, "TimestampSecondsWithFrac", zero, {expect![[r#"0.0"#]]};
+        civil::DateTime, "TimestampSecondsWithFrac", civil::date(1970, 1, 1).at(0, 0, 0, 500_000_000), {expect![[r#"0.5"#]]};
+        civil::DateTime, "TimestampSecondsWithFrac", one_second, {expect![[r#"1.0"#]]};
+        civil::DateTime, "TimestampSecondsWithFrac", civil::date(1969, 12, 31).at(23, 59, 59, 500_000_000), {expect![[r#"-0.5"#]]};
+        civil::DateTime, "TimestampSecondsWithFrac", civil::date(1969, 12, 31).at(23, 59, 59, 0), {expect![[r#"-1.0"#]]};
+    };
+}
+
+#[test]
+fn test_duration_seconds() {
+    let zero = SignedDuration::ZERO;
+    let one_second = SignedDuration::from_secs(1);
+    let half_second = SignedDuration::new(0, 500_000_000);
+    let minus_one_second = SignedDuration::from_secs(-1);
+    let minus_half_second = SignedDuration::new(0, -500_000_000);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructIntStrict(#[serde_as(as = "DurationSeconds<i64>")] SignedDuration);
+
+    is_equal(StructIntStrict(zero), expect![[r#"0"#]]);
+    is_equal(StructIntStrict(one_second), expect![[r#"1"#]]);
+    is_equal(StructIntStrict(minus_one_second), expect![[r#"-1"#]]);
+    check_serialization(StructIntStrict(half_second), expect![[r#"1"#]]);
+    check_serialization(StructIntStrict(minus_half_second), expect![[r#"-1"#]]);
+    check_error_deserialization::<StructIntStrict>(
+        r#""1""#,
+        expect![[r#"invalid type: string "1", expected i64 at line 1 column 3"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructIntFlexible(#[serde_as(as = "DurationSeconds<i64, Flexible>")] SignedDuration);
+
+    is_equal(StructIntFlexible(zero), expect![[r#"0"#]]);
+    is_equal(StructIntFlexible(one_second), expect![[r#"1"#]]);
+    is_equal(StructIntFlexible(minus_one_second), expect![[r#"-1"#]]);
+    check_deserialization(StructIntFlexible(half_second), r#""0.5""#);
+    check_deserialization(StructIntFlexible(minus_half_second), r#""-0.5""#);
+    check_deserialization(StructIntFlexible(one_second), r#""1""#);
+    check_deserialization(StructIntFlexible(zero), r#""0""#);
+    check_error_deserialization::<StructIntFlexible>(
+        r#""a""#,
+        expect![[
+            r#"invalid value: string "a", expected an integer, a float, or a string containing a number at line 1 column 3"#
+        ]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Structf64Strict(#[serde_as(as = "DurationSeconds<f64>")] SignedDuration);
+
+    is_equal(Structf64Strict(zero), expect![[r#"0.0"#]]);
+    is_equal(Structf64Strict(one_second), expect![[r#"1.0"#]]);
+    is_equal(Structf64Strict(minus_one_second), expect![[r#"-1.0"#]]);
+    check_serialization(Structf64Strict(half_second), expect![[r#"1.0"#]]);
+    check_serialization(Structf64Strict(minus_half_second), expect![[r#"-1.0"#]]);
+    check_error_deserialization::<Structf64Strict>(
+        r#""1""#,
+        expect![[r#"invalid type: string "1", expected f64 at line 1 column 3"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructStringStrict(#[serde_as(as = "DurationSeconds<String>")] SignedDuration);
+
+    is_equal(StructStringStrict(zero), expect![[r#""0""#]]);
+    is_equal(StructStringStrict(one_second), expect![[r#""1""#]]);
+    is_equal(StructStringStrict(minus_one_second), expect![[r#""-1""#]]);
+    check_serialization(StructStringStrict(half_second), expect![[r#""1""#]]);
+    check_serialization(StructStringStrict(minus_half_second), expect![[r#""-1""#]]);
+    check_error_deserialization::<StructStringStrict>(
+        r#"1"#,
+        expect![[
+            r#"invalid type: integer `1`, expected a string containing a number at line 1 column 1"#
+        ]],
+    );
+}
+
+#[test]
+fn test_duration_seconds_with_frac() {
+    let zero = SignedDuration::ZERO;
+    let one_second = SignedDuration::from_secs(1);
+    let half_second = SignedDuration::new(0, 500_000_000);
+    let minus_one_second = SignedDuration::from_secs(-1);
+    let minus_half_second = SignedDuration::new(0, -500_000_000);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Structf64Strict(#[serde_as(as = "DurationSecondsWithFrac<f64>")] SignedDuration);
+
+    is_equal(Structf64Strict(zero), expect![[r#"0.0"#]]);
+    is_equal(Structf64Strict(one_second), expect![[r#"1.0"#]]);
+    is_equal(Structf64Strict(minus_one_second), expect![[r#"-1.0"#]]);
+    is_equal(Structf64Strict(half_second), expect![[r#"0.5"#]]);
+    is_equal(Structf64Strict(minus_half_second), expect![[r#"-0.5"#]]);
+    check_error_deserialization::<Structf64Strict>(
+        r#""1""#,
+        expect![[r#"invalid type: string "1", expected f64 at line 1 column 3"#]],
+    );
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Structf64Flexible(
+        #[serde_as(as = "DurationSecondsWithFrac<f64, Flexible>")] SignedDuration,
+    );
+
+    is_equal(Structf64Flexible(zero), expect![[r#"0.0"#]]);
+    is_equal(Structf64Flexible(minus_half_second), expect![[r#"-0.5"#]]);
+    check_deserialization(Structf64Flexible(half_second), r#""0.5""#);
+    check_deserialization(Structf64Flexible(minus_one_second), r#""-1""#);
+
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct StructStringStrict(#[serde_as(as = "DurationSecondsWithFrac<String>")] SignedDuration);
+
+    is_equal(StructStringStrict(zero), expect![[r#""0""#]]);
+    is_equal(StructStringStrict(half_second), expect![[r#""0.5""#]]);
+    is_equal(
+        StructStringStrict(minus_half_second),
+        expect![[r#""-0.5""#]],
+    );
+    is_equal(StructStringStrict(minus_one_second), expect![[r#""-1""#]]);
+}
+
+// The full error messages contain jiff error text, which differs between jiff versions.
+// Only check for the version independent prefix added by serde_with.
+
+#[test]
+fn test_duration_out_of_range() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "DurationSeconds<i64, Flexible>")] SignedDuration);
+
+    let err = serde_json::from_str::<S>(r#"18446744073709551615"#).unwrap_err();
+    assert!(err
+        .to_string()
+        .starts_with("Duration is outside of the representable range:"));
+}
+
+#[test]
+fn test_timestamp_out_of_range() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "TimestampSeconds<i64>")] Timestamp);
+
+    let err = serde_json::from_str::<S>(r#"253402207201"#).unwrap_err();
+    assert!(err
+        .to_string()
+        .starts_with("Timestamp is outside of the representable range:"));
+}
+
+#[test]
+fn test_civil_datetime_out_of_range() {
+    #[serde_as]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct S(#[serde_as(as = "TimestampSeconds<i64>")] civil::DateTime);
+
+    let err = serde_json::from_str::<S>(r#"300000000000"#).unwrap_err();
+    assert!(err
+        .to_string()
+        .starts_with("DateTime is outside of the representable range:"));
+}


### PR DESCRIPTION
As `chrono` is being  soft-deprecated (see chronotope/chrono#1768; [see also](https://dirkjan.ochtman.nl/writing/2026/01/09/reviewing-2025.html)) and `jiff` is the recommended migration path, it makes sense to add `jiff` support to `serde_with`. Lots of teams are migrating away from `chrono`, and `serde_with` support ends up causing friction for some teams.

Closes #936