### PR TITLE
Improve the time unit macros to remove unnecessary repetition and make the code smaller

### DIFF
--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -205,6 +205,169 @@ fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
     }
 }
 
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident $(,)?)*
+                })*
+            }
+        )+
+    ) => {
+        $($(
+            $(#[$attr])?
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
+fn datetime_to_duration<TZ>(source: &DateTime<TZ>) -> DurationSigned
+where
+    TZ: TimeZone,
+{
+    duration_into_duration_signed(&source.clone().signed_duration_since(unix_epoch_utc()))
+}
+
+fn naive_datetime_to_duration(source: &NaiveDateTime) -> DurationSigned {
+    duration_into_duration_signed(&source.signed_duration_since(unix_epoch_naive()))
+}
+
+// No sub-unit precision
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Duration; duration_into_duration_signed =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        DateTime<TZ>; datetime_to_duration =>
+        {i64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
+        {f64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
+    }
+    => {
+        NaiveDateTime; naive_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Duration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        DateTime<TZ>; datetime_to_duration =>
+        {f64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
+    }
+    => {
+        NaiveDateTime; naive_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident)*
+                })*
+            }
+        )+
+    ) =>{
+        $($(
+            $(#[$attr])?
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
 /// Convert a [`DurationSigned`] into a [`chrono_0_4::Duration`]
 fn duration_from_duration_signed<'de, D>(dur: DurationSigned) -> Result<Duration, D::Error>
 where
@@ -222,218 +385,6 @@ where
         chrono_dur = -chrono_dur;
     }
     Ok(chrono_dur)
-}
-
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident $(,)?)*
-            })*
-        }
-    ) => {
-        $(
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_ser!($main_trait $internal_trait => $rest); )+
-    };
-}
-
-fn datetime_to_duration<TZ>(source: &DateTime<TZ>) -> DurationSigned
-where
-    TZ: TimeZone,
-{
-    duration_into_duration_signed(&source.clone().signed_duration_since(unix_epoch_utc()))
-}
-
-fn naive_datetime_to_duration(source: &NaiveDateTime) -> DurationSigned {
-    duration_into_duration_signed(&source.signed_duration_since(unix_epoch_naive()))
-}
-
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Duration; duration_into_duration_signed =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Duration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        DateTime<TZ>; datetime_to_duration =>
-        {i64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
-        {f64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        DateTime<TZ>; datetime_to_duration =>
-        {String, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        NaiveDateTime; naive_datetime_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        NaiveDateTime; naive_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-// Duration/Timestamp WITH FRACTIONS
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Duration; duration_into_duration_signed =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Duration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        DateTime<TZ>; datetime_to_duration =>
-        {f64, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        DateTime<TZ>; datetime_to_duration =>
-        {String, STRICTNESS => TZ: TimeZone, STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        NaiveDateTime; naive_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        NaiveDateTime; naive_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident)*
-            })*
-        }
-    ) =>{
-        $(
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_de!($main_trait $internal_trait => $rest); )+
-    };
 }
 
 fn duration_to_datetime_utc<'de, D>(dur: DurationSigned) -> Result<DateTime<Utc>, D::Error>
@@ -466,110 +417,38 @@ use_duration_signed_de!(
     DurationNanoSeconds DurationNanoSeconds,
     => {
         Duration; duration_from_duration_signed =>
-        {i64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Duration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Duration; duration_from_duration_signed =>
-        {f64, Strict =>}
-    }
-);
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        DateTime<Utc>; duration_to_datetime_utc =>
         {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
+    }
+);
+
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        DateTime<Utc>; duration_to_datetime_utc =>
         {FORMAT, Flexible => FORMAT: Format}
