### PR TITLE
Cleanup references to old tool

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -32,10 +32,8 @@ coverage:
         # Only include coverage of the "tests/" folder
         paths:
           - "serde_with/tests/"
-        # We cannot require 100%, as tarpaulin has some issues in counting lines
-        # Require at least 90% to pass this check
-        # FIXME: target is currently broken: https://community.codecov.io/t/github-check-not-properly-handling-subsets-of-files/1853
-        # target: 90%
+        # Compare the coverage with the base branch
+        target: auto
         # Allow the coverage to change by up to 5%
         threshold: "5%"
 
@@ -50,10 +48,8 @@ coverage:
       serde_with_macros_test:
         paths:
           - "serde_with_macros/tests/"
-        # We cannot require 100%, as tarpaulin has some issues in counting lines
-        # Require at least 90% to pass this check
-        # FIXME: target is currently broken: https://community.codecov.io/t/github-check-not-properly-handling-subsets-of-files/1853
-        # target: 90%
+        # Compare the coverage with the base branch
+        target: auto
         # Allow the coverage to change by up to 5%
         threshold: "5%"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: Rust CI
 on:
   # Always test pull requests
   pull_request:
-  # Bors related branches
   push:
     branches:
       - master
@@ -140,8 +139,7 @@ jobs:
           disable_search: true
           files: lcov.info
 
-  # Added to summarize the matrix (otherwise we would need to list every single
-  # job in bors.toml)
+  # Added to summarize the matrix
   # https://forum.bors.tech/t/bors-with-github-workflows/426
   tests-result:
     name: Tests result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unused_qualifications = "warn"
 variant_size_differences = "warn"
 # Unsafe code is needed for array initialization using MaybeUninit.
 # unsafe_code = "forbid"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)', 'cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [] }
 
 [workspace.lints.clippy]
 # These lints have false positives and are disabled until they are fixed.

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-# List of commit statuses that must pass on the merge commit before it is pushed to master.
-status = [
-    "Tests result",
-    "Rustsec Audit",
-]
-# If set to true, and if the PR branch is on the same repository that bors-ng itself is on, the branch will be deleted.
-delete_merged_branches = true

--- a/serde_with/src/content/mod.rs
+++ b/serde_with/src/content/mod.rs
@@ -2,7 +2,5 @@
 //!
 //! <https://github.com/serde-rs/serde/blob/55a7cedd737278a9d75a2efd038c6f38b8c38bd6/serde/src/private/ser.rs#L338-L997>
 
-#![cfg(not(tarpaulin_include))]
-
 pub(crate) mod de;
 pub(crate) mod ser;

--- a/serde_with_macros/src/lib.rs
+++ b/serde_with_macros/src/lib.rs
@@ -21,8 +21,6 @@
 // Not needed for 2018 edition and conflicts with `rust_2018_idioms`
 #![doc(test(no_crate_inject))]
 #![doc(html_root_url = "https://docs.rs/serde_with_macros/3.22.0/")]
-// Tarpaulin does not work well with proc macros and marks most of the lines as uncovered.
-#![cfg(not(tarpaulin_include))]
 // FIXME: The darling 0.24.0 derives trigger this lint
 #![allow(unused_qualifications)]
 

--- a/serde_with_macros/tests/compiler-messages.rs
+++ b/serde_with_macros/tests/compiler-messages.rs
@@ -1,6 +1,5 @@
 //! Test Cases
 
-#[cfg_attr(tarpaulin, ignore)]
 // The error messages are different on beta and nightly, thus breaking the test.
 #[rustversion::attr(beta, ignore)]
 #[rustversion::attr(nightly, ignore)]


### PR DESCRIPTION
* Remove mentions of tarpaulin. Code coverage is done with llvm-cov now
* Remove bors.toml as bors-ng is not maintained since a while