+        {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        DateTime<Utc>; duration_to_datetime_utc =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        DateTime<Utc>; duration_to_datetime_utc =>
-        {f64, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
     => {
         DateTime<Local>; duration_to_datetime_local =>
-        {i64, Strict =>}
-        {f64, Strict =>}
-        {String, Strict =>}
+        #[cfg(feature = "std")] {i64, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
+        #[cfg(feature = "std")] {String, Strict =>}
+        #[cfg(feature = "std")] {FORMAT, Flexible => FORMAT: Format}
+    }
+    => {
+        NaiveDateTime; duration_to_naive_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        NaiveDateTime; duration_to_naive_datetime =>
         {i64, Strict =>}
-        {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        NaiveDateTime; duration_to_naive_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        NaiveDateTime; duration_to_naive_datetime =>
-        {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
 );
 
@@ -581,21 +460,12 @@ use_duration_signed_de!(
     DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         Duration; duration_from_duration_signed =>
-        {f64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
+        {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Duration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
+
 use_duration_signed_de!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
@@ -603,53 +473,20 @@ use_duration_signed_de!(
     TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         DateTime<Utc>; duration_to_datetime_utc =>
-        {f64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
+        {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        DateTime<Utc>; duration_to_datetime_utc =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         DateTime<Local>; duration_to_datetime_local =>
-        {f64, Strict =>}
-        {String, Strict =>}
-        {FORMAT, Flexible => FORMAT: Format}
+        #[cfg(feature = "std")] {FORMAT, Flexible => FORMAT: Format}
+        #[cfg(feature = "std")] {f64, Strict =>}
+        #[cfg(feature = "std")] {String, Strict =>}
     }
-);
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         NaiveDateTime; duration_to_naive_datetime =>
-        {f64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        NaiveDateTime; duration_to_naive_datetime =>
-        {String, Strict =>}
+        {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );

--- a/serde_with/src/chrono_0_4.rs
+++ b/serde_with/src/chrono_0_4.rs
@@ -12,6 +12,7 @@
 use crate::{
     formats::{Flexible, Format, Strict, Strictness},
     prelude::*,
+    utils::duration::{use_duration_signed_de, use_duration_signed_ser},
 };
 #[cfg(feature = "std")]
 use ::chrono_0_4::Local;
@@ -205,52 +206,6 @@ fn duration_into_duration_signed(dur: &Duration) -> DurationSigned {
     }
 }
 
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident $(,)?)*
-                })*
-            }
-        )+
-    ) => {
-        $($(
-            $(#[$attr])?
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
-    };
-}
-
 fn datetime_to_duration<TZ>(source: &DateTime<TZ>) -> DurationSigned
 where
     TZ: TimeZone,
@@ -324,49 +279,6 @@ use_duration_signed_ser!(
         #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident)*
-                })*
-            }
-        )+
-    ) =>{
-        $($(
-            $(#[$attr])?
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
-    };
-}
 
 /// Convert a [`DurationSigned`] into a [`chrono_0_4::Duration`]
 fn duration_from_duration_signed<'de, D>(dur: DurationSigned) -> Result<Duration, D::Error>

--- a/serde_with/src/jiff_0_2.rs
+++ b/serde_with/src/jiff_0_2.rs
@@ -15,9 +15,9 @@ use crate::{
     formats::{Flexible, Format, Strict, Strictness},
     prelude::*,
 };
-#[cfg(feature = "std")]
-use ::jiff_0_2::tz::TimeZone;
-use ::jiff_0_2::{civil::DateTime as CivilDateTime, SignedDuration, Timestamp, Zoned};
+use ::jiff_0_2::{
+    civil::DateTime as CivilDateTime, tz::TimeZone, SignedDuration, Timestamp, Zoned,
+};
 
 /// Create a [`CivilDateTime`] for the Unix Epoch
 fn unix_epoch_civil() -> CivilDateTime {
@@ -43,6 +43,181 @@ fn duration_into_duration_signed(dur: &SignedDuration) -> DurationSigned {
     )
 }
 
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident $(,)?)*
+                })*
+            }
+        )+
+    ) => {
+        $($(
+            $(#[$attr])?
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
+fn timestamp_to_duration(source: &Timestamp) -> DurationSigned {
+    duration_into_duration_signed(&source.as_duration())
+}
+
+fn zoned_to_duration(source: &Zoned) -> DurationSigned {
+    timestamp_to_duration(&source.timestamp())
+}
+
+fn civil_datetime_to_duration(source: &CivilDateTime) -> DurationSigned {
+    duration_into_duration_signed(&source.duration_since(unix_epoch_civil()))
+}
+
+// No sub-unit precision
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        Zoned; zoned_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        SignedDuration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Timestamp; timestamp_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        Zoned; zoned_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        CivilDateTime; civil_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident)*
+                })*
+            }
+        )+
+    ) =>{
+        $($(
+            $(#[$attr])?
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
 /// Convert a [`DurationSigned`] into a [`SignedDuration`]
 fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<SignedDuration, D::Error>
 where
@@ -62,306 +237,6 @@ where
     Ok(dur)
 }
 
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident $(,)?)*
-            })*
-        }
-    ) => {
-        $(
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_ser!($main_trait $internal_trait => $rest); )+
-    };
-}
-
-fn timestamp_to_duration(source: &Timestamp) -> DurationSigned {
-    duration_into_duration_signed(&source.as_duration())
-}
-
-fn zoned_to_duration(source: &Zoned) -> DurationSigned {
-    timestamp_to_duration(&source.timestamp())
-}
-
-fn civil_datetime_to_duration(source: &CivilDateTime) -> DurationSigned {
-    duration_into_duration_signed(&source.duration_since(unix_epoch_civil()))
-}
-
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        SignedDuration; duration_into_duration_signed =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        SignedDuration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        SignedDuration; duration_into_duration_signed =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; timestamp_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; timestamp_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; timestamp_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Zoned; zoned_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Zoned; zoned_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Zoned; zoned_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; civil_datetime_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; civil_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; civil_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-// Duration/Timestamp WITH FRACTIONS
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        SignedDuration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        SignedDuration; duration_into_duration_signed =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Timestamp; timestamp_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Timestamp; timestamp_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Zoned; zoned_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Zoned; zoned_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        CivilDateTime; civil_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        CivilDateTime; civil_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident)*
-            })*
-        }
-    ) =>{
-        $(
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_de!($main_trait $internal_trait => $rest); )+
-    };
-}
-
 fn duration_to_timestamp<'de, D>(dur: DurationSigned) -> Result<Timestamp, D::Error>
 where
     D: Deserializer<'de>,
@@ -373,7 +248,7 @@ where
     })
 }
 
-#[cfg(feature = "std")]
+// #[cfg(feature = "std")]
 fn duration_to_zoned<'de, D>(dur: DurationSigned) -> Result<Zoned, D::Error>
 where
     D: Deserializer<'de>,
@@ -394,7 +269,7 @@ where
         })
 }
 
-// No sub-second precision
+// No sub-unit precision
 use_duration_signed_de!(
     DurationSeconds DurationSeconds,
     DurationMilliSeconds DurationMilliSeconds,
@@ -402,110 +277,38 @@ use_duration_signed_de!(
     DurationNanoSeconds DurationNanoSeconds,
     => {
         SignedDuration; duration_from_duration_signed =>
-        {i64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        SignedDuration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        SignedDuration; duration_from_duration_signed =>
-        {f64, Strict =>}
-    }
-);
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; duration_to_timestamp =>
         {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
+    }
+);
+
+use_duration_signed_de!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        Timestamp; duration_to_timestamp =>
         {FORMAT, Flexible => FORMAT: Format}
+        {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; duration_to_timestamp =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        Timestamp; duration_to_timestamp =>
-        {f64, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
     => {
         Zoned; duration_to_zoned =>
-        {i64, Strict =>}
-        {f64, Strict =>}
-        {String, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; duration_to_civil_datetime =>
         {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
+    }
+    => {
+        CivilDateTime; duration_to_civil_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; duration_to_civil_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        CivilDateTime; duration_to_civil_datetime =>
-        {f64, Strict =>}
+        {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
 );
 
@@ -518,30 +321,11 @@ use_duration_signed_de!(
     => {
         SignedDuration; duration_from_duration_signed =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        SignedDuration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        SignedDuration; duration_from_duration_signed =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );
+
 use_duration_signed_de!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
@@ -550,72 +334,19 @@ use_duration_signed_de!(
     => {
         Timestamp; duration_to_timestamp =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Timestamp; duration_to_timestamp =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Timestamp; duration_to_timestamp =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         Zoned; duration_to_zoned =>
-        {f64, Strict =>}
-        {String, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
+        {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
-);
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         CivilDateTime; duration_to_civil_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        CivilDateTime; duration_to_civil_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        CivilDateTime; duration_to_civil_datetime =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );

--- a/serde_with/src/jiff_0_2.rs
+++ b/serde_with/src/jiff_0_2.rs
@@ -14,6 +14,7 @@
 use crate::{
     formats::{Flexible, Format, Strict, Strictness},
     prelude::*,
+    utils::duration::{use_duration_signed_de, use_duration_signed_ser},
 };
 use ::jiff_0_2::{
     civil::DateTime as CivilDateTime, tz::TimeZone, SignedDuration, Timestamp, Zoned,
@@ -41,52 +42,6 @@ fn duration_into_duration_signed(dur: &SignedDuration) -> DurationSigned {
         },
         std_dur,
     )
-}
-
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident $(,)?)*
-                })*
-            }
-        )+
-    ) => {
-        $($(
-            $(#[$attr])?
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
-    };
 }
 
 fn timestamp_to_duration(source: &Timestamp) -> DurationSigned {
@@ -174,49 +129,6 @@ use_duration_signed_ser!(
         #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident)*
-                })*
-            }
-        )+
-    ) =>{
-        $($(
-            $(#[$attr])?
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
-    };
-}
 
 /// Convert a [`DurationSigned`] into a [`SignedDuration`]
 fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<SignedDuration, D::Error>

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -48,6 +48,166 @@ fn duration_into_duration_signed(dur: &Time03Duration) -> DurationSigned {
     )
 }
 
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident $(,)?)*
+                })*
+            }
+        )+
+    ) => {
+        $($(
+            $(#[$attr])?
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
+fn offset_datetime_to_duration(source: &OffsetDateTime) -> DurationSigned {
+    duration_into_duration_signed(&(*source - OffsetDateTime::UNIX_EPOCH))
+}
+
+fn primitive_datetime_to_duration(source: &PrimitiveDateTime) -> DurationSigned {
+    duration_into_duration_signed(&(*source - unix_epoch_primitive()))
+}
+
+// No sub-unit precision
+use_duration_signed_ser!(
+    DurationSeconds DurationSeconds,
+    DurationMilliSeconds DurationMilliSeconds,
+    DurationMicroSeconds DurationMicroSeconds,
+    DurationNanoSeconds DurationNanoSeconds,
+    => {
+        Time03Duration; duration_into_duration_signed =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSeconds DurationSeconds,
+    TimestampMilliSeconds DurationMilliSeconds,
+    TimestampMicroSeconds DurationMicroSeconds,
+    TimestampNanoSeconds DurationNanoSeconds,
+    => {
+        OffsetDateTime; offset_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        PrimitiveDateTime; primitive_datetime_to_duration =>
+        {i64, STRICTNESS => STRICTNESS: Strictness}
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+// Duration/Timestamp WITH FRACTIONS
+use_duration_signed_ser!(
+    DurationSecondsWithFrac DurationSecondsWithFrac,
+    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        Time03Duration; duration_into_duration_signed =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+use_duration_signed_ser!(
+    TimestampSecondsWithFrac DurationSecondsWithFrac,
+    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
+    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
+    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
+    => {
+        OffsetDateTime; offset_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+    => {
+        PrimitiveDateTime; primitive_datetime_to_duration =>
+        {f64, STRICTNESS => STRICTNESS: Strictness}
+        #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+    }
+);
+
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident)*
+                })*
+            }
+        )+
+    ) =>{
+        $($(
+            $(#[$attr])?
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+
 /// Convert a [`DurationSigned`] into a [`time_0_3::Duration`]
 fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<Time03Duration, D::Error>
 where
@@ -67,248 +227,6 @@ where
     Ok(dur)
 }
 
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident $(,)?)*
-            })*
-        }
-    ) => {
-        $(
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_ser!($main_trait $internal_trait => $rest); )+
-    };
-}
-
-fn offset_datetime_to_duration(source: &OffsetDateTime) -> DurationSigned {
-    duration_into_duration_signed(&(*source - OffsetDateTime::UNIX_EPOCH))
-}
-
-fn primitive_datetime_to_duration(source: &PrimitiveDateTime) -> DurationSigned {
-    duration_into_duration_signed(&(*source - unix_epoch_primitive()))
-}
-
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Time03Duration; duration_into_duration_signed =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Time03Duration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Time03Duration; duration_into_duration_signed =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        OffsetDateTime; offset_datetime_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        OffsetDateTime; offset_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        OffsetDateTime; offset_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; primitive_datetime_to_duration =>
-        {i64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; primitive_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; primitive_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-// Duration/Timestamp WITH FRACTIONS
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Time03Duration; duration_into_duration_signed =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Time03Duration; duration_into_duration_signed =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        OffsetDateTime; offset_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        OffsetDateTime; offset_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        PrimitiveDateTime; primitive_datetime_to_duration =>
-        {String, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_ser!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        PrimitiveDateTime; primitive_datetime_to_duration =>
-        {f64, STRICTNESS => STRICTNESS: Strictness}
-    }
-);
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident =>
-        {
-            $ty:ty; $converter:ident =>
-            $({
-                $format:ty, $strictness:ty =>
-                $($tbound:ident: $bound:ident)*
-            })*
-        }
-    ) =>{
-        $(
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*
-    };
-    (
-        $( $main_trait:ident $internal_trait:ident, )+ => $rest:tt
-    ) => {
-        $( use_duration_signed_de!($main_trait $internal_trait => $rest); )+
-    };
-}
-
 fn duration_to_offset_datetime<'de, D>(dur: DurationSigned) -> Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
@@ -325,7 +243,7 @@ where
     Ok(unix_epoch_primitive() + duration_from_duration_signed::<D>(dur)?)
 }
 
-// No sub-second precision
+// No sub-unit precision
 use_duration_signed_de!(
     DurationSeconds DurationSeconds,
     DurationMilliSeconds DurationMilliSeconds,
@@ -333,32 +251,13 @@ use_duration_signed_de!(
     DurationNanoSeconds DurationNanoSeconds,
     => {
         Time03Duration; duration_from_duration_signed =>
-        {i64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
+        {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
 );
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Time03Duration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    DurationSeconds DurationSeconds,
-    DurationMilliSeconds DurationMilliSeconds,
-    DurationMicroSeconds DurationMicroSeconds,
-    DurationNanoSeconds DurationNanoSeconds,
-    => {
-        Time03Duration; duration_from_duration_signed =>
-        {f64, Strict =>}
-    }
-);
+
 use_duration_signed_de!(
     TimestampSeconds DurationSeconds,
     TimestampMilliSeconds DurationMilliSeconds,
@@ -366,63 +265,17 @@ use_duration_signed_de!(
     TimestampNanoSeconds DurationNanoSeconds,
     => {
         OffsetDateTime; duration_to_offset_datetime =>
-        {i64, Strict =>}
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        OffsetDateTime; duration_to_offset_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        OffsetDateTime; duration_to_offset_datetime =>
-        {f64, Strict =>}
-    }
-);
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; duration_to_primitive_datetime =>
         {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
+    }
+    => {
+        PrimitiveDateTime; duration_to_primitive_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; duration_to_primitive_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSeconds DurationSeconds,
-    TimestampMilliSeconds DurationMilliSeconds,
-    TimestampMicroSeconds DurationMicroSeconds,
-    TimestampNanoSeconds DurationNanoSeconds,
-    => {
-        PrimitiveDateTime; duration_to_primitive_datetime =>
-        {f64, Strict =>}
+        {i64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
+        #[cfg(feature = "std")] {f64, Strict =>}
     }
 );
 
@@ -435,30 +288,11 @@ use_duration_signed_de!(
     => {
         Time03Duration; duration_from_duration_signed =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Time03Duration; duration_from_duration_signed =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    DurationSecondsWithFrac DurationSecondsWithFrac,
-    DurationMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    DurationMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    DurationNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        Time03Duration; duration_from_duration_signed =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );
+
 use_duration_signed_de!(
     TimestampSecondsWithFrac DurationSecondsWithFrac,
     TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
@@ -467,60 +301,14 @@ use_duration_signed_de!(
     => {
         OffsetDateTime; duration_to_offset_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        OffsetDateTime; duration_to_offset_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        OffsetDateTime; duration_to_offset_datetime =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
-);
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
     => {
         PrimitiveDateTime; duration_to_primitive_datetime =>
         {FORMAT, Flexible => FORMAT: Format}
-    }
-);
-#[cfg(feature = "alloc")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        PrimitiveDateTime; duration_to_primitive_datetime =>
-        {String, Strict =>}
-    }
-);
-#[cfg(feature = "std")]
-use_duration_signed_de!(
-    TimestampSecondsWithFrac DurationSecondsWithFrac,
-    TimestampMilliSecondsWithFrac DurationMilliSecondsWithFrac,
-    TimestampMicroSecondsWithFrac DurationMicroSecondsWithFrac,
-    TimestampNanoSecondsWithFrac DurationNanoSecondsWithFrac,
-    => {
-        PrimitiveDateTime; duration_to_primitive_datetime =>
         {f64, Strict =>}
+        #[cfg(feature = "alloc")] {String, Strict =>}
     }
 );
 

--- a/serde_with/src/time_0_3.rs
+++ b/serde_with/src/time_0_3.rs
@@ -15,6 +15,7 @@
 use crate::{
     formats::{Flexible, Format, Strict, Strictness},
     prelude::*,
+    utils::duration::{use_duration_signed_de, use_duration_signed_ser},
 };
 #[cfg(feature = "std")]
 use ::time_0_3::format_description::well_known::{
@@ -46,52 +47,6 @@ fn duration_into_duration_signed(dur: &Time03Duration) -> DurationSigned {
         },
         std_dur,
     )
-}
-
-macro_rules! use_duration_signed_ser {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident $(,)?)*
-                })*
-            }
-        )+
-    ) => {
-        $($(
-            $(#[$attr])?
-            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
-                where
-                    S: Serializer,
-                {
-                    let dur: DurationSigned = $converter(source);
-                    $internal_trait::<$format, $strictness>::serialize_as(
-                        &dur,
-                        serializer,
-                    )
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
-    };
 }
 
 fn offset_datetime_to_duration(source: &OffsetDateTime) -> DurationSigned {
@@ -164,49 +119,6 @@ use_duration_signed_ser!(
         #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
     }
 );
-
-macro_rules! use_duration_signed_de {
-    (
-        $main_trait:ident $internal_trait:ident
-        $(
-            => {
-                $ty:ty; $converter:ident =>
-                $($(#[$attr:meta])? {
-                    $format:ty, $strictness:ty =>
-                    $($tbound:ident: $bound:ident)*
-                })*
-            }
-        )+
-    ) =>{
-        $($(
-            $(#[$attr])?
-            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
-            where
-                $($tbound: $bound,)*
-            {
-                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
-                    $converter::<D>(dur)
-                }
-            }
-        )*)+
-    };
-    (
-        $main_traitA:ident $internal_traitA:ident,
-        $main_traitB:ident $internal_traitB:ident,
-        $main_traitC:ident $internal_traitC:ident,
-        $main_traitD:ident $internal_traitD:ident,
-        $(=> $rest:tt)+
-    ) => {
-        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
-        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
-        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
-        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
-    };
-}
 
 /// Convert a [`DurationSigned`] into a [`time_0_3::Duration`]
 fn duration_from_duration_signed<'de, D>(sdur: DurationSigned) -> Result<Time03Duration, D::Error>

--- a/serde_with/src/utils/duration.rs
+++ b/serde_with/src/utils/duration.rs
@@ -560,6 +560,124 @@ fn parse_float_into_time_parts(mut value: &str) -> Result<(Sign, u64, u32), Pars
     }
 }
 
+/// The following macros are used to implement `SerializeAs` and `DeserializeAs` for the various `DurationSigned` types
+///
+/// ```rust,ignore
+/// use_duration_signed_ser!(
+///     DurationSeconds DurationSeconds,
+///     DurationMilliSeconds DurationMilliSeconds,
+///     DurationMicroSeconds DurationMicroSeconds,
+///     DurationNanoSeconds DurationNanoSeconds,
+///     => {
+///         SignedDuration; duration_into_duration_signed =>
+///         {i64, STRICTNESS => STRICTNESS: Strictness}
+///         {f64, STRICTNESS => STRICTNESS: Strictness}
+///         #[cfg(feature = "alloc")] {String, STRICTNESS => STRICTNESS: Strictness}
+///     }
+/// );
+/// ```
+///
+/// They take the conversion that should be implemented publicly (`DurationSeconds`, `TimestampSeconds`, etc.) and the internal
+/// conversion that is used with the `DurationSigned` (`DurationSeconds`) and then the types that should be implemented
+/// for (`i64`, `f64`, `String`) and the strictness that should be used (Strict, Flexible).
+#[cfg(any(feature = "chrono_0_4", feature = "jiff_0_2", feature = "time_0_3"))]
+macro_rules! use_duration_signed_ser {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident $(,)?)*
+                })*
+            }
+        )+
+    ) => {
+        $($(
+            $(#[$attr])?
+            impl<$($tbound ,)*> SerializeAs<$ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn serialize_as<S>(source: &$ty, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let dur: DurationSigned = $converter(source);
+                    $internal_trait::<$format, $strictness>::serialize_as(
+                        &dur,
+                        serializer,
+                    )
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_ser!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_ser!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_ser!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_ser!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+// Make the macros available to the rest of the crate
+#[cfg(any(feature = "chrono_0_4", feature = "jiff_0_2", feature = "time_0_3"))]
+pub(crate) use use_duration_signed_ser;
+
+/// The following macros are used to implement `SerializeAs` and `DeserializeAs` for the various `DurationSigned` types
+#[cfg(any(feature = "chrono_0_4", feature = "jiff_0_2", feature = "time_0_3"))]
+macro_rules! use_duration_signed_de {
+    (
+        $main_trait:ident $internal_trait:ident
+        $(
+            => {
+                $ty:ty; $converter:ident =>
+                $($(#[$attr:meta])? {
+                    $format:ty, $strictness:ty =>
+                    $($tbound:ident: $bound:ident)*
+                })*
+            }
+        )+
+    ) =>{
+        $($(
+            $(#[$attr])?
+            impl<'de, $($tbound,)*> DeserializeAs<'de, $ty> for $main_trait<$format, $strictness>
+            where
+                $($tbound: $bound,)*
+            {
+                fn deserialize_as<D>(deserializer: D) -> Result<$ty, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let dur: DurationSigned = $internal_trait::<$format, $strictness>::deserialize_as(deserializer)?;
+                    $converter::<D>(dur)
+                }
+            }
+        )*)+
+    };
+    (
+        $main_traitA:ident $internal_traitA:ident,
+        $main_traitB:ident $internal_traitB:ident,
+        $main_traitC:ident $internal_traitC:ident,
+        $main_traitD:ident $internal_traitD:ident,
+        $(=> $rest:tt)+
+    ) => {
+        use_duration_signed_de!($main_traitA $internal_traitA $(=> $rest)+);
+        use_duration_signed_de!($main_traitB $internal_traitB $(=> $rest)+);
+        use_duration_signed_de!($main_traitC $internal_traitC $(=> $rest)+);
+        use_duration_signed_de!($main_traitD $internal_traitD $(=> $rest)+);
+    };
+}
+// Make the macros available to the rest of the crate
+#[cfg(any(feature = "chrono_0_4", feature = "jiff_0_2", feature = "time_0_3"))]
+pub(crate) use use_duration_signed_de;
+
 #[test]
 fn test_parse_float_into_time_parts() {
     // Test normal behavior


### PR DESCRIPTION
* Multiple use_duration_signed_ser! can be combined if they are for the same types.
* Feature gating is now supported inside the macro, avoiding more duplications of use_duration_signed_ser!